### PR TITLE
Python update

### DIFF
--- a/python/apc_csv_processing.py
+++ b/python/apc_csv_processing.py
@@ -7,7 +7,6 @@ from collections import OrderedDict
 import datetime
 import locale
 import logging
-from logging.handlers import MemoryHandler
 import os
 import sys
 
@@ -84,37 +83,6 @@ class CSVColumn(object):
             self.overwrite = CSVColumn.OW_NEVER
             return old_value
 
-class ANSIColorFormatter(logging.Formatter):
-    """
-    A simple logging formatter using ANSI codes to colorize messages
-    """
-    FORMATS = {
-        logging.ERROR: "\033[91m%(levelname)s: %(message)s\033[0m",
-        logging.WARNING: "\033[93m%(levelname)s: %(message)s\033[0m",
-        logging.INFO: "\033[94m%(levelname)s: %(message)s\033[0m",
-        "DEFAULT": "%(levelname)s: %(message)s"
-    }
-
-    def format(self, record):
-        self._fmt = self.FORMATS.get(record.levelno, self.FORMATS["DEFAULT"])
-        return logging.Formatter.format(self, record)
-
-class BufferedErrorHandler(MemoryHandler):
-    """
-    A modified MemoryHandler without automatic flushing.
-
-    This handler serves the simple purpose of buffering error and critical
-    log messages so that they can be shown to the user in collected form when
-    the enrichment process has finished.
-    """
-    def __init__(self, target):
-        MemoryHandler.__init__(self, 100000, target=target)
-        self.setLevel(logging.ERROR)
-
-    def shouldFlush(self, record):
-        return False
-
-
 ARG_HELP_STRINGS = {
     "csv_file": "CSV file containing your APC data. It must contain at least " +
                 "the 4 mandatory columns defined by the OpenAPC data schema: " +
@@ -141,6 +109,12 @@ ARG_HELP_STRINGS = {
                        "csv file",
     "overwrite": "Always overwrite existing data with imported data " +
                  "(instead of asking on the first conflict)",
+    "no_crossref": "Do not import metadata from crossref. Since journal ISSN " +
+                   "numbers are imported from crossref, this will also make " +
+                   "a DOAJ lookup impossible if no ISSN fields are present in " +
+                   "the input data.",
+    "no_pubmed": "Do not import metadata from pubmed.",
+    "no_doaj": "Do not look up journals for being listended in the DOAJ.",
     "institution": "Manually identify the 'institution' column if the script " +
                    "fails to detect it automatically. The value is the " +
                    "numerical column index in the CSV file, with the " +
@@ -213,6 +187,12 @@ def main():
                         help=ARG_HELP_STRINGS["verbose"])
     parser.add_argument("-o", "--overwrite", action="store_true",
                         help=ARG_HELP_STRINGS["overwrite"])
+    parser.add_argument("--no-crossref", action="store_true",
+                        help=ARG_HELP_STRINGS["no_crossref"])
+    parser.add_argument("--no-pubmed", action="store_true",
+                        help=ARG_HELP_STRINGS["no_pubmed"])
+    parser.add_argument("--no-doaj", action="store_true",
+                        help=ARG_HELP_STRINGS["no_doaj"])
     parser.add_argument("-institution", "--institution_column", type=int,
                         help=ARG_HELP_STRINGS["institution"])
     parser.add_argument("-period", "--period_column", type=int,
@@ -238,9 +218,9 @@ def main():
     enc = None # CSV file encoding
 
     handler = logging.StreamHandler(sys.stderr)
-    handler.setFormatter(ANSIColorFormatter())
-    bufferedHandler = BufferedErrorHandler(handler)
-    bufferedHandler.setFormatter(ANSIColorFormatter())
+    handler.setFormatter(oat.ANSIColorFormatter())
+    bufferedHandler = oat.BufferedErrorHandler(handler)
+    bufferedHandler.setFormatter(oat.ANSIColorFormatter())
     logging.root.addHandler(handler)
     logging.root.addHandler(bufferedHandler)
     logging.root.setLevel(logging.INFO)
@@ -572,7 +552,8 @@ def main():
             continue
         print "---Processing line number " + str(row_num) + "---"
         enriched_row = oat.process_row(row, row_num, column_map, num_columns,
-                                       doaj_offline_analysis,
+                                       args.no_crossref, args.no_pubmed,
+                                       args.no_doaj, doaj_offline_analysis,
                                        args.bypass_cert_verification)
         enriched_content.append(enriched_row)
 

--- a/python/openapc_toolkit.py
+++ b/python/openapc_toolkit.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 import json
 import locale
 import logging
+from logging.handlers import MemoryHandler
 import re
 import ssl
 import sys
@@ -200,6 +201,36 @@ class CSVAnalysisResult(object):
                         int(self.enc_conf * 100))
         ret += "***************************"
         return ret
+
+class ANSIColorFormatter(logging.Formatter):
+    """
+    A simple logging formatter using ANSI codes to colorize messages
+    """
+    FORMATS = {
+        logging.ERROR: "\033[91m%(levelname)s: %(message)s\033[0m",
+        logging.WARNING: "\033[93m%(levelname)s: %(message)s\033[0m",
+        logging.INFO: "\033[94m%(levelname)s: %(message)s\033[0m",
+        "DEFAULT": "%(levelname)s: %(message)s"
+    }
+
+    def format(self, record):
+        self._fmt = self.FORMATS.get(record.levelno, self.FORMATS["DEFAULT"])
+        return logging.Formatter.format(self, record)
+
+class BufferedErrorHandler(MemoryHandler):
+    """
+    A modified MemoryHandler without automatic flushing.
+
+    This handler serves the simple purpose of buffering error and critical
+    log messages so that they can be shown to the user in collected form when
+    the enrichment process has finished.
+    """
+    def __init__(self, target):
+        MemoryHandler.__init__(self, 100000, target=target)
+        self.setLevel(logging.ERROR)
+
+    def shouldFlush(self, record):
+        return False
     
 def get_normalised_DOI(doi_string):
     doi_match = DOI_RE.match(doi_string.strip())
@@ -474,6 +505,12 @@ def get_metadata_from_crossref(doi_string):
         response = urllib2.urlopen(req)
         content_string = response.read()
         root = ET.fromstring(content_string)
+        doi_element = root.findall(".//cr_qr:doi", namespaces)
+        doi_type = doi_element[0].attrib['type']
+        if doi_type != "journal_article":
+            msg = ("Unsupported DOI type '" + doi_type + "' (OpenAPC only " +
+                   "supports journal articles)")
+            raise ValueError(msg)
         crossref_data = {}
         for path, elem in xpaths.iteritems():
             if elem not in crossref_data:
@@ -492,6 +529,9 @@ def get_metadata_from_crossref(doi_string):
     except ET.ParseError as etpe:
         ret_value['success'] = False
         ret_value['error_msg'] = "ElementTree ParseError: {}".format(str(etpe))
+    except ValueError as ve:
+        ret_value['success'] = False
+        ret_value['error_msg'] = str(ve)
     return ret_value
 
 def get_metadata_from_pubmed(doi_string):
@@ -593,7 +633,9 @@ def lookup_journal_in_doaj(issn, bypass_cert_verification=False):
     return ret_value
 
 def process_row(row, row_num, column_map, num_required_columns,
-                doaj_offline_analysis=False, bypass_cert_verification=False):
+                no_crossref_lookup=False, no_pubmed_lookup=False,
+                no_doaj_lookup=False, doaj_offline_analysis=False,
+                bypass_cert_verification=False):
     """
     Enrich a single row of data and reformat it according to Open APC standards.
 
@@ -609,11 +651,17 @@ def process_row(row, row_num, column_map, num_required_columns,
         num_required_columns: An int describing the required length of the row
                               list. If not matched, an error is logged and the
                               row is returned unchanged.
+        no_crossref_lookup: If true, no metadata will be imported from crossref.
+        no_pubmed_lookup: If true, no_metadata will be imported from pubmed.
+        no_doaj_lookup: If true, journals will not be checked for being
+                        listended in the DOAJ (default).
         doaj_offline_analysis: If true, a local copy will be used for the DOAJ
-                               lookup.
+                               lookup. Has no effect if no_doaj_lookup is set to
+                               true.
         bypass_cert_verification: If true, certificate validation will be
                                   skipped when connecting to metadata
                                   providers via TLS.
+
      Returns:
         A list of values which represents the enriched and re-arranged variant
         of the input row. If no errors were logged during the process, this
@@ -639,7 +687,8 @@ def process_row(row, row_num, column_map, num_required_columns,
                                  "discrimination ('%s')",
         "unknown_prefix": u"publisher 'Springer Nature' found for a " +
                            "pre-2015 article, but discrimination was " +
-                           "not possible - unknown prefix ('%s')"
+                           "not possible - unknown prefix ('%s')",
+        "issn_hyphen_fix": u"Normalisation: Added hyphen to %s value (%s -> %s)"
     }
 
     if len(row) != num_required_columns:
@@ -688,126 +737,136 @@ def process_row(row, row_num, column_map, num_required_columns,
             msg = MESSAGES["doi_norm"].format(doi, norm_doi)
             logging.warning(msg)
         # include crossref metadata
-        crossref_result = get_metadata_from_crossref(doi)
-        if crossref_result["success"]:
-            logging.info("Crossref: DOI resolved: " + doi)
-            current_row["indexed_in_crossref"] = "TRUE"
-            data = crossref_result["data"]
-            prefix = data.pop("prefix")
-            for key, value in data.iteritems():
-                if value is not None:
-                    if key == "journal_full_title":
-                        unified_value = get_unified_journal_title(value)
-                        if unified_value != value:
-                            msg = MESSAGES["unify"].format("journal title",
-                                                           value,
-                                                           unified_value)
-                            logging.warning(msg)
-                        new_value = unified_value
-                    elif key == "publisher":
-                        unified_value = get_unified_publisher_name(value)
-                        if unified_value != value:
-                            msg = MESSAGES["unify"].format("publisher name",
-                                                           value,
-                                                           unified_value)
-                            logging.warning(msg)
-                        new_value = unified_value
-                        # Treat Springer Nature special case: crossref erroneously
-                        # reports publisher "Springer Nature" even for articles
-                        # published before 2015 (publishers fusioned only then)
-                        if int(current_row["period"]) < 2015 and new_value == "Springer Nature":
-                            publisher = None
-                            if prefix in ["Springer (Biomed Central Ltd.)", "Springer-Verlag", "Springer - Psychonomic Society"]:
-                                publisher = "Springer Science + Business Media"
-                            elif prefix in ["Nature Publishing Group", "Nature Publishing Group - Macmillan Publishers"]:
-                                publisher = "Nature Publishing Group"
-                            if publisher:
-                                msg = "Line %s: " + MESSAGES["springer_distinction"]
-                                logging.warning(msg, row_num, publisher, prefix)
-                                new_value = publisher
-                            else:
-                                msg = "Line %s: " + MESSAGES["unknown_prefix"]
-                                logging.error(msg, row_num, prefix)
+        if not no_crossref_lookup:
+            crossref_result = get_metadata_from_crossref(doi)
+            if crossref_result["success"]:
+                logging.info("Crossref: DOI resolved: " + doi)
+                current_row["indexed_in_crossref"] = "TRUE"
+                data = crossref_result["data"]
+                prefix = data.pop("prefix")
+                for key, value in data.iteritems():
+                    if value is not None:
+                        if key == "journal_full_title":
+                            unified_value = get_unified_journal_title(value)
+                            if unified_value != value:
+                                msg = MESSAGES["unify"].format("journal title",
+                                                               value,
+                                                               unified_value)
+                                logging.warning(msg)
+                            new_value = unified_value
+                        elif key == "publisher":
+                            unified_value = get_unified_publisher_name(value)
+                            if unified_value != value:
+                                msg = MESSAGES["unify"].format("publisher name",
+                                                               value,
+                                                               unified_value)
+                                logging.warning(msg)
+                            new_value = unified_value
+                            # Treat Springer Nature special case: crossref erroneously
+                            # reports publisher "Springer Nature" even for articles
+                            # published before 2015 (publishers fusioned only then)
+                            if int(current_row["period"]) < 2015 and new_value == "Springer Nature":
+                                publisher = None
+                                if prefix in ["Springer (Biomed Central Ltd.)", "Springer-Verlag", "Springer - Psychonomic Society"]:
+                                    publisher = "Springer Science + Business Media"
+                                elif prefix in ["Nature Publishing Group", "Nature Publishing Group - Macmillan Publishers"]:
+                                    publisher = "Nature Publishing Group"
+                                if publisher:
+                                    msg = "Line %s: " + MESSAGES["springer_distinction"]
+                                    logging.warning(msg, row_num, publisher, prefix)
+                                    new_value = publisher
+                                else:
+                                    msg = "Line %s: " + MESSAGES["unknown_prefix"]
+                                    logging.error(msg, row_num, prefix)
+                        # Fix ISSNs without hyphen
+                        elif key in ["issn", "issn_print", "issn_electronic"]:
+                            new_value = value
+                            if re.match("^\d{7}[\dxX]$", value):
+                                new_value = value[:4] + "-" + value[4:]
+                                msg = "Line %s: " + MESSAGES["issn_hyphen_fix"]
+                                logging.warning(msg, row_num, key, value, new_value)
+                        else:
+                            new_value = value
                     else:
-                        new_value = value
-                else:
-                    new_value = "NA"
-                    msg = (u"WARNING: Element '%s' not found in in response for " +
-                           "doi %s.")
-                    logging.debug(msg, key, doi)
-                old_value = current_row[key]
-                current_row[key] = column_map[key].check_overwrite(old_value, new_value)
-        else:
-            msg = "Line %s: Crossref: Error while trying to resolve DOI %s: %s"
-            logging.error(msg, row_num, doi, crossref_result["error_msg"])
-            current_row["indexed_in_crossref"] = "FALSE"
-
+                        new_value = "NA"
+                        msg = (u"WARNING: Element '%s' not found in in response for " +
+                               "doi %s.")
+                        logging.debug(msg, key, doi)
+                    old_value = current_row[key]
+                    current_row[key] = column_map[key].check_overwrite(old_value, new_value)
+            else:
+                msg = "Line %s: Crossref: Error while trying to resolve DOI %s: %s"
+                logging.error(msg, row_num, doi, crossref_result["error_msg"])
+                current_row["indexed_in_crossref"] = "FALSE"
         # include pubmed metadata
-        pubmed_result = get_metadata_from_pubmed(doi)
-        if pubmed_result["success"]:
-            logging.info("Pubmed: DOI resolved: " + doi)
-            data = pubmed_result["data"]
-            for key, value in data.iteritems():
-                if value is not None:
-                    new_value = value
-                else:
-                    new_value = "NA"
-                    msg = (u"WARNING: Element %s not found in in response for " +
-                           "doi %s.")
-                    logging.debug(msg, key, doi)
-                old_value = current_row[key]
-                current_row[key] = column_map[key].check_overwrite(old_value, new_value)
-        else:
-            msg = "Line %s: Pubmed: Error while trying to resolve DOI %s: %s"
-            logging.error(msg, row_num, doi, pubmed_result["error_msg"])
+        if not no_pubmed_lookup:
+            pubmed_result = get_metadata_from_pubmed(doi)
+            if pubmed_result["success"]:
+                logging.info("Pubmed: DOI resolved: " + doi)
+                data = pubmed_result["data"]
+                for key, value in data.iteritems():
+                    if value is not None:
+                        new_value = value
+                    else:
+                        new_value = "NA"
+                        msg = (u"WARNING: Element %s not found in in response for " +
+                               "doi %s.")
+                        logging.debug(msg, key, doi)
+                    old_value = current_row[key]
+                    current_row[key] = column_map[key].check_overwrite(old_value, new_value)
+            else:
+                msg = "Line %s: Pubmed: Error while trying to resolve DOI %s: %s"
+                logging.error(msg, row_num, doi, pubmed_result["error_msg"])
 
     # lookup in DOAJ. try the EISSN first, then ISSN and finally print ISSN
-    issns = []
-    new_value = "NA"
-    if current_row["issn_electronic"] != "NA":
-        issns.append(current_row["issn_electronic"])
-    if current_row["issn"] != "NA":
-        issns.append(current_row["issn"])
-    if current_row["issn_print"] != "NA":
-        issns.append(current_row["issn_print"])
-    for issn in issns:
-        # In some cases xref delievers ISSNs without a hyphen. Add it
-        # temporarily to prevent the DOAJ lookup from failing.
-        if re.match("^\d{7}[\dxX]$", issn):
-            issn = issn[:4] + "-" + issn[4:]
-        # look up in an offline copy of the DOAJ if requested...
-        if doaj_offline_analysis:
-            lookup_result = doaj_offline_analysis.lookup(issn)
-            if lookup_result:
-                msg = (u"DOAJ: Journal ISSN (%s) found in DOAJ " +
-                       "offline copy ('%s').")
-                logging.info(msg, issn, lookup_result)
-                new_value = "TRUE"
-                break
-            else:
-                msg = (u"DOAJ: Journal ISSN (%s) not found in DOAJ " +
-                       "offline copy.")
-                new_value = "FALSE"
-                logging.info(msg, issn)
-        # ...or query the online API
-        else:
-            doaj_res = lookup_journal_in_doaj(issn, bypass_cert_verification)
-            if doaj_res["data_received"]:
-                if doaj_res["data"]["in_doaj"]:
-                    msg = u"DOAJ: Journal ISSN (%s) found in DOAJ ('%s')."
-                    logging.info(msg, issn, doaj_res["data"]["title"])
+    if not no_doaj_lookup:
+        issns = []
+        new_value = "NA"
+        if current_row["issn_electronic"] != "NA":
+            issns.append(current_row["issn_electronic"])
+        if current_row["issn"] != "NA":
+            issns.append(current_row["issn"])
+        if current_row["issn_print"] != "NA":
+            issns.append(current_row["issn_print"])
+        for issn in issns:
+            # In some cases xref delievers ISSNs without a hyphen. Add it
+            # temporarily to prevent the DOAJ lookup from failing.
+            if re.match("^\d{7}[\dxX]$", issn):
+                issn = issn[:4] + "-" + issn[4:]
+            # look up in an offline copy of the DOAJ if requested...
+            if doaj_offline_analysis:
+                lookup_result = doaj_offline_analysis.lookup(issn)
+                if lookup_result:
+                    msg = (u"DOAJ: Journal ISSN (%s) found in DOAJ " +
+                           "offline copy ('%s').")
+                    logging.info(msg, issn, lookup_result)
                     new_value = "TRUE"
                     break
                 else:
-                    msg = u"DOAJ: Journal ISSN (%s) not found in DOAJ."
-                    logging.info(msg, issn)
+                    msg = (u"DOAJ: Journal ISSN (%s) not found in DOAJ " +
+                           "offline copy.")
                     new_value = "FALSE"
+                    logging.info(msg, issn)
+            # ...or query the online API
             else:
-                msg = (u"Line %s: DOAJ: Error while trying to look up " +
-                       "ISSN %s: %s")
-                logging.error(msg, row_num, issn, doaj_res["error_msg"])
-    old_value = current_row["doaj"]
-    current_row["doaj"] = column_map["doaj"].check_overwrite(old_value, new_value)
+                doaj_res = lookup_journal_in_doaj(issn, bypass_cert_verification)
+                if doaj_res["data_received"]:
+                    if doaj_res["data"]["in_doaj"]:
+                        msg = u"DOAJ: Journal ISSN (%s) found in DOAJ ('%s')."
+                        logging.info(msg, issn, doaj_res["data"]["title"])
+                        new_value = "TRUE"
+                        break
+                    else:
+                        msg = u"DOAJ: Journal ISSN (%s) not found in DOAJ."
+                        logging.info(msg, issn)
+                        new_value = "FALSE"
+                else:
+                    msg = (u"Line %s: DOAJ: Error while trying to look up " +
+                           "ISSN %s: %s")
+                    logging.error(msg, row_num, issn, doaj_res["error_msg"])
+        old_value = current_row["doaj"]
+        current_row["doaj"] = column_map["doaj"].check_overwrite(old_value,
+                                                                 new_value)
     return current_row.values()
 
 
@@ -924,7 +983,9 @@ def get_unified_journal_title(journal_full_title):
         "Journal of Mass Communication & Journalism": "Journal of Mass Communication and Journalism",
         "Journal of Child and Adolescent Behavior": "Journal of Child and Adolescent Behaviour",
         "Journal of Otolaryngology - Head and Neck Surgery": "Journal of Otolaryngology - Head & Neck Surgery",
-        "manuscripta mathematica": "Manuscripta Mathematica"
+        "manuscripta mathematica": "Manuscripta Mathematica",
+        "CPT Pharmacometrics Syst. Pharmacol.": "CPT: Pharmacometrics & Systems Pharmacology",
+        "Taal en tongval": "Taal en Tongval"
     }
     return journal_mappings.get(journal_full_title, journal_full_title)
 

--- a/python/sciencedirect_check_oa.py
+++ b/python/sciencedirect_check_oa.py
@@ -1,0 +1,133 @@
+#!/usr/bin/python
+# -*- coding: UTF-8 -*-
+
+import argparse
+import codecs
+import logging
+import re
+import sys
+import time
+import urllib2
+
+import openapc_toolkit as oat
+
+ARG_HELP_STRINGS = {
+    "csv_file": "An OpenAPC-conforming CSV file where oa status for elsevier " +
+                "articles should be checked",
+    "encoding": "The encoding of the CSV file. Setting this argument will " +
+                "disable automatic guessing of encoding.",
+    "start": "Do not process the whole file, but start from this line " +
+             "number. May be used together with '-end' to select a specific " +
+             "segment.",
+    "end": "Do not process the whole file, but end at this line number. May " +
+           "be used together with '-start' to select a specific segment."
+}
+
+# regex for landing pages with a single pdf file
+pdflink_re = re.compile('<a id="pdfLink".*?pdfurl="(.*?)"')
+
+# regex for pages with more than one pdf. Note that this snippet is located
+# in a commented section (it is transformed via js dynamically), so the href
+# link might not be initially valid (ampersand escaping etc)
+pdflink_multi_re = re.compile('<a class="download-pdf-link".*?href="(.*?)"')
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("csv_file", help=ARG_HELP_STRINGS["csv_file"])
+    parser.add_argument("-e", "--encoding", help=ARG_HELP_STRINGS["encoding"])
+    parser.add_argument("-start", type=int, default=1, help=ARG_HELP_STRINGS["start"])
+    parser.add_argument("-end", type=int, help=ARG_HELP_STRINGS["start"])
+    args = parser.parse_args()
+
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(oat.ANSIColorFormatter())
+    bufferedHandler = oat.BufferedErrorHandler(handler)
+    bufferedHandler.setFormatter(oat.ANSIColorFormatter())
+    logging.root.addHandler(handler)
+    logging.root.addHandler(bufferedHandler)
+    logging.root.setLevel(logging.INFO)
+
+    enc = None
+    if args.encoding:
+        try:
+            codec = codecs.lookup(args.encoding)
+            msg = ("Encoding '{}' found in Python's codec collection " +
+                   "as '{}'").format(args.encoding, codec.name)
+            oat.print_g(msg)
+            enc = args.encoding
+        except LookupError:
+            msg = ("Error: '" + args.encoding + "' not found Python's " +
+                   "codec collection. Either look for a valid name here " +
+                   "(https://docs.python.org/2/library/codecs.html#standard-" +
+                   "encodings) or omit this argument to enable automated " +
+                   "guessing.")
+            oat.print_r(msg)
+            sys.exit()
+
+    head, content = oat.get_csv_file_content(args.csv_file, enc)
+    content = head + content
+
+    header = {"User-Agent": "Mozilla/5.0 Firefox/45.0"}
+
+    line_num = 0
+    for line in content:
+        line_num += 1
+        if args.start and args.start > line_num:
+            continue
+        if args.end and args.end < line_num:
+            continue
+        institution = line[0]
+        period = line[1]
+        doi = line[3]
+        is_hybrid = line[4]
+        publisher = line[5]
+        journal = line[6]
+        if publisher != "Elsevier" or is_hybrid != "TRUE":
+            continue
+        init_msg = (u"Line {}: Checking {} article from {}, published in " +
+                    "{}...").format(line_num, institution, period, journal)
+        oat.print_b(init_msg)
+        url = 'http://doi.org/' + doi
+        req = urllib2.Request(url, None, header)
+        ret_value = {'success': True}
+        try:
+            response = urllib2.urlopen(req)
+            target = response.geturl()
+            resolve_msg = u"DOI {} resolved, led us to {}".format(doi, target)
+            if "sciencedirect.com" not in target:
+                oat.print_y(resolve_msg)
+                oat.print_y("Journal not located at sciencedirect, skipping...")
+                continue
+            oat.print_b(resolve_msg)
+            content_string = response.read()
+            single_match = pdflink_re.search(content_string)
+            if single_match:
+                link_url = single_match.groups()[0]
+                oat.print_g(u"PDF link found: " + link_url)
+            else:
+                multi_match = pdflink_multi_re.search(content_string)
+                if multi_match:
+                   link_url = multi_match.groups()[0]
+                   link_url = link_url.replace("&amp;", "&")
+                   oat.print_g(u"PDF link found (more than one document): " + link_url)
+                else:
+                    error_msg = (u"No PDF link found! (line {}, DOI: {}, " +
+                                 "landing page: {})").format(line_num, doi, target)
+                    logging.error(error_msg)
+            time.sleep(1)
+        except urllib2.HTTPError as httpe:
+            code = str(httpe.getcode())
+            oat.print_r("HTTPError: {} - {}".format(code, httpe.reason))
+        except urllib2.URLError as urle:
+            oat.print_r("URLError: {}".format(urle.reason))
+
+    if not bufferedHandler.buffer:
+        oat.print_g("\nLookup finished, all articles were accessible on sciencedirect")
+    else:
+        oat.print_r("\nLookup finished, not all articles could be accessed on sciencedirect:\n")
+    # closing will implicitly flush the handler and print any buffered
+    # messages to stderr
+    bufferedHandler.close()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Changes:
* Processing sources (crossref, pubmed, doaj) can now be turned on/off via command line
* ISSNs will now be normalised (Sometimes crossref delivers them without a hyphen)
* Document type will now be checked during crossref enrichment, everything except a journal article will throw an error message
* Moved some helper classes to toolkit

New:
* Added a script to look up PDF links on sciencedirect (See http://openapc.github.io/general/openapc/2017/02/23/elsevier_hybrid_access)