### PR TITLE
Additional metadata (ut + issn_l) added to apc_se file 

### DIFF
--- a/data/apc_se.csv
+++ b/data/apc_se.csv
@@ -1,2172 +1,2172 @@
 institution,period,euro,doi,is_hybrid,publisher,journal_full_title,issn,issn_print,issn_electronic,issn_l,license_ref,indexed_in_crossref,pmid,pmcid,ut,url,doaj
-bth,2016,2200,10.1007/s11187-016-9801-2,TRUE,Springer,Small Business Economics,0921-898X,0921-898X,1573-0913,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2013,413,10.1080/21663831.2013.844737,FALSE,Taylor & Francis,Materials Research Letters,2166-3831,NA,2166-3831,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-cth,2014,2429,10.1080/00207543.2014.980456,TRUE,Taylor & Francis,International Journal of Production Research,0020-7543,0020-7543,1366-588X,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-cth,2014,2429,10.1080/01490451.2013.879508,TRUE,Taylor & Francis,Geomicrobiology Journal,0149-0451,0149-0451,1521-0529,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-cth,2014,2429,10.1080/13669877.2014.889194,TRUE,Taylor & Francis,Journal of Risk Research,1366-9877,1366-9877,1466-4461,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-cth,2014,3040,10.3109/14992027.2014.996826,TRUE,Taylor & Francis,International Journal of Audiology,1499-2027,1499-2027,1708-8186,NA,NA,TRUE,25705995,PMC4487578,NA,NA,FALSE
-cth,2016,1169,10.1080/23311916.2016.1239516,FALSE,Taylor & Francis,Cogent Engineering,2331-1916,NA,2331-1916,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-cth,2016,2132,10.1080/10643389.2016.1149903,TRUE,Taylor & Francis,Critical Reviews in Environmental Science and Technology,1064-3389,1064-3389,1547-6537,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2132,10.1080/17445760.2016.1241880,TRUE,Taylor & Francis,"International Journal of Parallel, Emergent and Distributed Systems",1744-5760,1744-5760,1744-5779,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2132,10.1080/19376812.2015.1130636,TRUE,Taylor & Francis,African Geographical Review,1937-6812,1937-6812,2163-2642,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s00023-016-0531-4,TRUE,Springer,Annales Henri Poincaré,1424-0637,1424-0637,1424-0661,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s00190-016-0974-x,TRUE,Springer,Journal of Geodesy,0949-7714,0949-7714,1432-1394,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s00707-016-1754-7,TRUE,Springer,Acta Mechanica,0001-5970,0001-5970,1619-6937,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s00766-016-0259-1,TRUE,Springer,Requirements Engineering,0947-3602,0947-3602,1432-010X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s00766-016-0261-7,TRUE,Springer,Requirements Engineering,0947-3602,0947-3602,1432-010X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s10064-016-0962-7,TRUE,Springer,Bulletin of Engineering Geology and the Environment,1435-9529,1435-9529,1435-9537,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s10107-016-1055-x,TRUE,Springer,Mathematical Programming,0025-5610,0025-5610,1436-4646,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s10295-016-1814-y,TRUE,Springer,Journal of Industrial Microbiology & Biotechnology,1367-5435,1367-5435,1476-5535,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27565672,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s10472-016-9532-8,TRUE,Springer,Annals of Mathematics and Artificial Intelligence,1012-2443,1012-2443,1573-7470,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s10494-016-9760-3,TRUE,Springer,"Flow, Turbulence and Combustion",1386-6184,1386-6184,1573-1987,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s10534-016-9976-7,TRUE,Springer,BioMetals,0966-0844,0966-0844,1572-8773,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27744583,PMC5285417,NA,NA,FALSE
-cth,2016,2200,10.1007/s10543-016-0635-8,TRUE,Springer,BIT Numerical Mathematics,0006-3835,0006-3835,1572-9125,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s10570-016-1080-1,TRUE,Springer,Cellulose,0969-0239,0969-0239,1572-882X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s10664-016-9482-0,TRUE,Springer,Empirical Software Engineering,1382-3256,1382-3256,1573-7616,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s10811-016-0957-6,TRUE,Springer,Journal of Applied Phycology,0921-8971,0921-8971,1573-5176,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28344391,PMC5346136,NA,NA,FALSE
-cth,2016,2200,10.1007/s10948-016-3666-0,TRUE,Springer,Journal of Superconductivity and Novel Magnetism,1557-1939,1557-1939,1557-1947,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s10948-016-3851-1,TRUE,Springer,Journal of Superconductivity and Novel Magnetism,1557-1939,1557-1939,1557-1947,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s11044-016-9542-7,TRUE,Springer,Multibody System Dynamics,1384-5640,1384-5640,1573-272X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s11081-016-9342-1,TRUE,Springer,Optimization and Engineering,1389-4420,1389-4420,1573-2924,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s11241-016-9258-z,TRUE,Springer,Real-Time Systems,0922-6443,0922-6443,1573-1383,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s11367-016-1182-x,TRUE,Springer,The International Journal of Life Cycle Assessment,0948-3349,0948-3349,1614-7502,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s11517-016-1578-6,TRUE,Springer,Medical & Biological Engineering & Computing,0140-0118,0140-0118,1741-0444,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s12528-016-9127-8,TRUE,Springer,Journal of Computing in Higher Education,1042-1726,1042-1726,1867-1233,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s13399-016-0228-4,TRUE,Springer,Biomass Conversion and Biorefinery,2190-6815,2190-6815,2190-6823,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1007/s40831-016-0072-6,TRUE,Springer,Journal of Sustainable Metallurgy,2199-3823,2199-3823,2199-3831,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-cth,2016,2200,10.1208/s12248-016-9991-1,TRUE,Springer,The AAPS Journal,1550-7416,NA,1550-7416,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27681102,NA,NA,NA,FALSE
-cth,2016,560,10.1080/19942060.2016.1235515,FALSE,Taylor & Francis,Engineering Applications of Computational Fluid Mechanics,1994-2060,1994-2060,1997-003X,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-du,2014,1712,10.1186/1471-2393-14-349,FALSE,BioMed Central,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,NA,http://www.springer.com/tdm,TRUE,25288075,PMC4286931,NA,http://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/1471-2393-14-349,TRUE
-du,2014,1760,10.1186/1472-6882-14-187,FALSE,BioMed Central,BMC Complementary and Alternative Medicine,1472-6882,NA,1472-6882,NA,http://www.springer.com/tdm,TRUE,24913704,PMC4055800,NA,http://bmccomplementalternmed.biomedcentral.com/articles/10.1186/1472-6882-14-187,TRUE
-du,2014,1765,10.1186/1471-2458-14-892,FALSE,BioMed Central,BMC Public Health,1471-2458,NA,1471-2458,NA,http://www.springer.com/tdm,TRUE,25174960,PMC4168062,NA,http://bmcpublichealth.biomedcentral.com/articles/10.1186/1471-2458-14-892,TRUE
-du,2014,2211,10.1186/1471-2318-15-3,FALSE,BioMed Central,BMC Geriatrics,1471-2318,NA,1471-2318,NA,http://www.springer.com/tdm,TRUE,25563507,PMC4323237,NA,http://bmcgeriatr.biomedcentral.com/articles/10.1186/1471-2318-15-3,TRUE
-du,2014,2607,10.1111/scs.12121,TRUE,Wiley,Scandinavian Journal of Caring Sciences,0283-9318,NA,1471-6712,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,24602178,PMC4244179,NA,http://onlinelibrary.wiley.com/doi/10.1111/scs.12121/full,FALSE
-du,2014,660,10.1155/2014/860612,FALSE,Hindawi Publishing Corporation,Journal of Aging Research,2090-2204,2090-2204,2090-2212,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,25548675,PMC4273510,NA,https://www.hindawi.com/journals/jar/2014/860612/,TRUE
-du,2015,1320,10.1371/journal.pone.0133354,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26327217,PMC4556554,NA,http://journals.plos.org/plosone/article?id=10.1371%2Fjournal.pone.0133354,TRUE
-du,2015,1631,10.1016/j.ssci.2015.09.011,TRUE,Elsevier,Safety Science,0925-7535,0925-7535,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S0925753515002404,FALSE
-du,2015,1760,10.1186/s12906-015-0708-2,FALSE,BioMed Central,BMC Complementary and Alternative Medicine,1472-6882,NA,1472-6882,NA,http://www.springer.com/tdm,TRUE,26066641,PMC4490752,NA,http://bmccomplementalternmed.biomedcentral.com/articles/10.1186/s12906-015-0708-2,TRUE
-du,2015,1936,10.1186/s12884-015-0429-z,FALSE,BioMed Central,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,NA,http://www.springer.com/tdm,TRUE,25591791,PMC4299129,NA,http://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-015-0429-z,TRUE
-du,2015,2338,10.1186/s12913-015-0782-7,FALSE,BioMed Central,BMC Health Services Research,1472-6963,NA,1472-6963,NA,http://www.springer.com/tdm,TRUE,25888922,PMC4373305,NA,http://bmchealthservres.biomedcentral.com/articles/10.1186/s12913-015-0782-7,TRUE
-du,2015,2613,10.1016/j.jdiacomp.2015.07.026,TRUE,Elsevier,Journal of Diabetes and its Complications,1056-8727,1056-8727,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26318959,NA,NA,http://www.sciencedirect.com/science/article/pii/S1056872715003268,FALSE
-du,2015,2731,10.1111/jan.12655,TRUE,Wiley,Journal of Advanced Nursing,0309-2402,0309-2402,1365-2648,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25810044,NA,NA,http://onlinelibrary.wiley.com/doi/10.1111/jan.12655/full,FALSE
-du,2015,283,10.5430/jnep.v5n8p82,TRUE,Sciedu Press,Journal of Nursing Education and Practice,1925-4059,1925-4040,1925-4059,NA,NA,TRUE,NA,NA,NA,http://www.sciedu.ca/journal/index.php/jnep/article/view/6740,FALSE
-du,2015,440,10.1016/j.amper.2015.06.001,FALSE,Elsevier,Ampersand,2215-0390,2215-0390,2215-0390,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S2215039015000107,TRUE
-du,2015,498,10.1016/j.orp.2015.06.002,FALSE,Elsevier,Operations Research Perspectives,2214-7160,2214-7160,2214-7160,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S2214716015000135,TRUE
-du,2015,572,10.3402/gha.v8.27512,FALSE,Taylor & Francis,Global Health Action,1654-9716,1654-9716,1654-9880,NA,NA,TRUE,25828071,PMC4380857,NA,http://www.globalhealthaction.net/index.php/gha/article/view/27512,TRUE
-du,2015,598,10.1080/02673843.2015.1106414,TRUE,Taylor & Francis,International Journal of Adolescence and Youth,0267-3843,0267-3843,2164-4527,NA,NA,TRUE,NA,NA,NA,http://www.tandfonline.com/doi/full/10.1080/02673843.2015.1106414,TRUE
-du,2015,747,10.2174/1874434601610010026,TRUE,Bentham Open,The Open Nursing Journal,1874-4346,1874-4346,1874-4346,NA,NA,TRUE,27347252,PMC4894944,NA,https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4894944/,FALSE
-du,2015,926,10.1186/s13104-015-1597-7,FALSE,BioMed Central,BMC Research Notes,1756-0500,NA,1756-0500,NA,NA,TRUE,26517989,PMC4627617,NA,http://bmcresnotes.biomedcentral.com/articles/10.1186/s13104-015-1597-7,TRUE
-du,2016,1051,10.4236/ojn.2017.72013,FALSE,Scientific Research Publishing,Open Journal of Nursing,2162-5336,2162-5336,2162-5344,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,NA,http://www.scirp.org/Journal/PaperInformation.aspx?PaperID=73974,FALSE
-du,2016,1429,10.1186/s12884-016-0955-3,FALSE,BioMed Central,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,NA,NA,TRUE,27430590,PMC4949764,NA,https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-016-0955-3,TRUE
-du,2016,1614,10.2147/OAJSM.S101995,FALSE,Dove Medical Press,Open Access Journal of Sports Medicine,1179-1543,NA,1179-1543,NA,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,26937207,PMC4762471,NA,https://www.dovepress.com/the-influence-of-sex-age-and-race-experience-on-pacing-profiles-during-peer-reviewed-article-OAJSM,TRUE
-du,2016,1636,10.2147/OAJSM.S93174,FALSE,Dove Medical Press,Open Access Journal of Sports Medicine,1179-1543,NA,1179-1543,NA,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,26719730,PMC4689292,NA,https://www.dovepress.com/optimal-vo2max-to-mass-ratio-for-predicting-15-km-performance-among-el-peer-reviewed-article-OAJSM,TRUE
-du,2016,1650,10.1136/acupmed-2016-011164,TRUE,BMJ,Acupuncture in Medicine,0964-5284,0964-5284,1759-9873,NA,NA,TRUE,27986648,NA,NA,http://aim.bmj.com/content/early/2016/12/16/acupmed-2016-011164,FALSE
-du,2016,1698,10.1002/ece3.2449,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,2045-7758,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,http://onlinelibrary.wiley.com/doi/10.1002/ece3.2449/full,TRUE
-du,2016,1724,10.1186/s12889-016-3726-1,FALSE,BioMed Central,BMC Public Health,1471-2458,NA,1471-2458,NA,http://www.springer.com/tdm,TRUE,27745552,PMC5066281,NA,https://bmcpublichealth.biomedcentral.com/articles/10.1186/s12889-016-3726-1,TRUE
-du,2016,1792,10.1136/bmjopen-2015-010249,FALSE,BMJ,BMJ Open,2044-6055,2044-6055,2044-6055,NA,NA,TRUE,27013595,PMC4809096,NA,http://bmjopen.bmj.com/content/6/3/e010249.full,TRUE
-du,2016,1815,10.1186/s12884-016-1183-6,FALSE,BioMed Central,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,NA,NA,TRUE,28049520,PMC5209800,NA,http://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-016-1183-6,TRUE
-du,2016,1919,10.1186/s12909-016-0532-5,FALSE,BioMed Central,BMC Medical Education,1472-6920,NA,1472-6920,NA,NA,TRUE,26758763,PMC4710021,NA,http://bmcmededuc.biomedcentral.com/articles/10.1186/s12909-016-0532-5,TRUE
-du,2016,1980,10.1186/s12914-016-0082-2,FALSE,BioMed Central,BMC International Health and Human Rights,1472-698X,NA,1472-698X,NA,NA,TRUE,26883321,PMC4754847,NA,https://bmcinthealthhumrights.biomedcentral.com/articles/10.1186/s12914-016-0082-2,TRUE
-du,2016,2271,10.1186/s12913-016-1957-6,FALSE,BioMed Central,BMC Health Services Research,1472-6963,NA,1472-6963,NA,NA,TRUE,28077130,PMC5225615,NA,http://bmchealthservres.biomedcentral.com/articles/10.1186/s12913-016-1957-6,TRUE
-du,2016,2519,10.1016/j.midw.2016.05.009,TRUE,Elsevier,Midwifery,0266-6138,0266-6138,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27428093,NA,NA,http://www.sciencedirect.com/science/article/pii/S0266613816300614,FALSE
-du,2016,2690,10.1111/apa.13417,TRUE,Wiley,Acta Paediatrica,0803-5253,NA,1651-2227,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27059114,PMC5074324,NA,http://onlinelibrary.wiley.com/doi/10.1111/apa.13417/full,FALSE
-du,2016,2764,10.1111/2041-210X.12535,TRUE,Wiley,Methods in Ecology and Evolution,2041-210X,NA,2041-210X,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27478587,PMC4950150,NA,http://onlinelibrary.wiley.com/doi/10.1111/2041-210X.12535/full,FALSE
-du,2016,2794,10.1111/scs.12391,TRUE,Wiley,Scandinavian Journal of Caring Sciences,0283-9318,NA,1471-6712,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27862156,NA,NA,http://onlinelibrary.wiley.com/doi/10.1111/scs.12391/full,FALSE
-du,2016,2852,10.1016/j.diabres.2016.09.015,TRUE,Elsevier,Diabetes Research and Clinical Practice,0168-8227,0168-8227,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27718374,NA,NA,http://www.sciencedirect.com/science/article/pii/S0168822716306064,FALSE
-du,2016,3428,10.1016/j.matchar.2016.10.017,TRUE,Elsevier,Materials Characterization,1044-5803,1044-5803,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1044580316306131,FALSE
-du,2016,4679,10.1111/wvn.12178,TRUE,Wiley,Worldviews on Evidence-Based Nursing,1545-102X,1545-102X,1741-6787,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27741384,NA,NA,http://onlinelibrary.wiley.com/doi/10.1111/wvn.12178/full,FALSE
-du,2016,726,10.1155/2016/6373101,FALSE,Hindawi Publishing Corporation,Journal of Aging Research,2090-2204,2090-2204,2090-2212,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,NA,https://www.hindawi.com/journals/jar/2016/6373101/,TRUE
-foi,2016,2200,10.1007/s10967-016-5062-4,TRUE,Springer,Journal of Radioanalytical and Nuclear Chemistry,0236-5731,0236-5731,1588-2780,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28250544,PMC5306257,NA,NA,FALSE
-gih,2016,2200,10.1007/s00421-016-3428-5,TRUE,Springer,European Journal of Applied Physiology,1439-6319,1439-6319,1439-6327,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27448605,PMC4983295,NA,NA,FALSE
-gu,2010,2630,10.1080/02664760903222208,TRUE,Taylor & Francis,Journal of Applied Statistics,0266-4763,0266-4763,1360-0532,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-gu,2013,2429,10.1080/10439463.2013.817995,TRUE,Taylor & Francis,Policing and Society,1043-9463,1043-9463,1477-2728,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-gu,2013,2429,10.1080/10439463.2013.817996,TRUE,Taylor & Francis,Policing and Society,1043-9463,1043-9463,1477-2728,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-gu,2014,0,10.1159/000369918,FALSE,Karger,Audiology and Neurotology Extra,1664-5537,NA,1664-5537,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-gu,2014,2132,10.1080/16506073.2014.921834,TRUE,Taylor & Francis,Cognitive Behaviour Therapy,1650-6073,1650-6073,1651-2316,NA,NA,TRUE,24911260,PMC4260664,NA,NA,FALSE
-gu,2014,2429,10.1080/2158379X.2014.963381,TRUE,Taylor & Francis,Journal of Political Power,2158-379X,2158-379X,2158-3803,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-gu,2014,2779,10.1111/adb.12202,TRUE,Wiley,Addiction Biology,1355-6215,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25475101,NA,NA,NA,FALSE
-gu,2014,755,10.1159/000362164,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,NA,NA,TRUE,25254036,PMC4164083,NA,NA,TRUE
-gu,2014,755,10.1159/000366119,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,NA,NA,TRUE,25493088,PMC4255994,NA,NA,TRUE
-gu,2015,0,10.1159/000441128,FALSE,Karger,Medical Principles and Practice,1011-7571,1011-7571,1423-0151,NA,NA,TRUE,26698595,NA,NA,NA,FALSE
-gu,2015,0,10.3109/17453674.2015.1135664,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,NA,NA,TRUE,26848766,PMC4900098,NA,NA,TRUE
-gu,2015,1425.1,10.1186/s12889-015-2599-z,FALSE,Springer,BMC Public Health,1471-2458,NA,1471-2458,NA,http://www.springer.com/tdm,TRUE,26689711,PMC4687316,NA,NA,TRUE
-gu,2015,2132,10.3109/00365521.2015.1087588,TRUE,Taylor & Francis,Scandinavian Journal of Gastroenterology,0036-5521,0036-5521,1502-7708,NA,NA,TRUE,26418670,PMC4732462,NA,NA,FALSE
-gu,2015,2429,10.1080/13607863.2015.1083945,TRUE,Taylor & Francis,Aging & Mental Health,1360-7863,1360-7863,1364-6915,NA,NA,TRUE,26381843,PMC4720055,NA,NA,FALSE
-gu,2015,2760,10.1586/14737159.2015.1057124,TRUE,Taylor & Francis,Expert Review of Molecular Diagnostics,1473-7159,1473-7159,1744-8352,NA,NA,TRUE,26132215,PMC4673511,NA,NA,FALSE
-gu,2015,2779,10.1002/gcc.22314,TRUE,Wiley,"Genes, Chromosomes and Cancer",1045-2257,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26493165,PMC5057327,NA,NA,FALSE
-gu,2015,2779,10.1002/gps.4390,TRUE,Wiley,International Journal of Geriatric Psychiatry,0885-6230,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26560405,PMC4908825,NA,NA,FALSE
-gu,2015,2779,10.1002/jbmr.2718,TRUE,Wiley,Journal of Bone and Mineral Research,0884-0431,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26391196,PMC4832265,NA,NA,FALSE
-gu,2015,2779,10.1002/jbmr.2747,TRUE,Wiley,Journal of Bone and Mineral Research,0884-0431,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26588353,NA,NA,NA,FALSE
-gu,2015,2779,10.1111/adb.12277,TRUE,Wiley,Addiction Biology,1355-6215,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26059200,PMC5033010,NA,NA,FALSE
-gu,2015,2779,10.1111/adb.12295,TRUE,Wiley,Addiction Biology,1355-6215,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26303264,PMC5049632,NA,NA,FALSE
-gu,2015,2779,10.1111/apa.13124,TRUE,Wiley,Acta Paediatrica,0803-5253,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26175065,PMC5049485,NA,NA,FALSE
-gu,2015,2779,10.1111/ddi.12394,TRUE,Wiley,Diversity and Distributions,1366-9516,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
-gu,2015,2779,10.1111/jch.12682,TRUE,Wiley,The Journal of Clinical Hypertension,1524-6175,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26456490,PMC5057328,NA,NA,FALSE
-gu,2015,2779,10.1111/jvh.12464,TRUE,Wiley,Journal of Viral Hepatitis,1352-0504,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26353843,NA,NA,NA,FALSE
-gu,2015,397,10.3109/02813432.2015.1067515,FALSE,Taylor & Francis,Scandinavian Journal of Primary Health Care,0281-3432,0281-3432,1502-7724,NA,NA,TRUE,26194171,PMC4750718,NA,NA,TRUE
-gu,2015,702,10.1080/15476286.2015.1056975,TRUE,Taylor & Francis,RNA Biology,1547-6286,1547-6286,1555-8584,NA,NA,TRUE,26176991,PMC4615768,NA,NA,FALSE
-gu,2015,702,10.1080/2162402X.2015.1041701,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,NA,NA,TRUE,26942055,PMC4760300,NA,NA,FALSE
-gu,2015,702,10.1080/21624054.2015.1096490,TRUE,Taylor & Francis,Worm,2162-4054,NA,2162-4054,NA,NA,TRUE,27123370,PMC4826155,NA,NA,FALSE
-gu,2016,0,10.1080/20004508.2016.1275177,FALSE,Taylor & Francis,Education Inquiry,2000-4508,NA,2000-4508,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,0,10.1080/20004508.2016.1275182,FALSE,Taylor & Francis,Education Inquiry,2000-4508,NA,2000-4508,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,0,10.1093/ckj/sfv152,FALSE,Oxford University Press (OUP),Clinical Kidney Journal,2048-8505,2048-8505,2048-8513,NA,NA,TRUE,26985373,PMC4792626,NA,NA,TRUE
-gu,2016,0,10.1107/S1600576715023444,TRUE,International Union of Crystallography (IUCr),Journal of Applied Crystallography,1600-5767,NA,1600-5767,NA,http://creativecommons.org/licenses/by/2.0/uk/legalcode,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,0,10.1111/eva.12277,FALSE,Wiley,Evolutionary Applications,1752-4571,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27087845,PMC4780386,NA,NA,TRUE
-gu,2016,0,10.1111/pbi.12479,FALSE,Wiley,Plant Biotechnology Journal,1467-7644,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26403330,NA,NA,NA,FALSE
-gu,2016,0,10.1177/2056305115624528,FALSE,SAGE Publications,Social Media + Society,2056-3051,2056-3051,2056-3051,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,0,10.1186/s12884-016-1127-1,FALSE,Springer,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,NA,http://www.springer.com/tdm,TRUE,27793111,PMC5084442,NA,NA,TRUE
-gu,2016,0,10.1186/s12884-016-1178-3,FALSE,Springer,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,NA,http://www.springer.com/tdm,TRUE,27931191,PMC5146820,NA,NA,TRUE
-gu,2016,0,10.1186/s40176-016-0061-3,FALSE,Springer,IZA Journal of Migration,2193-9039,NA,2193-9039,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,0,10.1186/s40536-016-0020-8,FALSE,Springer,Large-scale Assessments in Education,2196-0739,NA,2196-0739,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,0,10.1186/s40536-016-0027-1,FALSE,Springer,Large-scale Assessments in Education,2196-0739,NA,2196-0739,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,0,10.1515/nsad-2016-0020,FALSE,Walter de Gruyter,Nordic Studies on Alcohol and Drugs,1458-6126,NA,1458-6126,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,0,10.4309/jgi.2016.34.2,FALSE,Journal of Gambling Issues,Journal of Gambling Issues,1910-7595,1910-7595,NA,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,1009.1,10.1210/en.2016-1181,TRUE,The Endocrine Society,Endocrinology,0013-7227,0013-7227,1945-7170,NA,NA,TRUE,27254004,PMC4967117,NA,NA,FALSE
-gu,2016,1044,10.1186/s40658-016-0137-4,FALSE,Springer,EJNMMI Physics,2197-7364,NA,2197-7364,NA,NA,TRUE,26782039,PMC4718906,NA,NA,TRUE
-gu,2016,1082.35,10.1016/j.ssmph.2016.08.004,FALSE,Elsevier,SSM - Population Health,2352-8273,2352-8273,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1121,10.3390/su8121340,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1130,10.14814/phy2.12789,FALSE,Wiley,Physiological Reports,2051-817X,2051-817X,2051-817X,NA,NA,TRUE,27273879,PMC4908486,NA,NA,TRUE
-gu,2016,1157.4,10.1186/s40658-016-0168-x,FALSE,Springer,EJNMMI Physics,2197-7364,NA,2197-7364,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28070731,PMC5222763,NA,NA,TRUE
-gu,2016,1159.6,10.1186/s13104-016-1878-9,FALSE,Springer,BMC Research Notes,1756-0500,NA,1756-0500,NA,NA,TRUE,26843185,PMC4739106,NA,NA,TRUE
-gu,2016,1160,10.1002/ece3.2318,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1165,10.1038/srep20413,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,26846342,PMC4742773,NA,NA,TRUE
-gu,2016,1165,10.1038/srep24717,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,27090401,PMC4835753,NA,NA,TRUE
-gu,2016,1165,10.1038/srep29200,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,27383650,PMC4935877,NA,NA,TRUE
-gu,2016,1165,10.1038/srep31524,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,27528202,PMC4985744,NA,NA,TRUE
-gu,2016,1165,10.1038/srep35279,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,27756898,PMC5069500,NA,NA,TRUE
-gu,2016,1195,10.3389/fncom.2016.00088,FALSE,Frontiers,Frontiers in Computational Neuroscience,1662-5188,NA,1662-5188,NA,NA,TRUE,27601989,PMC4993777,NA,NA,TRUE
-gu,2016,1200,10.1002/iid3.105,FALSE,Wiley,"Immunity, Inflammation and Disease",2050-4527,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1208.5,10.1186/s40658-016-0153-4,FALSE,Springer,EJNMMI Physics,2197-7364,NA,2197-7364,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27491429,PMC4975733,NA,NA,TRUE
-gu,2016,1224,10.1002/ece3.2126,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27516852,PMC4972216,NA,NA,TRUE
-gu,2016,1256,10.1371/journal.pone.0150286,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26981623,PMC4794193,NA,NA,TRUE
-gu,2016,1256,10.1371/journal.pone.0153296,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27077913,PMC4831691,NA,NA,TRUE
-gu,2016,1256,10.1371/journal.pone.0155465,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27192203,PMC4871506,NA,NA,TRUE
-gu,2016,1256,10.1371/journal.pone.0156484,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27243937,PMC4886961,NA,NA,TRUE
-gu,2016,1307,10.1186/s12987-016-0037-y,FALSE,Springer,Fluids and Barriers of the CNS,2045-8118,NA,2045-8118,NA,NA,TRUE,27472944,PMC4967298,NA,NA,TRUE
-gu,2016,1338.81,10.1016/j.pmedr.2016.04.010,FALSE,Elsevier,Preventive Medicine Reports,2211-3355,2211-3355,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27413660,PMC4929080,NA,NA,TRUE
-gu,2016,1341,10.3389/fmars.2016.00011,FALSE,Frontiers,Frontiers in Marine Science,2296-7745,NA,2296-7745,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1345.5,10.1371/journal.pone.0145890,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26752550,PMC4709062,NA,NA,TRUE
-gu,2016,1345.5,10.1371/journal.pone.0147152,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26766577,PMC4713078,NA,NA,TRUE
-gu,2016,1345.5,10.1371/journal.pone.0149456,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26925974,PMC4771210,NA,NA,TRUE
-gu,2016,1345.5,10.1371/journal.pone.0152198,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27022948,PMC4811441,NA,NA,TRUE
-gu,2016,1345.5,10.1371/journal.pone.0153888,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27100092,PMC4839681,NA,NA,TRUE
-gu,2016,1345.5,10.1371/journal.pone.0155164,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27214132,PMC4876998,NA,NA,TRUE
-gu,2016,1345.5,10.1371/journal.pone.0157160,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27295036,PMC4905676,NA,NA,TRUE
-gu,2016,1345.5,10.1371/journal.pone.0157504,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27299883,PMC4907497,NA,NA,TRUE
-gu,2016,1345.5,10.1371/journal.pone.0158973,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27441551,PMC4956037,NA,NA,TRUE
-gu,2016,1345.5,10.1371/journal.pone.0159105,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27434143,PMC4951030,NA,NA,TRUE
-gu,2016,1345.5,10.1371/journal.pone.0165914,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27812209,PMC5094703,NA,NA,TRUE
-gu,2016,1345.5,10.1371/journal.pone.0167800,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27977703,PMC5158052,NA,NA,TRUE
-gu,2016,1345.5,10.1371/journal.pone.0167965,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27941994,PMC5152857,NA,NA,TRUE
-gu,2016,1351.1,10.3390/v8090259,FALSE,MDPI,Viruses,1999-4915,NA,1999-4915,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1385.3,10.1371/journal.pone.0156708,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27311019,PMC4911171,NA,NA,TRUE
-gu,2016,1391,10.1371/journal.pone.0154477,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27139195,PMC4854378,NA,NA,TRUE
-gu,2016,1391,10.1371/journal.pone.0154630,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27159398,PMC4861286,NA,NA,TRUE
-gu,2016,1391,10.1371/journal.pone.0155083,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27223117,PMC4880197,NA,NA,TRUE
-gu,2016,1391,10.1371/journal.pone.0155099,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27166587,PMC4864434,NA,NA,TRUE
-gu,2016,1391,10.1371/journal.pone.0155328,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27171440,PMC4865157,NA,NA,TRUE
-gu,2016,1391,10.1371/journal.pone.0158957,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27463968,PMC4963079,NA,NA,TRUE
-gu,2016,1391,10.1371/journal.pone.0158985,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27441602,PMC4956274,NA,NA,TRUE
-gu,2016,1391,10.1371/journal.pone.0159593,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27483138,PMC4970800,NA,NA,TRUE
-gu,2016,1391,10.1371/journal.pone.0160335,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27490719,PMC4973994,NA,NA,TRUE
-gu,2016,1391,10.1371/journal.pone.0161161,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27513955,PMC4981371,NA,NA,TRUE
-gu,2016,1391,10.1371/journal.pone.0161266,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27525655,PMC4985153,NA,NA,TRUE
-gu,2016,1391,10.1371/journal.pone.0161270,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27517693,PMC4982604,NA,NA,TRUE
-gu,2016,1391,10.1371/journal.pone.0161629,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27552229,PMC4994938,NA,NA,TRUE
-gu,2016,1391,10.1371/journal.pone.0162638,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27611867,PMC5017602,NA,NA,TRUE
-gu,2016,1397.7,10.3390/v8040110,FALSE,MDPI,Viruses,1999-4915,NA,1999-4915,NA,NA,TRUE,27110813,PMC4848603,NA,NA,TRUE
-gu,2016,1397.7,10.3390/v8100273,FALSE,MDPI,Viruses,1999-4915,NA,1999-4915,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1398,10.1038/srep23728,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,NA,TRUE,27020613,PMC4810423,NA,NA,TRUE
-gu,2016,1402.6,10.1186/s12872-016-0400-6,FALSE,Springer,BMC Cardiovascular Disorders,1471-2261,NA,1471-2261,NA,http://www.springer.com/tdm,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1402.6,10.1186/s12883-016-0753-6,FALSE,Springer,BMC Neurology,1471-2377,NA,1471-2377,NA,http://www.springer.com/tdm,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1402.6,10.1186/s12886-016-0392-0,FALSE,Springer,BMC Ophthalmology,1471-2415,NA,1471-2415,NA,http://www.springer.com/tdm,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1403.6,10.1186/s12877-016-0345-8,FALSE,Springer,BMC Geriatrics,1471-2318,NA,1471-2318,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1403.6,10.1186/s12888-016-1147-4,FALSE,Springer,BMC Psychiatry,1471-244X,NA,1471-244X,NA,http://www.springer.com/tdm,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1403.6,10.1186/s12889-016-3852-9,FALSE,Springer,BMC Public Health,1471-2458,NA,1471-2458,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1405.5,10.1186/s12014-016-9104-2,FALSE,Springer,Clinical Proteomics,1542-6416,1542-6416,1559-0275,NA,NA,TRUE,26924951,PMC4768413,NA,NA,TRUE
-gu,2016,1405.5,10.1186/s12859-016-1250-z,FALSE,Springer,BMC Bioinformatics,1471-2105,NA,1471-2105,NA,NA,TRUE,27618934,PMC5020511,NA,NA,TRUE
-gu,2016,1405.5,10.1186/s12872-016-0309-0,FALSE,Springer,BMC Cardiovascular Disorders,1471-2261,NA,1471-2261,NA,http://www.springer.com/tdm,TRUE,27267131,PMC4895810,NA,NA,TRUE
-gu,2016,1405.5,10.1186/s12873-016-0087-0,FALSE,Springer,BMC Emergency Medicine,1471-227X,NA,1471-227X,NA,NA,TRUE,27449526,PMC4957482,NA,NA,TRUE
-gu,2016,1405.5,10.1186/s12880-016-0145-9,FALSE,Springer,BMC Medical Imaging,1471-2342,NA,1471-2342,NA,http://www.springer.com/tdm,TRUE,27400959,PMC4940685,NA,NA,TRUE
-gu,2016,1405.5,10.1186/s12882-016-0251-5,FALSE,Springer,BMC Nephrology,1471-2369,NA,1471-2369,NA,http://www.springer.com/tdm,TRUE,27044423,PMC4820936,NA,NA,TRUE
-gu,2016,1405.5,10.1186/s12883-016-0599-y,FALSE,Springer,BMC Neurology,1471-2377,NA,1471-2377,NA,NA,TRUE,27411309,PMC4942912,NA,NA,TRUE
-gu,2016,1405.5,10.1186/s12889-016-2900-9,FALSE,Springer,BMC Public Health,1471-2458,NA,1471-2458,NA,NA,TRUE,26944255,PMC4779265,NA,NA,TRUE
-gu,2016,1405.5,10.1186/s12889-016-3626-4,FALSE,Springer,BMC Public Health,1471-2458,NA,1471-2458,NA,NA,TRUE,27608963,PMC5017061,NA,NA,TRUE
-gu,2016,1405.5,10.1186/s12889-016-3654-0,FALSE,Springer,BMC Public Health,1471-2458,NA,1471-2458,NA,NA,TRUE,27633778,PMC5025586,NA,NA,TRUE
-gu,2016,1405.5,10.1186/s12890-015-0158-0,FALSE,Springer,BMC Pulmonary Medicine,1471-2466,NA,1471-2466,NA,NA,TRUE,26673917,PMC4681169,NA,NA,TRUE
-gu,2016,1405.5,10.1186/s12912-016-0173-3,FALSE,Springer,BMC Nursing,1472-6955,NA,1472-6955,NA,NA,TRUE,27616936,PMC5017008,NA,NA,TRUE
-gu,2016,1405.5,10.1186/s12967-016-0927-4,FALSE,Springer,Journal of Translational Medicine,1479-5876,NA,1479-5876,NA,NA,TRUE,27320496,PMC4913423,NA,NA,TRUE
-gu,2016,1422.5,10.1371/journal.pone.0152899,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27054573,PMC4824445,NA,NA,TRUE
-gu,2016,1422.5,10.1371/journal.pone.0164435,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27760182,PMC5070875,NA,NA,TRUE
-gu,2016,1422.5,10.1371/journal.pone.0166251,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27861529,PMC5115717,NA,NA,TRUE
-gu,2016,1422.5,10.1371/journal.pone.0166469,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27851775,PMC5112775,NA,NA,TRUE
-gu,2016,1422.5,10.1371/journal.pone.0166918,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27973542,PMC5156420,NA,NA,TRUE
-gu,2016,1422.5,10.1371/journal.pone.0167287,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27907047,PMC5131947,NA,NA,TRUE
-gu,2016,1422.5,10.1371/journal.pone.0167529,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27907124,PMC5132201,NA,NA,TRUE
-gu,2016,1422.5,10.1371/journal.pone.0168128,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27977802,PMC5157998,NA,NA,TRUE
-gu,2016,1425.1,10.1186/s13195-016-0178-x,FALSE,Springer,Alzheimer's Research & Therapy,1758-9193,NA,1758-9193,NA,NA,TRUE,26948580,PMC4780148,NA,NA,TRUE
-gu,2016,1425.9,10.1186/s13195-015-0160-z,FALSE,Springer,Alzheimer's Research & Therapy,1758-9193,NA,1758-9193,NA,NA,TRUE,26689589,PMC4687145,NA,NA,TRUE
-gu,2016,1439.7,10.1186/s12937-016-0160-2,FALSE,Springer,Nutrition Journal,1475-2891,NA,1475-2891,NA,NA,TRUE,27103118,PMC4840851,NA,NA,TRUE
-gu,2016,1479.2,10.1186/s13293-016-0059-9,FALSE,Springer,Biology of Sex Differences,2042-6410,NA,2042-6410,NA,NA,TRUE,26779332,PMC4715328,NA,NA,TRUE
-gu,2016,1482,10.1186/s12859-016-1144-0,FALSE,Springer,BMC Bioinformatics,1471-2105,NA,1471-2105,NA,NA,TRUE,27370569,PMC4930602,NA,NA,TRUE
-gu,2016,1482,10.1186/s12874-016-0167-6,FALSE,Springer,BMC Medical Research Methodology,1471-2288,NA,1471-2288,NA,NA,TRUE,27387456,PMC4937582,NA,NA,TRUE
-gu,2016,1482,10.1186/s12879-016-1628-6,FALSE,Springer,BMC Infectious Diseases,1471-2334,NA,1471-2334,NA,http://www.springer.com/tdm,TRUE,27329293,PMC4915053,NA,NA,TRUE
-gu,2016,1482,10.1186/s12884-016-0969-x,FALSE,Springer,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,NA,NA,TRUE,27473076,PMC4967348,NA,NA,TRUE
-gu,2016,1482,10.1186/s12885-016-2196-2,FALSE,Springer,BMC Cancer,1471-2407,NA,1471-2407,NA,NA,TRUE,26908052,PMC4763409,NA,NA,TRUE
-gu,2016,1482,10.1186/s12890-016-0306-1,FALSE,Springer,BMC Pulmonary Medicine,1471-2466,NA,1471-2466,NA,http://www.springer.com/tdm,TRUE,27842581,PMC5109668,NA,NA,TRUE
-gu,2016,1482,10.1186/s12891-016-0911-4,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,NA,NA,TRUE,26846791,PMC4743196,NA,NA,TRUE
-gu,2016,1482,10.1186/s12891-016-0960-8,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,NA,NA,TRUE,26922375,PMC4769824,NA,NA,TRUE
-gu,2016,1482,10.1186/s12891-016-1112-x,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,NA,http://www.springer.com/tdm,TRUE,27286829,PMC4901501,NA,NA,TRUE
-gu,2016,1482,10.1186/s12891-016-1154-0,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,NA,http://www.springer.com/tdm,TRUE,27406174,PMC4941027,NA,NA,TRUE
-gu,2016,1482,10.1186/s12891-016-1262-x,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,NA,http://www.springer.com/tdm,TRUE,27716136,PMC5050595,NA,NA,TRUE
-gu,2016,1482,10.1186/s12891-016-1315-1,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,NA,http://www.springer.com/tdm,TRUE,27829407,PMC5103594,NA,NA,TRUE
-gu,2016,1482,10.1186/s12891-016-1354-7,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,NA,http://www.springer.com/tdm,TRUE,27955647,PMC5154076,NA,NA,TRUE
-gu,2016,1482,10.1186/s12894-016-0168-0,FALSE,Springer,BMC Urology,1471-2490,NA,1471-2490,NA,NA,TRUE,27531014,PMC4986175,NA,NA,TRUE
-gu,2016,1482,10.1186/s12898-016-0067-y,FALSE,Springer,BMC Ecology,1472-6785,NA,1472-6785,NA,NA,TRUE,26928449,PMC4772348,NA,NA,TRUE
-gu,2016,1482,10.1186/s12944-016-0342-0,FALSE,Springer,Lipids in Health and Disease,1476-511X,NA,1476-511X,NA,NA,TRUE,27671740,PMC5037885,NA,NA,TRUE
-gu,2016,1482,10.1186/s12947-016-0091-2,FALSE,Springer,Cardiovascular Ultrasound,1476-7120,NA,1476-7120,NA,http://www.springer.com/tdm,TRUE,27919286,PMC5139021,NA,NA,TRUE
-gu,2016,1482,10.1186/s40795-016-0094-2,FALSE,Springer,BMC Nutrition,2055-0928,NA,2055-0928,NA,http://www.springer.com/tdm,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1490.9,10.1039/C6SM00580B,TRUE,Royal Society of Chemistry (RSC),Soft Matter,1744-683X,1744-683X,1744-6848,NA,NA,TRUE,27112965,NA,NA,NA,FALSE
-gu,2016,1490.9,10.3390/ijerph13080836,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,NA,NA,TRUE,27556476,PMC4997522,NA,NA,TRUE
-gu,2016,1503,10.1186/s13195-016-0208-8,FALSE,Springer,Alzheimer's Research & Therapy,1758-9193,NA,1758-9193,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1503.8,10.1186/s13601-016-0112-0,FALSE,Springer,Clinical and Translational Allergy,2045-7022,NA,2045-7022,NA,NA,TRUE,27493721,PMC4973051,NA,NA,TRUE
-gu,2016,1524.4,10.1098/rstb.2015.0225,TRUE,The Royal Society,Philosophical Transactions of the Royal Society B: Biological Sciences,0962-8436,0962-8436,1471-2970,NA,NA,TRUE,26977065,PMC4810818,NA,NA,FALSE
-gu,2016,1528.4,10.1186/s40164-016-0047-0,FALSE,Springer,Experimental Hematology & Oncology,2162-3619,NA,2162-3619,NA,NA,TRUE,27366593,PMC4928343,NA,NA,TRUE
-gu,2016,1528.4,10.1186/s40164-016-0053-2,FALSE,Springer,Experimental Hematology & Oncology,2162-3619,NA,2162-3619,NA,NA,TRUE,27525194,PMC4982317,NA,NA,TRUE
-gu,2016,1530,10.1002/ece3.2096,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27127613,PMC4842207,NA,NA,TRUE
-gu,2016,1560,10.1093/sysbio/syw064,TRUE,Oxford University Press (OUP),Systematic Biology,1063-5157,1063-5157,1076-836X,NA,NA,TRUE,27486181,NA,NA,NA,FALSE
-gu,2016,1560,10.1093/sysbio/syw066,TRUE,Oxford University Press (OUP),Systematic Biology,1063-5157,1063-5157,1076-836X,NA,NA,TRUE,27616324,NA,NA,NA,FALSE
-gu,2016,1578.5,10.1186/s12884-016-1144-0,FALSE,Springer,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,NA,http://www.springer.com/tdm,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1594.3,10.1186/s13148-016-0274-6,FALSE,Springer,Clinical Epigenetics,1868-7075,1868-7075,1868-7083,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1597.3,10.1186/s13643-016-0344-z,FALSE,Springer,Systematic Reviews,2046-4053,NA,2046-4053,NA,http://www.springer.com/tdm,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1621.3,10.1155/2016/5482087,FALSE,Hindawi Publishing Corporation,Journal of Immunology Research,2314-8861,2314-8861,2314-7156,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28127567,PMC5227169,NA,NA,TRUE
-gu,2016,1643.3,10.1186/s12909-016-0749-3,FALSE,Springer,BMC Medical Education,1472-6920,NA,1472-6920,NA,http://www.springer.com/tdm,TRUE,27565878,PMC5002212,NA,NA,TRUE
-gu,2016,1643.3,10.1186/s12913-016-1710-1,FALSE,Springer,BMC Health Services Research,1472-6963,NA,1472-6963,NA,http://www.springer.com/tdm,TRUE,27576359,PMC5006424,NA,NA,TRUE
-gu,2016,1646.2,10.1186/s12868-015-0221-z,FALSE,Springer,BMC Neuroscience,1471-2202,NA,1471-2202,NA,NA,TRUE,26608570,PMC4660658,NA,NA,TRUE
-gu,2016,1686.6,10.1186/s12891-016-0947-5,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,NA,NA,TRUE,26932181,PMC4774121,NA,NA,TRUE
-gu,2016,1692,10.1186/s40168-016-0199-5,FALSE,Springer,Microbiome,2049-2618,NA,2049-2618,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1701.3,10.1080/00219266.2016.1233130,TRUE,Taylor & Francis,Journal of Biological Education,0021-9266,0021-9266,2157-6009,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,1705,10.1161/JAHA.115.003071,FALSE,Wolters Kluwer,Journal of the American Heart Association,2047-9980,2047-9980,2047-9980,NA,NA,TRUE,26908411,PMC4802444,NA,NA,TRUE
-gu,2016,1710,10.5194/hess-20-3719-2016,FALSE,Copernicus Publications,Hydrology and Earth System Sciences,1607-7938,NA,1607-7938,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1740.45,10.1016/j.vaccine.2016.04.055,TRUE,Elsevier,Vaccine,0264-410X,0264-410X,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27133878,NA,NA,NA,FALSE
-gu,2016,1743,10.1186/s12884-016-0836-9,FALSE,Springer,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,NA,NA,TRUE,26951777,PMC4782290,NA,NA,TRUE
-gu,2016,1743,10.1186/s13102-016-0054-9,FALSE,Springer,"BMC Sports Science, Medicine and Rehabilitation",2052-1847,NA,2052-1847,NA,NA,TRUE,27602228,PMC5011845,NA,NA,TRUE
-gu,2016,1743,10.1186/s40842-016-0026-8,FALSE,Springer,Clinical Diabetes and Endocrinology,2055-8260,NA,2055-8260,NA,NA,TRUE,28702241,PMC5471721,NA,NA,TRUE
-gu,2016,1756.8,10.1186/s12859-016-1134-2,FALSE,Springer,BMC Bioinformatics,1471-2105,NA,1471-2105,NA,NA,TRUE,27334112,PMC4917999,NA,NA,TRUE
-gu,2016,1756.8,10.1186/s12863-016-0382-5,FALSE,Springer,BMC Genetics,1471-2156,NA,1471-2156,NA,NA,TRUE,27245440,PMC4886457,NA,NA,TRUE
-gu,2016,1782.4,10.1186/s13075-016-1141-8,FALSE,Springer,Arthritis Research & Therapy,1478-6362,NA,1478-6362,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,1784.3,10.3402/ecrj.v3.30319,FALSE,Taylor & Francis,European Clinical Respiratory Journal,2001-8525,NA,2001-8525,NA,NA,TRUE,27421832,PMC4947195,NA,NA,TRUE
-gu,2016,1788,10.3389/fimmu.2016.00001,FALSE,Frontiers,Frontiers in Immunology,1664-3224,NA,1664-3224,NA,NA,TRUE,26834743,PMC4717187,NA,NA,TRUE
-gu,2016,1788,10.3389/fnbeh.2016.00041,FALSE,Frontiers,Frontiers in Behavioral Neuroscience,1662-5153,NA,1662-5153,NA,NA,TRUE,27014003,PMC4792870,NA,NA,TRUE
-gu,2016,1788,10.3389/fncel.2016.00054,FALSE,Frontiers,Frontiers in Cellular Neuroscience,1662-5102,NA,1662-5102,NA,NA,TRUE,26973467,PMC4777716,NA,NA,TRUE
-gu,2016,1788,10.3389/fpsyg.2016.01012,FALSE,Frontiers,Frontiers in Psychology,1664-1078,NA,1664-1078,NA,NA,TRUE,27445957,PMC4927566,NA,NA,TRUE
-gu,2016,1801,10.1186/s13054-015-1181-5,FALSE,Springer,Critical Care,1364-8535,NA,1364-8535,NA,NA,TRUE,26781032,PMC4717610,NA,NA,TRUE
-gu,2016,1801,10.1186/s13075-016-0917-1,FALSE,Springer,Arthritis Research & Therapy,1478-6362,NA,1478-6362,NA,NA,TRUE,26785608,PMC4718040,NA,NA,FALSE
-gu,2016,1847,10.1111/eva.12335,FALSE,Wiley,Evolutionary Applications,1752-4571,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1893,10.1186/s13075-016-1062-6,FALSE,Springer,Arthritis Research & Therapy,1478-6362,NA,1478-6362,NA,NA,TRUE,27412614,PMC4944470,NA,NA,FALSE
-gu,2016,1893,10.1186/s13075-016-1073-3,FALSE,Springer,Arthritis Research & Therapy,1478-6362,NA,1478-6362,NA,NA,TRUE,27473164,PMC4967304,NA,NA,FALSE
-gu,2016,1927.88,10.1016/j.chiabu.2016.06.001,TRUE,Elsevier,Child Abuse & Neglect,0145-2134,0145-2134,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27286134,NA,NA,NA,FALSE
-gu,2016,1927.88,10.1016/j.worlddev.2016.03.006,TRUE,Elsevier,World Development,0305-750X,0305-750X,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,1982,10.1038/ncomms11050,FALSE,Springer,Nature Communications,2041-1723,NA,2041-1723,NA,NA,TRUE,26996674,PMC4802176,NA,NA,TRUE
-gu,2016,2025,10.1371/journal.pgen.1006000,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27171399,PMC4865040,NA,NA,TRUE
-gu,2016,2025,10.1371/journal.pntd.0004312,FALSE,Public Library of Science (PLoS),PLOS Neglected Tropical Diseases,1935-2735,NA,1935-2735,NA,https://creativecommons.org/publicdomain/zero/1.0/,TRUE,26820516,PMC4731218,NA,NA,TRUE
-gu,2016,2083,10.1111/evo.12957,TRUE,Wiley,Evolution,0014-3820,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27196373,PMC5089645,NA,NA,FALSE
-gu,2016,2130,10.1016/j.neurobiolaging.2015.11.010,TRUE,Elsevier,Neurobiology of Aging,0197-4580,0197-4580,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26827644,PMC5125016,NA,NA,FALSE
-gu,2016,2130,10.1093/nar/gkw302,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,NA,NA,TRUE,27112570,PMC4937320,NA,NA,TRUE
-gu,2016,2130,10.1093/nar/gkw468,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,NA,NA,TRUE,27220468,PMC4937333,NA,NA,TRUE
-gu,2016,2130,10.1093/nar/gkw674,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,2140.89,10.1371/journal.pgen.1005982,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27082444,PMC4833288,NA,NA,TRUE
-gu,2016,2150,10.1080/00141844.2016.1213760,TRUE,Taylor & Francis,Ethnos,0014-1844,0014-1844,1469-588X,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2150,10.1080/14623943.2016.1178633,TRUE,Taylor & Francis,Reflective Practice,1462-3943,1462-3943,1470-1103,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2150,10.1080/17550874.2016.1264017,TRUE,Taylor & Francis,Plant Ecology & Diversity,1755-0874,1755-0874,1755-1668,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s00125-016-4171-5,TRUE,Springer,Diabetologia,0012-186X,0012-186X,1432-0428,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27981357,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s00167-016-4280-1,TRUE,Springer,"Knee Surgery, Sports Traumatology, Arthroscopy",0942-2056,0942-2056,1433-7347,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s00167-016-4387-4,TRUE,Springer,"Knee Surgery, Sports Traumatology, Arthroscopy",0942-2056,0942-2056,1433-7347,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s00167-016-4399-0,TRUE,Springer,"Knee Surgery, Sports Traumatology, Arthroscopy",0942-2056,0942-2056,1433-7347,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s00191-016-0478-0,TRUE,Springer,Journal of Evolutionary Economics,0936-9937,0936-9937,1432-1386,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28163393,PMC5253718,NA,NA,FALSE
-gu,2016,2200,10.1007/s00198-016-3738-9,TRUE,Springer,Osteoporosis International,0937-941X,0937-941X,1433-2965,NA,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27585578,PMC5206252,NA,NA,FALSE
-gu,2016,2200,10.1007/s00198-016-3846-6,TRUE,Springer,Osteoporosis International,0937-941X,0937-941X,1433-2965,NA,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27921145,PMC5306148,NA,NA,FALSE
-gu,2016,2200,10.1007/s00216-016-9812-5,TRUE,Springer,Analytical and Bioanalytical Chemistry,1618-2642,1618-2642,1618-2650,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27549796,PMC5012256,NA,NA,FALSE
-gu,2016,2200,10.1007/s00227-016-2984-x,TRUE,Springer,Marine Biology,0025-3162,0025-3162,1432-1793,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27729710,PMC5030223,NA,NA,FALSE
-gu,2016,2200,10.1007/s00265-016-2215-y,TRUE,Springer,Behavioral Ecology and Sociobiology,0340-5443,0340-5443,1432-0762,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27881895,PMC5102978,NA,NA,FALSE
-gu,2016,2200,10.1007/s00266-016-0684-z,TRUE,Springer,Aesthetic Plastic Surgery,0364-216X,0364-216X,1432-5241,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27495261,PMC5030227,NA,NA,FALSE
-gu,2016,2200,10.1007/s00267-016-0786-z,TRUE,Springer,Environmental Management,0364-152X,0364-152X,1432-1009,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27838769,PMC5274640,NA,NA,FALSE
-gu,2016,2200,10.1007/s00268-016-3632-9,TRUE,Springer,World Journal of Surgery,0364-2313,0364-2313,1432-2323,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27417107,PMC5104810,NA,NA,FALSE
-gu,2016,2200,10.1007/s00382-016-3426-7,TRUE,Springer,Climate Dynamics,0930-7575,0930-7575,1432-0894,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s00382-016-3452-5,TRUE,Springer,Climate Dynamics,0930-7575,0930-7575,1432-0894,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s00384-016-2628-0,TRUE,Springer,International Journal of Colorectal Disease,0179-1958,0179-1958,1432-1262,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27506432,PMC5031731,NA,NA,FALSE
-gu,2016,2200,10.1007/s00384-016-2636-0,TRUE,Springer,International Journal of Colorectal Disease,0179-1958,0179-1958,1432-1262,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27567926,PMC5285409,NA,NA,FALSE
-gu,2016,2200,10.1007/s00408-016-9937-5,TRUE,Springer,Lung,0341-2040,0341-2040,1432-1750,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27638152,PMC5093197,NA,NA,FALSE
-gu,2016,2200,10.1007/s00420-016-1163-1,TRUE,Springer,International Archives of Occupational and Environmental Health,0340-0131,0340-0131,1432-1246,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s00420-016-1180-0,TRUE,Springer,International Archives of Occupational and Environmental Health,0340-0131,0340-0131,1432-1246,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27815725,PMC5263194,NA,NA,FALSE
-gu,2016,2200,10.1007/s00464-016-5096-2,TRUE,Springer,Surgical Endoscopy,0930-2794,0930-2794,1432-2218,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27422249,PMC5315718,NA,NA,FALSE
-gu,2016,2200,10.1007/s00701-016-3040-9,TRUE,Springer,Acta Neurochirurgica,0001-6268,0001-6268,0942-0940,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27928631,PMC5241331,NA,NA,FALSE
-gu,2016,2200,10.1007/s10096-016-2854-y,TRUE,Springer,European Journal of Clinical Microbiology & Infectious Diseases,0934-9723,0934-9723,1435-4373,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27924435,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s10113-015-0895-x,TRUE,Springer,Regional Environmental Change,1436-3798,1436-3798,1436-378X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s10308-016-0464-z,TRUE,Springer,Asia Europe Journal,1610-2932,1610-2932,1612-1031,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s10439-016-1776-2,TRUE,Springer,Annals of Biomedical Engineering,0090-6964,0090-6964,1573-9686,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s10545-016-9978-1,TRUE,Springer,Journal of Inherited Metabolic Disease,0141-8955,0141-8955,1573-2665,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27718144,PMC5203857,NA,NA,FALSE
-gu,2016,2200,10.1007/s10639-016-9546-1,TRUE,Springer,Education and Information Technologies,1360-2357,1360-2357,1573-7608,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s10641-016-0550-5,TRUE,Springer,Environmental Biology of Fishes,0378-1909,0378-1909,1573-5133,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s10689-016-9934-0,TRUE,Springer,Familial Cancer,1389-9600,1389-9600,1573-7292,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27696107,PMC5357488,NA,NA,FALSE
-gu,2016,2200,10.1007/s10763-016-9781-3,TRUE,Springer,International Journal of Science and Mathematics Education,1571-0068,1571-0068,1573-1774,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s10767-016-9241-7,TRUE,Springer,"International Journal of Politics, Culture, and Society",0891-4486,0891-4486,1573-3416,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s10822-016-9926-z,TRUE,Springer,Journal of Computer-Aided Molecular Design,0920-654X,0920-654X,1573-4951,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27460060,PMC5206257,NA,NA,FALSE
-gu,2016,2200,10.1007/s10856-016-5779-1,TRUE,Springer,Journal of Materials Science: Materials in Medicine,0957-4530,0957-4530,1573-4838,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s10856-016-5814-2,TRUE,Springer,Journal of Materials Science: Materials in Medicine,0957-4530,0957-4530,1573-4838,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s10955-016-1607-8,TRUE,Springer,Journal of Statistical Physics,0022-4715,0022-4715,1572-9613,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s10995-016-2199-2,TRUE,Springer,Maternal and Child Health Journal,1092-7875,1092-7875,1573-6628,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28032239,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s11017-016-9393-5,TRUE,Springer,Theoretical Medicine and Bioethics,1386-7415,1386-7415,1573-1200,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28040857,PMC5325837,NA,NA,FALSE
-gu,2016,2200,10.1007/s11060-016-2202-1,TRUE,Springer,Journal of Neuro-Oncology,0167-594X,0167-594X,1573-7373,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27423645,PMC5020107,NA,NA,FALSE
-gu,2016,2200,10.1007/s11102-016-0764-8,TRUE,Springer,Pituitary,1386-341X,1386-341X,1573-7403,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27743172,PMC5357499,NA,NA,FALSE
-gu,2016,2200,10.1007/s11118-016-9590-x,TRUE,Springer,Potential Analysis,0926-2601,0926-2601,1572-929X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s11229-016-1217-7,TRUE,Springer,Synthese,0039-7857,0039-7857,1573-0964,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s11252-016-0581-x,TRUE,Springer,Urban Ecosystems,1083-8155,1083-8155,1573-1642,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s11883-016-0614-1,TRUE,Springer,Current Atherosclerosis Reports,1523-3804,1523-3804,1534-6242,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27613744,PMC5018018,NA,NA,FALSE
-gu,2016,2200,10.1007/s11896-016-9206-9,TRUE,Springer,Journal of Police and Criminal Psychology,0882-0783,0882-0783,1936-6469,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s12187-016-9416-9,TRUE,Springer,Child Indicators Research,1874-897X,1874-897X,1874-8988,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s12526-016-0566-2,TRUE,Springer,Marine Biodiversity,1867-1616,1867-1616,1867-1624,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s13280-016-0848-8,TRUE,Springer,Ambio,0044-7447,0044-7447,1654-7209,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27844420,PMC5347527,NA,NA,FALSE
-gu,2016,2200,10.1007/s13361-016-1539-1,TRUE,Springer,Journal of The American Society for Mass Spectrometry,1044-0305,1044-0305,1879-1123,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27873218,PMC5227003,NA,NA,FALSE
-gu,2016,2200,10.1007/s13365-016-0500-1,TRUE,Springer,Journal of NeuroVirology,1355-0284,1355-0284,1538-2443,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27913959,PMC5332498,NA,NA,FALSE
-gu,2016,2200,10.1007/s13437-016-0114-8,TRUE,Springer,WMU Journal of Maritime Affairs,1651-436X,1651-436X,1654-1642,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s40141-016-0128-3,TRUE,Springer,Current Physical Medicine and Rehabilitation Reports,2167-4833,NA,2167-4833,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2200,10.1007/s40368-016-0256-6,TRUE,Springer,European Archives of Paediatric Dentistry,1818-6300,1818-6300,1996-9805,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27830462,PMC5126186,NA,NA,FALSE
-gu,2016,2224.1,10.1186/s13075-016-1037-7,FALSE,Springer,Arthritis Research & Therapy,1478-6362,NA,1478-6362,NA,NA,TRUE,27301320,PMC4908726,NA,NA,FALSE
-gu,2016,223,10.1016/j.dib.2015.12.003,FALSE,Elsevier,Data in Brief,2352-3409,2352-3409,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26862586,PMC4707292,NA,NA,TRUE
-gu,2016,2231.35,10.1016/j.ijrobp.2016.05.007,TRUE,Elsevier,International Journal of Radiation Oncology*Biology*Physics,0360-3016,0360-3016,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27475671,NA,NA,NA,FALSE
-gu,2016,2231.35,10.1016/j.jacl.2016.02.015,TRUE,Elsevier,Journal of Clinical Lipidology,1933-2874,1933-2874,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27578112,NA,NA,NA,FALSE
-gu,2016,2250,10.1093/molbev/msw066,TRUE,Oxford University Press (OUP),Molecular Biology and Evolution,0737-4038,0737-4038,1537-1719,NA,NA,TRUE,27189557,PMC4948705,NA,NA,FALSE
-gu,2016,2275,10.1093/rheumatology/kew192,TRUE,Oxford University Press (OUP),Rheumatology,1462-0324,1462-0324,1462-0332,NA,NA,TRUE,27121779,PMC4957673,NA,NA,FALSE
-gu,2016,2275,10.1093/rpd/ncw041,TRUE,Oxford University Press (OUP),Radiation Protection Dosimetry,0144-8420,0144-8420,1742-3406,NA,NA,TRUE,26994093,PMC4911967,NA,NA,FALSE
-gu,2016,2275,10.1093/rpd/ncw046,TRUE,Oxford University Press (OUP),Radiation Protection Dosimetry,0144-8420,0144-8420,1742-3406,NA,NA,TRUE,27012883,PMC4911968,NA,NA,FALSE
-gu,2016,2320.6,10.1016/j.bbr.2016.04.015,TRUE,Elsevier,Behavioural Brain Research,0166-4328,0166-4328,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27083304,NA,NA,NA,FALSE
-gu,2016,2343,10.3389/fnagi.2016.00225,FALSE,Frontiers,Frontiers in Aging Neuroscience,1663-4365,NA,1663-4365,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,2343,10.3389/fnbeh.2016.00178,FALSE,Frontiers,Frontiers in Behavioral Neuroscience,1662-5153,NA,1662-5153,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,2343,10.3389/fpls.2016.01051,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,NA,NA,TRUE,27489553,PMC4951524,NA,NA,TRUE
-gu,2016,2343,10.3389/fpsyg.2016.01808,FALSE,Frontiers,Frontiers in Psychology,1664-1078,NA,1664-1078,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,2345.1,10.1016/j.jelechem.2016.11.011,TRUE,Elsevier,Journal of Electroanalytical Chemistry,1572-6657,1572-6657,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2345.1,10.1016/j.neuropharm.2016.07.039,TRUE,Elsevier,Neuropharmacology,0028-3908,0028-3908,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27496691,NA,NA,NA,FALSE
-gu,2016,2345.1,10.1016/j.yhbeh.2016.07.008,TRUE,Elsevier,Hormones and Behavior,0018-506X,0018-506X,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27487416,NA,NA,NA,FALSE
-gu,2016,2368.66,10.1002/pro.3046,TRUE,Wiley,Protein Science,0961-8368,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27643892,PMC5119558,NA,NA,FALSE
-gu,2016,2450,10.1093/hmg/ddw341,TRUE,Oxford University Press (OUP),Human Molecular Genetics,0964-6906,0964-6906,1460-2083,NA,NA,TRUE,27742777,NA,NA,NA,FALSE
-gu,2016,2454.48,10.1016/j.psyneuen.2015.11.021,TRUE,Elsevier,Psychoneuroendocrinology,0306-4530,0306-4530,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26724568,NA,NA,NA,FALSE
-gu,2016,246.2,10.1080/23723556.2015.1124174,TRUE,Taylor & Francis,Molecular & Cellular Oncology,2372-3556,NA,2372-3556,NA,NA,TRUE,27308621,PMC4905420,NA,NA,FALSE
-gu,2016,2550,10.1093/eurheartj/ehw221,TRUE,Oxford University Press (OUP),European Heart Journal,0195-668X,0195-668X,1522-9645,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2597,10.1093/nar/gkw224,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,NA,NA,TRUE,27060140,PMC4914102,NA,NA,TRUE
-gu,2016,2610,10.1371/journal.pmed.1002156,FALSE,Public Library of Science (PLoS),PLOS Medicine,1549-1676,NA,1549-1676,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27727282,PMC5058554,NA,NA,TRUE
-gu,2016,2627,10.1017/S0007123416000508,TRUE,Cambridge University Press (CUP),British Journal of Political Science,0007-1234,0007-1234,1469-2112,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2641,10.18632/oncotarget.8508,FALSE,Impact Journals,OncoTarget,1949-2553,NA,1949-2553,NA,NA,TRUE,27049722,PMC5045374,NA,NA,FALSE
-gu,2016,2705.88,10.1016/j.csr.2016.09.005,TRUE,Elsevier,Continental Shelf Research,0278-4343,0278-4343,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2750,10.1007/s00198-015-3445-y,TRUE,Springer,Osteoporosis International,0937-941X,0937-941X,1433-2965,NA,http://creativecommons.org/licenses/by-nc/4.0,TRUE,26659067,PMC4839051,NA,NA,FALSE
-gu,2016,2750,10.1007/s00198-016-3643-2,TRUE,Springer,Osteoporosis International,0937-941X,0937-941X,1433-2965,NA,http://creativecommons.org/licenses/by-nc/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2750,10.1007/s12678-016-0310-5,TRUE,Springer,Electrocatalysis,1868-2529,1868-2529,1868-5994,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2779,10.1002/2015JC011451,TRUE,Wiley,Journal of Geophysical Research: Oceans,2169-9275,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2779,10.1002/acr.22868,TRUE,Wiley,Arthritis Care & Research,2151-464X,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26881821,PMC5129496,NA,NA,FALSE
-gu,2016,2779,10.1002/jbmr.2743,TRUE,Wiley,Journal of Bone and Mineral Research,0884-0431,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26572678,PMC4832374,NA,NA,FALSE
-gu,2016,2779,10.1002/jbmr.3006,TRUE,Wiley,Journal of Bone and Mineral Research,0884-0431,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27676223,NA,NA,NA,FALSE
-gu,2016,2779,10.1111/1460-6984.12302,TRUE,Wiley,International Journal of Language & Communication Disorders,1368-2822,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28039933,NA,NA,NA,FALSE
-gu,2016,2779,10.1111/aogs.13054,TRUE,Wiley,Acta Obstetricia et Gynecologica Scandinavica,0001-6349,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27861716,NA,NA,NA,FALSE
-gu,2016,2779,10.1111/apa.13295,TRUE,Wiley,Acta Paediatrica,0803-5253,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26648201,PMC5066675,NA,NA,FALSE
-gu,2016,2779,10.1111/apa.13407,TRUE,Wiley,Acta Paediatrica,0803-5253,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26999007,PMC5074256,NA,NA,FALSE
-gu,2016,2779,10.1111/apa.13531,TRUE,Wiley,Acta Paediatrica,0803-5253,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27426283,PMC5095866,NA,NA,FALSE
-gu,2016,2779,10.1111/bcpt.12613,TRUE,Wiley,Basic & Clinical Pharmacology & Toxicology,1742-7835,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27112967,NA,NA,NA,FALSE
-gu,2016,2779,10.1111/hiv.12431,TRUE,Wiley,HIV Medicine,1464-2662,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27535540,PMC5347969,NA,NA,FALSE
-gu,2016,279.5,10.3390/jfb7010007,FALSE,MDPI,Journal of Functional Biomaterials,2079-4983,NA,2079-4983,NA,NA,TRUE,26999231,PMC4810066,NA,NA,TRUE
-gu,2016,2791,10.1002/ana.24677,TRUE,Wiley,Annals of Neurology,0364-5134,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27130143,PMC5084793,NA,NA,FALSE
-gu,2016,2791,10.1002/jbmr.2509,TRUE,Wiley,Journal of Bone and Mineral Research,0884-0431,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25777580,NA,NA,NA,FALSE
-gu,2016,2791,10.1111/adb.12355,TRUE,Wiley,Addiction Biology,1355-6215,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26769653,NA,NA,NA,FALSE
-gu,2016,2791,10.1111/apa.13350,TRUE,Wiley,Acta Paediatrica,0803-5253,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26833743,PMC5069563,NA,NA,FALSE
-gu,2016,2791,10.1111/azo.12164,TRUE,Wiley,Acta Zoologica,0001-7272,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2796.08,10.1016/j.jcis.2016.09.005,TRUE,Elsevier,Journal of Colloid and Interface Science,0021-9797,0021-9797,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27619384,NA,NA,NA,FALSE
-gu,2016,2800,10.1038/tp.2016.104,FALSE,Springer,Translational Psychiatry,2158-3188,NA,2158-3188,NA,NA,TRUE,27271860,PMC4931602,NA,NA,TRUE
-gu,2016,2800,10.1038/tp.2016.12,FALSE,Springer,Translational Psychiatry,2158-3188,NA,2158-3188,NA,NA,TRUE,27003188,PMC4872438,NA,NA,TRUE
-gu,2016,2842.39,10.1002/dys.1545,TRUE,Wiley,Dyslexia,1076-9242,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27892641,NA,NA,NA,FALSE
-gu,2016,2851,10.1177/0010414015626445,TRUE,SAGE Publications,Comparative Political Studies,0010-4140,0010-4140,1552-3829,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,2900,10.1038/npp.2016.118,TRUE,Springer,Neuropsychopharmacology,0893-133X,0893-133X,1740-634X,NA,NA,TRUE,27388328,PMC5101553,NA,NA,FALSE
-gu,2016,2976.47,10.1016/j.ijcard.2016.06.037,TRUE,Elsevier,International Journal of Cardiology,0167-5273,0167-5273,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27376234,NA,NA,NA,FALSE
-gu,2016,2976.47,10.1016/j.ijcard.2016.07.060,TRUE,Elsevier,International Journal of Cardiology,0167-5273,0167-5273,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27441475,NA,NA,NA,FALSE
-gu,2016,3123.89,10.1016/j.biomaterials.2016.01.034,TRUE,Elsevier,Biomaterials,0142-9612,0142-9612,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26828682,NA,NA,NA,FALSE
-gu,2016,3201.96,10.1016/j.bbadis.2016.11.033,TRUE,Elsevier,Biochimica et Biophysica Acta (BBA) - Molecular Basis of Disease,0925-4439,0925-4439,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27915033,NA,NA,NA,FALSE
-gu,2016,3242,10.1002/jbm.a.35935,TRUE,Wiley,Journal of Biomedical Materials Research Part A,1549-3296,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27750392,PMC5216444,NA,NA,FALSE
-gu,2016,3256,10.1002/2015JC011112,TRUE,Wiley,Journal of Geophysical Research: Oceans,2169-9275,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,3256,10.1111/1462-2920.13557,TRUE,Wiley,Environmental Microbiology,1462-2912,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27696654,NA,NA,NA,FALSE
-gu,2016,3300,10.1038/npjpcrm.2015.82,FALSE,Springer,npj Primary Care Respiratory Medicine,2055-1010,NA,2055-1010,NA,http://www.springer.com/tdm,TRUE,26845513,PMC4741287,NA,NA,TRUE
-gu,2016,3355.3,10.1016/j.apergo.2016.06.012,TRUE,Elsevier,Applied Ergonomics,0003-6870,0003-6870,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27633215,NA,NA,NA,FALSE
-gu,2016,3427.45,10.1016/j.rse.2016.11.013,TRUE,Elsevier,Remote Sensing of Environment,0034-4257,0034-4257,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,3464.6,10.1136/bmj.i4070,FALSE,BMJ,BMJ,1756-1833,NA,1756-1833,NA,http://www.bmj.org/licenses/tdm/1.0/terms-and-conditions.html,TRUE,27492939,PMC4975020,NA,NA,FALSE
-gu,2016,3474,10.1002/bjs.10230,TRUE,Wiley,British Journal of Surgery,0007-1323,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27548306,PMC5095815,NA,NA,FALSE
-gu,2016,3474,10.1002/jbmr.3002,TRUE,Wiley,Journal of Bone and Mineral Research,0884-0431,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27664946,NA,NA,NA,FALSE
-gu,2016,3474,10.1111/apa.13515,TRUE,Wiley,Acta Paediatrica,0803-5253,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27381249,PMC5129460,NA,NA,FALSE
-gu,2016,3474,10.1111/jgs.14439,TRUE,Wiley,Journal of the American Geriatrics Society,0002-8614,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27689675,NA,NA,NA,FALSE
-gu,2016,3474,10.1111/joim.12514,TRUE,Wiley,Journal of Internal Medicine,0954-6820,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27196563,NA,NA,NA,FALSE
-gu,2016,3474,10.1111/joim.12572,TRUE,Wiley,Journal of Internal Medicine,0954-6820,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27925333,NA,NA,NA,FALSE
-gu,2016,3480.91,10.1016/j.cocis.2016.02.005,TRUE,Elsevier,Current Opinion in Colloid & Interface Science,1359-0294,1359-0294,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,354,10.1177/2333393615599168,FALSE,SAGE Publications,Global Qualitative Nursing Research,2333-3936,2333-3936,2333-3936,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,354,10.1177/2333393616630672,FALSE,SAGE Publications,Global Qualitative Nursing Research,2333-3936,NA,2333-3936,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,3571.76,10.1016/j.rmed.2016.10.005,TRUE,Elsevier,Respiratory Medicine,0954-6111,0954-6111,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27817808,NA,NA,NA,FALSE
-gu,2016,3700,10.1038/ncomms11161,FALSE,Springer,Nature Communications,2041-1723,NA,2041-1723,NA,NA,TRUE,27045731,PMC4822045,NA,NA,TRUE
-gu,2016,3700,10.1038/ncomms11447,FALSE,Springer,Nature Communications,2041-1723,NA,2041-1723,NA,NA,TRUE,27186890,PMC4873662,NA,NA,TRUE
-gu,2016,3700,10.1038/ncomms11654,FALSE,Springer,Nature Communications,2041-1723,NA,2041-1723,NA,NA,TRUE,27216227,PMC4890181,NA,NA,TRUE
-gu,2016,3700,10.1038/ncomms12689,FALSE,Springer,Nature Communications,2041-1723,NA,2041-1723,NA,NA,TRUE,27573539,PMC5013605,NA,NA,TRUE
-gu,2016,3706,10.1002/pds.4135,TRUE,Wiley,Pharmacoepidemiology and Drug Safety,1053-8569,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27859947,PMC5248645,NA,NA,FALSE
-gu,2016,400,10.1080/02813432.2016.1248628,FALSE,Taylor & Francis,Scandinavian Journal of Primary Health Care,0281-3432,0281-3432,1502-7724,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,400,10.1080/02813432.2016.1248635,FALSE,Taylor & Francis,Scandinavian Journal of Primary Health Care,0281-3432,0281-3432,1502-7724,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,4053,10.1111/cea.12757,TRUE,Wiley,Clinical & Experimental Allergy,0954-7894,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27159904,NA,NA,NA,FALSE
-gu,2016,4440,10.1038/ncomms12698,FALSE,Springer,Nature Communications,2041-1723,NA,2041-1723,NA,NA,TRUE,27596266,PMC5025876,NA,NA,TRUE
-gu,2016,446.27,10.1016/j.dib.2016.05.065,FALSE,Elsevier,Data in Brief,2352-3409,2352-3409,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27366778,PMC4910300,NA,NA,TRUE
-gu,2016,4462.7,10.1016/j.cmet.2016.05.001,TRUE,Elsevier,Cell Metabolism,1550-4131,1550-4131,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27304513,PMC4911343,NA,NA,FALSE
-gu,2016,521.5,10.1177/2058460116686392,FALSE,SAGE Publications,Acta Radiologica Open,2058-4601,2058-4601,2058-4601,NA,NA,TRUE,28286672,PMC5330413,NA,NA,TRUE
-gu,2016,541.18,10.1016/j.amper.2016.10.001,FALSE,Elsevier,Ampersand,2215-0390,2215-0390,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,580,10.1080/02673843.2015.1137777,FALSE,Taylor & Francis,International Journal of Adolescence and Youth,0267-3843,0267-3843,2164-4527,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,697,10.1080/2162402X.2015.1091147,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,NA,NA,TRUE,27141351,PMC4839365,NA,NA,FALSE
-gu,2016,713.63,10.1080/15548627.2015.1132134,TRUE,Taylor & Francis,Autophagy,1554-8627,1554-8627,1554-8635,NA,NA,TRUE,26727396,PMC4835980,NA,NA,FALSE
-gu,2016,713.63,10.1080/15592294.2016.1138195,TRUE,Taylor & Francis,Epigenetics,1559-2294,1559-2294,1559-2308,NA,NA,TRUE,26786290,PMC4846113,NA,NA,FALSE
-gu,2016,730,10.1080/15476286.2016.1249092,TRUE,Taylor & Francis,RNA Biology,1547-6286,1547-6286,1555-8584,NA,NA,TRUE,27791479,PMC5270547,NA,NA,FALSE
-gu,2016,746.93,10.1080/21624054.2016.1206171,TRUE,Taylor & Francis,Worm,2162-4054,NA,2162-4054,NA,NA,TRUE,27695656,PMC5022664,NA,NA,FALSE
-gu,2016,752,10.1186/s40064-016-2015-x,FALSE,Springer,SpringerPlus,2193-1801,NA,2193-1801,NA,NA,TRUE,27066384,PMC4811841,NA,NA,FALSE
-gu,2016,931.3,10.1177/2325967116667920,FALSE,SAGE Publications,Orthopaedic Journal of Sports Medicine,2325-9671,2325-9671,2325-9671,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,931.3,10.1177/2325967116669708,FALSE,SAGE Publications,Orthopaedic Journal of Sports Medicine,2325-9671,2325-9671,2325-9671,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,932,10.1038/srep28490,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,27329824,PMC4916408,NA,NA,TRUE
-gu,2016,947,10.1002/2015WR018375,TRUE,Wiley,Water Resources Research,0043-1397,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,960,10.1093/jhps/hnw023,FALSE,Oxford University Press (OUP),Journal of Hip Preservation Surgery,2054-8397,NA,2054-8397,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,981.79,10.1016/j.giq.2016.01.010,TRUE,Elsevier,Government Information Quarterly,0740-624X,0740-624X,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-gu,2017,1345.5,10.1371/journal.pone.0169759,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28061507,PMC5218734,NA,NA,TRUE
-gu,2017,1345.5,10.1371/journal.pone.0170613,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28125727,PMC5268365,NA,NA,TRUE
-gu,2017,1345.5,10.1371/journal.pone.0170754,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28129352,PMC5271333,NA,NA,TRUE
-gu,2017,1345.5,10.1371/journal.pone.0171222,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28152087,PMC5289588,NA,NA,TRUE
-gu,2017,1345.5,10.1371/journal.pone.0171461,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28158314,PMC5291512,NA,NA,TRUE
-gu,2017,1345.5,10.1371/journal.pone.0171797,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28222107,PMC5319760,NA,NA,TRUE
-gu,2017,1345.5,10.1371/journal.pone.0172896,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28249018,PMC5332093,NA,NA,TRUE
-gu,2017,1345.5,10.1371/journal.pone.0173463,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28273158,PMC5342245,NA,NA,TRUE
-gu,2017,1345.5,10.1371/journal.pone.0173492,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28264025,PMC5338833,NA,NA,TRUE
-gu,2017,1345.5,10.1371/journal.pone.0173654,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28288176,PMC5348013,NA,NA,TRUE
-gu,2017,2025,10.1371/journal.pgen.1006628,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28207748,PMC5336301,NA,NA,TRUE
-gu,2017,2343,10.3389/fimmu.2016.00640,FALSE,Frontiers,Frontiers in Immunology,1664-3224,NA,1664-3224,NA,NA,TRUE,28082979,PMC5183738,NA,NA,TRUE
-gu,2017,2343,10.3389/fncel.2016.00286,FALSE,Frontiers,Frontiers in Cellular Neuroscience,1662-5102,NA,1662-5102,NA,NA,TRUE,28018179,PMC5156678,NA,NA,TRUE
-gu,2017,2500,10.1111/joim.12587,TRUE,Wiley,Journal of Internal Medicine,0954-6820,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28097725,NA,NA,NA,FALSE
-hb,2016,2200,10.1007/s10615-016-0606-1,TRUE,Springer,Clinical Social Work Journal,0091-1674,0091-1674,1573-3343,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-hb,2016,2200,10.1007/s11192-016-2194-9,TRUE,Springer,Scientometrics,0138-9130,0138-9130,1588-2861,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28239206,PMC5306087,NA,NA,FALSE
-hhs,2016,2200,10.1007/s10683-016-9496-x,TRUE,Springer,Experimental Economics,1386-4157,1386-4157,1573-6938,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-hig,2016,2200,10.1007/s00421-016-3487-7,TRUE,Springer,European Journal of Applied Physiology,1439-6319,1439-6319,1439-6327,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-hig,2016,2200,10.1007/s10639-016-9536-3,TRUE,Springer,Education and Information Technologies,1360-2357,1360-2357,1573-7608,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-hig,2016,2200,10.1007/s10826-016-0534-2,TRUE,Springer,Journal of Child and Family Studies,1062-1024,1062-1024,1573-2843,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28111516,PMC5219017,NA,NA,FALSE
-hig,2016,2200,10.1007/s11042-016-3817-0,TRUE,Springer,Multimedia Tools and Applications,1380-7501,1380-7501,1573-7721,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-hig,2016,2200,10.1007/s11136-016-1373-8,TRUE,Springer,Quality of Life Research,0962-9343,0962-9343,1573-2649,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27506524,PMC5243911,NA,NA,FALSE
-hig,2016,2200,10.1007/s12063-016-0121-0,TRUE,Springer,Operations Management Research,1936-9735,1936-9735,1936-9743,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-his,2016,2200,10.1007/s00158-016-1569-0,TRUE,Springer,Structural and Multidisciplinary Optimization,1615-147X,1615-147X,1615-1488,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-his,2016,2200,10.1007/s10111-016-0399-6,TRUE,Springer,"Cognition, Technology & Work",1435-5558,1435-5558,1435-5566,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-his,2016,2200,10.1007/s11119-016-9491-4,TRUE,Springer,Precision Agriculture,1385-2256,1385-2256,1573-1618,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-hk,2016,2200,10.1007/s00244-016-0303-7,TRUE,Springer,Archives of Environmental Contamination and Toxicology,0090-4341,0090-4341,1432-0703,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27480162,PMC5014903,NA,NA,FALSE
-hk,2016,2200,10.1007/s11115-016-0368-9,TRUE,Springer,Public Organization Review,1566-7170,1566-7170,1573-7098,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kau,2016,2200,10.1007/s10346-016-0775-6,TRUE,Springer,Landslides,1612-510X,1612-510X,1612-5118,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kau,2016,2200,10.1007/s10955-016-1624-7,TRUE,Springer,Journal of Statistical Physics,0022-4715,0022-4715,1572-9613,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kau,2016,2200,10.1007/s11195-016-9459-3,TRUE,Springer,Sexuality and Disability,0146-1044,0146-1044,1573-6717,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27881887,PMC5102943,NA,NA,FALSE
-kau,2016,2200,10.1007/s13132-016-0411-7,TRUE,Springer,Journal of the Knowledge Economy,1868-7865,1868-7865,1868-7873,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2012,2630,10.1080/09297049.2012.727792,TRUE,Taylor & Francis,Child Neuropsychology,0929-7049,0929-7049,1744-4136,NA,NA,TRUE,23075095,PMC3827673,NA,NA,FALSE
-ki,2013,2429,10.1080/13554794.2013.791861,TRUE,Taylor & Francis,Neurocase,1355-4794,1355-4794,1465-3656,NA,NA,TRUE,23682688,PMC3998094,NA,NA,FALSE
-ki,2014,2429,10.1080/87565641.2014.886691,TRUE,Taylor & Francis,Developmental Neuropsychology,8756-5641,8756-5641,1532-6942,NA,NA,TRUE,24742310,PMC4017272,NA,NA,FALSE
-ki,2014,3040,10.3109/09638288.2014.998780,TRUE,Taylor & Francis,Disability and Rehabilitation,0963-8288,0963-8288,1464-5165,NA,NA,TRUE,25572319,PMC4720053,NA,NA,FALSE
-ki,2014,702,10.4161/15592294.2014.982445,TRUE,Taylor & Francis,Epigenetics,1559-2294,1559-2294,1559-2308,NA,NA,TRUE,25484259,PMC4622000,NA,NA,FALSE
-ki,2014,755,10.1159/000360415,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,NA,NA,TRUE,24847345,PMC4024511,NA,NA,TRUE
-ki,2014,755,10.1159/000363500,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,NA,NA,TRUE,25298777,PMC4176467,NA,NA,TRUE
-ki,2014,755,10.1159/000365091,FALSE,Karger,Nephron Extra,1664-5529,NA,1664-5529,NA,NA,TRUE,25404935,PMC4202611,NA,NA,TRUE
-ki,2014,755,10.1159/000366270,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,NA,NA,TRUE,25538726,PMC4264484,NA,NA,TRUE
-ki,2014,935,10.4161/15384101.2014.964108,TRUE,Taylor & Francis,Cell Cycle,1538-4101,1538-4101,1551-4005,NA,NA,TRUE,25483075,PMC4612677,NA,NA,FALSE
-ki,2014,935,10.4161/15384101.2015.945831,TRUE,Taylor & Francis,Cell Cycle,1538-4101,1538-4101,1551-4005,NA,NA,TRUE,25486360,PMC4615111,NA,NA,FALSE
-ki,2015,0,10.3109/03009734.2015.1040529,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,25947550,PMC4816888,NA,NA,FALSE
-ki,2015,2132,10.1080/09297049.2015.1063595,TRUE,Taylor & Francis,Child Neuropsychology,0929-7049,0929-7049,1744-4136,NA,NA,TRUE,26212755,PMC5214099,NA,NA,FALSE
-ki,2015,2132,10.3109/08958378.2015.1115567,TRUE,Taylor & Francis,Inhalation Toxicology,0895-8378,0895-8378,1091-7691,NA,NA,TRUE,26635308,PMC4732413,NA,NA,FALSE
-ki,2015,3040,10.3109/10408444.2015.1092498,TRUE,Taylor & Francis,Critical Reviews in Toxicology,1040-8444,1040-8444,1547-6898,NA,NA,TRUE,26515429,PMC4819830,NA,NA,FALSE
-ki,2015,702,10.1080/15476286.2015.1110675,TRUE,Taylor & Francis,RNA Biology,1547-6286,1547-6286,1555-8584,NA,NA,TRUE,26669816,PMC4829308,NA,NA,FALSE
-ki,2015,702,10.1080/15548627.2015.1068489,TRUE,Taylor & Francis,Autophagy,1554-8627,1554-8627,1554-8635,NA,NA,TRUE,26259639,PMC4590675,NA,NA,FALSE
-ki,2015,702,10.1080/19491034.2015.1106675,TRUE,Taylor & Francis,Nucleus,1949-1034,1949-1034,1949-1042,NA,NA,TRUE,26734725,PMC4915514,NA,NA,FALSE
-ki,2015,702,10.1080/2162402X.2015.1052213,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,NA,NA,TRUE,26942060,PMC4760332,NA,NA,FALSE
-ki,2015,755,10.1159/000441942,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,NA,NA,TRUE,26955384,PMC4777933,NA,NA,TRUE
-ki,2016,0,10.1080/03009734.2016.1201553,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,0,10.1080/03009734.2016.1208310,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,0,10.1080/03009734.2016.1219432,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,0,10.1080/17453674.2016.1202013,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,NA,NA,TRUE,27331243,PMC5016913,NA,NA,TRUE
-ki,2016,0,10.3109/03009734.2016.1158756,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,27064303,PMC4967266,NA,NA,FALSE
-ki,2016,1473,10.1080/2162402X.2016.1232222,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,NA,NA,TRUE,28123870,PMC5214950,NA,NA,FALSE
-ki,2016,199,10.3109/23320885.2016.1153974,FALSE,Taylor & Francis,Case Reports in Plastic Surgery and Hand Surgery,2332-0885,NA,2332-0885,NA,NA,TRUE,27583262,PMC4996062,NA,NA,FALSE
-ki,2016,2074,10.1080/00016357.2016.1206211,TRUE,Taylor & Francis,Acta Odontologica Scandinavica,0001-6357,0001-6357,1502-3850,NA,NA,TRUE,27409593,PMC4960510,NA,NA,FALSE
-ki,2016,2074,10.1080/10400419.2017.1263507,TRUE,Taylor & Francis,Creativity Research Journal,1040-0419,1040-0419,1532-6934,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2132,10.3109/08039488.2016.1159331,TRUE,Taylor & Francis,Nordic Journal of Psychiatry,0803-9488,0803-9488,1502-4725,NA,NA,TRUE,27103375,PMC4926784,NA,NA,FALSE
-ki,2016,2132,10.3109/13561820.2016.1143457,TRUE,Taylor & Francis,Journal of Interprofessional Care,1356-1820,1356-1820,1469-9567,NA,NA,TRUE,27152534,PMC4898142,NA,NA,FALSE
-ki,2016,2132,10.3109/13561820.2016.1159184,TRUE,Taylor & Francis,Journal of Interprofessional Care,1356-1820,1356-1820,1469-9567,NA,NA,TRUE,27268309,PMC4926788,NA,NA,FALSE
-ki,2016,2200,10.1007/s00068-016-0730-1,TRUE,Springer,European Journal of Trauma and Emergency Surgery,1863-9933,1863-9933,1863-9941,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s00109-016-1486-0,TRUE,Springer,Journal of Molecular Medicine,0946-2716,0946-2716,1432-1440,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27858116,PMC5225196,NA,NA,FALSE
-ki,2016,2200,10.1007/s00125-016-4074-5,TRUE,Springer,Diabetologia,0012-186X,0012-186X,1432-0428,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27535281,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s00167-016-4234-7,TRUE,Springer,"Knee Surgery, Sports Traumatology, Arthroscopy",0942-2056,0942-2056,1433-7347,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s00167-016-4270-3,TRUE,Springer,"Knee Surgery, Sports Traumatology, Arthroscopy",0942-2056,0942-2056,1433-7347,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s00167-016-4394-5,TRUE,Springer,"Knee Surgery, Sports Traumatology, Arthroscopy",0942-2056,0942-2056,1433-7347,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28004174,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s00192-016-3119-0,TRUE,Springer,International Urogynecology Journal,0937-3462,0937-3462,1433-3023,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27530518,PMC5306059,NA,NA,FALSE
-ki,2016,2200,10.1007/s00198-016-3818-x,TRUE,Springer,Osteoporosis International,0937-941X,0937-941X,1433-2965,NA,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27844133,PMC5206249,NA,NA,FALSE
-ki,2016,2200,10.1007/s00204-016-1879-4,TRUE,Springer,Archives of Toxicology,0340-5761,0340-5761,1432-0738,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s00213-016-4506-4,TRUE,Springer,Psychopharmacology,0033-3158,0033-3158,1432-2072,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28013354,PMC5263201,NA,NA,FALSE
-ki,2016,2200,10.1007/s00223-016-0194-7,TRUE,Springer,Calcified Tissue International,0171-967X,0171-967X,1432-0827,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27671989,PMC5214955,NA,NA,FALSE
-ki,2016,2200,10.1007/s00228-016-2105-2,TRUE,Springer,European Journal of Clinical Pharmacology,0031-6970,0031-6970,1432-1041,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27484241,PMC5021730,NA,NA,FALSE
-ki,2016,2200,10.1007/s00228-016-2152-8,TRUE,Springer,European Journal of Clinical Pharmacology,0031-6970,0031-6970,1432-1041,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27826643,PMC5226983,NA,NA,FALSE
-ki,2016,2200,10.1007/s00234-016-1760-4,TRUE,Springer,Neuroradiology,0028-3940,0028-3940,1432-1920,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27796449,PMC5153414,NA,NA,FALSE
-ki,2016,2200,10.1007/s00238-016-1252-0,TRUE,Springer,European Journal of Plastic Surgery,0930-343X,0930-343X,1435-0130,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s00259-016-3476-4,TRUE,Springer,European Journal of Nuclear Medicine and Molecular Imaging,1619-7070,1619-7070,1619-7089,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s00259-016-3544-9,TRUE,Springer,European Journal of Nuclear Medicine and Molecular Imaging,1619-7070,1619-7070,1619-7089,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27817159,PMC5215309,NA,NA,FALSE
-ki,2016,2200,10.1007/s00262-016-1922-6,TRUE,Springer,"Cancer Immunology, Immunotherapy",0340-7004,0340-7004,1432-0851,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27815572,PMC5222940,NA,NA,FALSE
-ki,2016,2200,10.1007/s00268-016-3705-9,TRUE,Springer,World Journal of Surgery,0364-2313,0364-2313,1432-2323,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27549597,PMC5104803,NA,NA,FALSE
-ki,2016,2200,10.1007/s00277-016-2787-7,TRUE,Springer,Annals of Hematology,0939-5555,0939-5555,1432-0584,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27561898,PMC5040742,NA,NA,FALSE
-ki,2016,2200,10.1007/s00277-016-2859-8,TRUE,Springer,Annals of Hematology,0939-5555,0939-5555,1432-0584,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27807648,PMC5226986,NA,NA,FALSE
-ki,2016,2200,10.1007/s00380-016-0924-9,TRUE,Springer,Heart and Vessels,0910-8327,0910-8327,1615-2573,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s00384-016-2678-3,TRUE,Springer,International Journal of Colorectal Disease,0179-1958,0179-1958,1432-1262,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27770250,PMC5285411,NA,NA,FALSE
-ki,2016,2200,10.1007/s00394-016-1298-6,TRUE,Springer,European Journal of Nutrition,1436-6207,1436-6207,1436-6215,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s00405-016-4321-x,TRUE,Springer,European Archives of Oto-Rhino-Laryngology,0937-4477,0937-4477,1434-4726,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27757542,PMC5309288,NA,NA,FALSE
-ki,2016,2200,10.1007/s00406-016-0759-5,TRUE,Springer,European Archives of Psychiatry and Clinical Neuroscience,0940-1334,0940-1334,1433-8491,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28039552,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s00420-016-1156-0,TRUE,Springer,International Archives of Occupational and Environmental Health,0340-0131,0340-0131,1432-1246,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s00420-016-1186-7,TRUE,Springer,International Archives of Occupational and Environmental Health,0340-0131,0340-0131,1432-1246,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27858151,PMC5263190,NA,NA,FALSE
-ki,2016,2200,10.1007/s00421-016-3473-0,TRUE,Springer,European Journal of Applied Physiology,1439-6319,1439-6319,1439-6327,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s00423-016-1501-5,TRUE,Springer,Langenbeck's Archives of Surgery,1435-2443,1435-2443,1435-2451,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27562317,PMC5143360,NA,NA,FALSE
-ki,2016,2200,10.1007/s00423-016-1512-2,TRUE,Springer,Langenbeck's Archives of Surgery,1435-2443,1435-2443,1435-2451,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27695941,PMC5309267,NA,NA,FALSE
-ki,2016,2200,10.1007/s00423-016-1524-y,TRUE,Springer,Langenbeck's Archives of Surgery,1435-2443,1435-2443,1435-2451,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27761713,PMC5309264,NA,NA,FALSE
-ki,2016,2200,10.1007/s00464-016-5173-6,TRUE,Springer,Surgical Endoscopy,0930-2794,0930-2794,1432-2218,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27572065,PMC5346119,NA,NA,FALSE
-ki,2016,2200,10.1007/s00520-016-3527-1,TRUE,Springer,Supportive Care in Cancer,0941-4355,0941-4355,1433-7339,NA,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27981366,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s00586-016-4854-0,TRUE,Springer,European Spine Journal,0940-6719,0940-6719,1432-0932,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s00586-016-4876-7,TRUE,Springer,European Spine Journal,0940-6719,0940-6719,1432-0932,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27888355,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s00701-016-3046-3,TRUE,Springer,Acta Neurochirurgica,0001-6268,0001-6268,0942-0940,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27957604,PMC5241347,NA,NA,FALSE
-ki,2016,2200,10.1007/s00726-016-2316-y,TRUE,Springer,Amino Acids,0939-4451,0939-4451,1438-2199,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27573935,PMC5107209,NA,NA,FALSE
-ki,2016,2200,10.1007/s00769-016-1228-6,TRUE,Springer,Accreditation and Quality Assurance,0949-1775,0949-1775,1432-0517,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s00784-016-1939-4,TRUE,Springer,Clinical Oral Investigations,1432-6981,1432-6981,1436-3771,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27568306,PMC5318472,NA,NA,FALSE
-ki,2016,2200,10.1007/s10096-016-2842-2,TRUE,Springer,European Journal of Clinical Microbiology & Infectious Diseases,0934-9723,0934-9723,1435-4373,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27909820,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s10120-016-0654-9,TRUE,Springer,Gastric Cancer,1436-3291,1436-3291,1436-3305,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27718134,PMC5316395,NA,NA,FALSE
-ki,2016,2200,10.1007/s10334-016-0599-3,TRUE,Springer,"Magnetic Resonance Materials in Physics, Biology and Medicine",0968-5243,0968-5243,1352-8661,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s10433-016-0394-z,TRUE,Springer,European Journal of Ageing,1613-9372,1613-9372,1613-9380,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s10534-016-9959-8,TRUE,Springer,BioMetals,0966-0844,0966-0844,1572-8773,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27530256,PMC5034004,NA,NA,FALSE
-ki,2016,2200,10.1007/s10549-016-3983-9,TRUE,Springer,Breast Cancer Research and Treatment,0167-6806,0167-6806,1573-7217,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s10584-016-1753-7,TRUE,Springer,Climatic Change,0165-0009,0165-0009,1573-1480,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s10654-016-0204-0,TRUE,Springer,European Journal of Epidemiology,0393-2990,0393-2990,1573-7284,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s10803-016-2914-2,TRUE,Springer,Journal of Autism and Developmental Disorders,0162-3257,0162-3257,1573-3432,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27734228,PMC5222913,NA,NA,FALSE
-ki,2016,2200,10.1007/s10865-016-9769-z,TRUE,Springer,Journal of Behavioral Medicine,0160-7715,0160-7715,1573-3521,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27469518,PMC5012257,NA,NA,FALSE
-ki,2016,2200,10.1007/s10875-016-0347-5,TRUE,Springer,Journal of Clinical Immunology,0271-9142,0271-9142,1573-2592,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27873105,PMC5226987,NA,NA,FALSE
-ki,2016,2200,10.1007/s10910-016-0693-9,TRUE,Springer,Journal of Mathematical Chemistry,0259-9791,0259-9791,1572-8897,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s10910-016-0694-8,TRUE,Springer,Journal of Mathematical Chemistry,0259-9791,0259-9791,1572-8897,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s10961-016-9490-7,TRUE,Springer,The Journal of Technology Transfer,0892-9912,0892-9912,1573-7047,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s10995-016-2202-y,TRUE,Springer,Maternal and Child Health Journal,1092-7875,1092-7875,1573-6628,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28035634,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s11019-016-9723-4,TRUE,Springer,"Medicine, Health Care and Philosophy",1386-7423,1386-7423,1572-8633,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27581427,PMC5318471,NA,NA,FALSE
-ki,2016,2200,10.1007/s11113-016-9412-2,TRUE,Springer,Population Research and Policy Review,0167-5923,0167-5923,1573-7829,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28190908,PMC5272880,NA,NA,FALSE
-ki,2016,2200,10.1007/s11605-016-3223-y,TRUE,Springer,Journal of Gastrointestinal Surgery,1091-255X,1091-255X,1873-4626,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27649704,PMC5187360,NA,NA,FALSE
-ki,2016,2200,10.1007/s11695-016-2431-6,TRUE,Springer,Obesity Surgery,0960-8923,0960-8923,1708-0428,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s11882-016-0652-3,TRUE,Springer,Current Allergy and Asthma Reports,1529-7322,1529-7322,1534-6315,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27645534,PMC5028403,NA,NA,FALSE
-ki,2016,2200,10.1007/s12020-016-1127-y,TRUE,Springer,Endocrine,1355-008X,1355-008X,1559-0100,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27699708,PMC5225211,NA,NA,FALSE
-ki,2016,2200,10.1007/s12062-016-9158-y,TRUE,Springer,Journal of Population Ageing,1874-7884,1874-7884,1874-7876,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s12529-016-9601-8,TRUE,Springer,International Journal of Behavioral Medicine,1070-5503,1070-5503,1532-7558,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s12529-016-9618-z,TRUE,Springer,International Journal of Behavioral Medicine,1070-5503,1070-5503,1532-7558,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s13304-016-0388-6,TRUE,Springer,Updates in Surgery,2038-131X,2038-131X,2038-3312,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s15010-016-0963-2,TRUE,Springer,Infection,0300-8126,0300-8126,1439-0973,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ki,2016,2200,10.1007/s40258-016-0272-z,TRUE,Springer,Applied Health Economics and Health Policy,1175-5652,1175-5652,1179-1896,NA,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27587010,PMC5253143,NA,NA,FALSE
-ki,2016,2200,10.1007/s40273-016-0461-5,TRUE,Springer,PharmacoEconomics,1170-7690,1170-7690,1179-2027,NA,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27798808,PMC5253157,NA,NA,FALSE
-ki,2016,2200,10.1007/s40520-016-0630-6,TRUE,Springer,Aging Clinical and Experimental Research,1720-8319,NA,1720-8319,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+bth,2016,2200,10.1007/s11187-016-9801-2,TRUE,Springer,Small Business Economics,0921-898X,0921-898X,1573-0913,0921-898X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392306200001,NA,FALSE
+cth,2013,413,10.1080/21663831.2013.844737,FALSE,Taylor & Francis,Materials Research Letters,2166-3831,NA,2166-3831,2166-3831,NA,TRUE,NA,NA,ut:000209767600007,NA,FALSE
+cth,2014,2429,10.1080/00207543.2014.980456,TRUE,Taylor & Francis,International Journal of Production Research,0020-7543,0020-7543,1366-588X,0020-7543,NA,TRUE,NA,NA,ut:000367046100008,NA,FALSE
+cth,2014,2429,10.1080/01490451.2013.879508,TRUE,Taylor & Francis,Geomicrobiology Journal,0149-0451,0149-0451,1521-0529,0149-0451,NA,TRUE,NA,NA,ut:000340188400008,NA,FALSE
+cth,2014,2429,10.1080/13669877.2014.889194,TRUE,Taylor & Francis,Journal of Risk Research,1366-9877,1366-9877,1466-4461,1366-9877,NA,TRUE,NA,NA,ut:000349671900002,NA,FALSE
+cth,2014,3040,10.3109/14992027.2014.996826,TRUE,Taylor & Francis,International Journal of Audiology,1499-2027,1499-2027,1708-8186,1499-2027,NA,TRUE,25705995,PMC4487578,ut:000354406500008,NA,FALSE
+cth,2016,1169,10.1080/23311916.2016.1239516,FALSE,Taylor & Francis,Cogent Engineering,2331-1916,NA,2331-1916,2331-1916,NA,TRUE,NA,NA,ut:000397384100026,NA,TRUE
+cth,2016,2132,10.1080/10643389.2016.1149903,TRUE,Taylor & Francis,Critical Reviews in Environmental Science and Technology,1064-3389,1064-3389,1547-6537,1064-3389,NA,TRUE,NA,NA,ut:000374956500001,NA,FALSE
+cth,2016,2132,10.1080/17445760.2016.1241880,TRUE,Taylor & Francis,"International Journal of Parallel, Emergent and Distributed Systems",1744-5760,1744-5760,1744-5779,1744-5760,NA,TRUE,NA,NA,NA,NA,FALSE
+cth,2016,2132,10.1080/19376812.2015.1130636,TRUE,Taylor & Francis,African Geographical Review,1937-6812,1937-6812,2163-2642,1937-6812,NA,TRUE,NA,NA,ut:000396599800006,NA,FALSE
+cth,2016,2200,10.1007/s00023-016-0531-4,TRUE,Springer,Annales Henri Poincaré,1424-0637,1424-0637,1424-0661,1424-0637,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392310200009,NA,FALSE
+cth,2016,2200,10.1007/s00190-016-0974-x,TRUE,Springer,Journal of Geodesy,0949-7714,0949-7714,1432-1394,0949-7714,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000403720900011,NA,FALSE
+cth,2016,2200,10.1007/s00707-016-1754-7,TRUE,Springer,Acta Mechanica,0001-5970,0001-5970,1619-6937,0001-5970,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000399297600005,NA,FALSE
+cth,2016,2200,10.1007/s00766-016-0259-1,TRUE,Springer,Requirements Engineering,0947-3602,0947-3602,1432-010X,0947-3602,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+cth,2016,2200,10.1007/s00766-016-0261-7,TRUE,Springer,Requirements Engineering,0947-3602,0947-3602,1432-010X,0947-3602,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+cth,2016,2200,10.1007/s10064-016-0962-7,TRUE,Springer,Bulletin of Engineering Geology and the Environment,1435-9529,1435-9529,1435-9537,1435-9529,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000401408700026,NA,FALSE
+cth,2016,2200,10.1007/s10107-016-1055-x,TRUE,Springer,Mathematical Programming,0025-5610,0025-5610,1436-4646,0025-5610,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000399178500003,NA,FALSE
+cth,2016,2200,10.1007/s10295-016-1814-y,TRUE,Springer,Journal of Industrial Microbiology & Biotechnology,1367-5435,1367-5435,1476-5535,1367-5435,http://creativecommons.org/licenses/by/4.0,TRUE,27565672,NA,ut:000400394000013,NA,FALSE
+cth,2016,2200,10.1007/s10472-016-9532-8,TRUE,Springer,Annals of Mathematics and Artificial Intelligence,1012-2443,1012-2443,1573-7470,1012-2443,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000404217400006,NA,FALSE
+cth,2016,2200,10.1007/s10494-016-9760-3,TRUE,Springer,"Flow, Turbulence and Combustion",1386-6184,1386-6184,1573-1987,1386-6184,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388171900014,NA,FALSE
+cth,2016,2200,10.1007/s10534-016-9976-7,TRUE,Springer,BioMetals,0966-0844,0966-0844,1572-8773,0966-0844,http://creativecommons.org/licenses/by/4.0,TRUE,27744583,PMC5285417,ut:000394146400003,NA,FALSE
+cth,2016,2200,10.1007/s10543-016-0635-8,TRUE,Springer,BIT Numerical Mathematics,0006-3835,0006-3835,1572-9125,0006-3835,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000401549700007,NA,FALSE
+cth,2016,2200,10.1007/s10570-016-1080-1,TRUE,Springer,Cellulose,0969-0239,0969-0239,1572-882X,0969-0239,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388961200022,NA,FALSE
+cth,2016,2200,10.1007/s10664-016-9482-0,TRUE,Springer,Empirical Software Engineering,1382-3256,1382-3256,1573-7616,1382-3256,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000406290500016,NA,FALSE
+cth,2016,2200,10.1007/s10811-016-0957-6,TRUE,Springer,Journal of Applied Phycology,0921-8971,0921-8971,1573-5176,0921-8971,http://creativecommons.org/licenses/by/4.0,TRUE,28344391,PMC5346136,ut:000396344800052,NA,FALSE
+cth,2016,2200,10.1007/s10948-016-3666-0,TRUE,Springer,Journal of Superconductivity and Novel Magnetism,1557-1939,1557-1939,1557-1947,1557-1939,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392334000002,NA,FALSE
+cth,2016,2200,10.1007/s10948-016-3851-1,TRUE,Springer,Journal of Superconductivity and Novel Magnetism,1557-1939,1557-1939,1557-1947,1557-1939,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000395062600030,NA,FALSE
+cth,2016,2200,10.1007/s11044-016-9542-7,TRUE,Springer,Multibody System Dynamics,1384-5640,1384-5640,1573-272X,1384-5640,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000390126700009,NA,FALSE
+cth,2016,2200,10.1007/s11081-016-9342-1,TRUE,Springer,Optimization and Engineering,1389-4420,1389-4420,1573-2924,1389-4420,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+cth,2016,2200,10.1007/s11241-016-9258-z,TRUE,Springer,Real-Time Systems,0922-6443,0922-6443,1573-1383,0922-6443,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000393594600002,NA,FALSE
+cth,2016,2200,10.1007/s11367-016-1182-x,TRUE,Springer,The International Journal of Life Cycle Assessment,0948-3349,0948-3349,1614-7502,0948-3349,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000399246100007,NA,FALSE
+cth,2016,2200,10.1007/s11517-016-1578-6,TRUE,Springer,Medical & Biological Engineering & Computing,0140-0118,0140-0118,1741-0444,0140-0118,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000407310300004,NA,FALSE
+cth,2016,2200,10.1007/s12528-016-9127-8,TRUE,Springer,Journal of Computing in Higher Education,1042-1726,1042-1726,1867-1233,1042-1726,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000399233000009,NA,FALSE
+cth,2016,2200,10.1007/s13399-016-0228-4,TRUE,Springer,Biomass Conversion and Biorefinery,2190-6815,2190-6815,2190-6823,2190-6815,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+cth,2016,2200,10.1007/s40831-016-0072-6,TRUE,Springer,Journal of Sustainable Metallurgy,2199-3823,2199-3823,2199-3831,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000400824500005,NA,FALSE
+cth,2016,2200,10.1208/s12248-016-9991-1,TRUE,Springer,The AAPS Journal,1550-7416,NA,1550-7416,1550-7416,http://creativecommons.org/licenses/by/4.0,TRUE,27681102,NA,ut:000395006000014,NA,FALSE
+cth,2016,560,10.1080/19942060.2016.1235515,FALSE,Taylor & Francis,Engineering Applications of Computational Fluid Mechanics,1994-2060,1994-2060,1997-003X,1994-2060,NA,TRUE,NA,NA,ut:000386338500003,NA,TRUE
+du,2014,1712,10.1186/1471-2393-14-349,FALSE,BioMed Central,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,1471-2393,http://www.springer.com/tdm,TRUE,25288075,PMC4286931,ut:000343175500001,http://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/1471-2393-14-349,TRUE
+du,2014,1760,10.1186/1472-6882-14-187,FALSE,BioMed Central,BMC Complementary and Alternative Medicine,1472-6882,NA,1472-6882,1472-6882,http://www.springer.com/tdm,TRUE,24913704,PMC4055800,ut:000337323400001,http://bmccomplementalternmed.biomedcentral.com/articles/10.1186/1472-6882-14-187,TRUE
+du,2014,1765,10.1186/1471-2458-14-892,FALSE,BioMed Central,BMC Public Health,1471-2458,NA,1471-2458,1471-2458,http://www.springer.com/tdm,TRUE,25174960,PMC4168062,ut:000341650800001,http://bmcpublichealth.biomedcentral.com/articles/10.1186/1471-2458-14-892,TRUE
+du,2014,2211,10.1186/1471-2318-15-3,FALSE,BioMed Central,BMC Geriatrics,1471-2318,NA,1471-2318,1471-2318,http://www.springer.com/tdm,TRUE,25563507,PMC4323237,ut:000348232800001,http://bmcgeriatr.biomedcentral.com/articles/10.1186/1471-2318-15-3,TRUE
+du,2014,2607,10.1111/scs.12121,TRUE,Wiley,Scandinavian Journal of Caring Sciences,0283-9318,NA,1471-6712,0283-9318,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,24602178,PMC4244179,ut:000334503400020,http://onlinelibrary.wiley.com/doi/10.1111/scs.12121/full,FALSE
+du,2014,660,10.1155/2014/860612,FALSE,Hindawi Publishing Corporation,Journal of Aging Research,2090-2204,2090-2204,2090-2212,2090-2204,http://creativecommons.org/licenses/by/3.0/,TRUE,25548675,PMC4273510,NA,https://www.hindawi.com/journals/jar/2014/860612/,TRUE
+du,2015,1320,10.1371/journal.pone.0133354,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26327217,PMC4556554,ut:000360437700006,http://journals.plos.org/plosone/article?id=10.1371%2Fjournal.pone.0133354,TRUE
+du,2015,1631,10.1016/j.ssci.2015.09.011,TRUE,Elsevier,Safety Science,0925-7535,0925-7535,NA,0925-7535,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000366766800012,http://www.sciencedirect.com/science/article/pii/S0925753515002404,FALSE
+du,2015,1760,10.1186/s12906-015-0708-2,FALSE,BioMed Central,BMC Complementary and Alternative Medicine,1472-6882,NA,1472-6882,1472-6882,http://www.springer.com/tdm,TRUE,26066641,PMC4490752,NA,http://bmccomplementalternmed.biomedcentral.com/articles/10.1186/s12906-015-0708-2,TRUE
+du,2015,1936,10.1186/s12884-015-0429-z,FALSE,BioMed Central,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,1471-2393,http://www.springer.com/tdm,TRUE,25591791,PMC4299129,ut:000348469300001,http://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-015-0429-z,TRUE
+du,2015,2338,10.1186/s12913-015-0782-7,FALSE,BioMed Central,BMC Health Services Research,1472-6963,NA,1472-6963,1472-6963,http://www.springer.com/tdm,TRUE,25888922,PMC4373305,ut:000351501200001,http://bmchealthservres.biomedcentral.com/articles/10.1186/s12913-015-0782-7,TRUE
+du,2015,2613,10.1016/j.jdiacomp.2015.07.026,TRUE,Elsevier,Journal of Diabetes and its Complications,1056-8727,1056-8727,NA,1056-8727,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26318959,NA,ut:000366884900036,http://www.sciencedirect.com/science/article/pii/S1056872715003268,FALSE
+du,2015,2731,10.1111/jan.12655,TRUE,Wiley,Journal of Advanced Nursing,0309-2402,0309-2402,1365-2648,0309-2402,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25810044,NA,ut:000357885800013,http://onlinelibrary.wiley.com/doi/10.1111/jan.12655/full,FALSE
+du,2015,283,10.5430/jnep.v5n8p82,TRUE,Sciedu Press,Journal of Nursing Education and Practice,1925-4059,1925-4040,1925-4059,1925-4040,NA,TRUE,NA,NA,NA,http://www.sciedu.ca/journal/index.php/jnep/article/view/6740,FALSE
+du,2015,440,10.1016/j.amper.2015.06.001,FALSE,Elsevier,Ampersand,2215-0390,2215-0390,2215-0390,2215-0390,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S2215039015000107,TRUE
+du,2015,498,10.1016/j.orp.2015.06.002,FALSE,Elsevier,Operations Research Perspectives,2214-7160,2214-7160,2214-7160,2214-7160,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000367348300012,http://www.sciencedirect.com/science/article/pii/S2214716015000135,TRUE
+du,2015,572,10.3402/gha.v8.27512,FALSE,Taylor & Francis,Global Health Action,1654-9716,1654-9716,1654-9880,1654-9880,NA,TRUE,25828071,PMC4380857,ut:000352006700001,http://www.globalhealthaction.net/index.php/gha/article/view/27512,TRUE
+du,2015,598,10.1080/02673843.2015.1106414,TRUE,Taylor & Francis,International Journal of Adolescence and Youth,0267-3843,0267-3843,2164-4527,0267-3843,NA,TRUE,NA,NA,ut:000407698200007,http://www.tandfonline.com/doi/full/10.1080/02673843.2015.1106414,TRUE
+du,2015,747,10.2174/1874434601610010026,TRUE,Bentham Open,The Open Nursing Journal,1874-4346,1874-4346,1874-4346,1874-4346,NA,TRUE,27347252,PMC4894944,NA,https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4894944/,FALSE
+du,2015,926,10.1186/s13104-015-1597-7,FALSE,BioMed Central,BMC Research Notes,1756-0500,NA,1756-0500,1756-0500,NA,TRUE,26517989,PMC4627617,NA,http://bmcresnotes.biomedcentral.com/articles/10.1186/s13104-015-1597-7,TRUE
+du,2016,1051,10.4236/ojn.2017.72013,FALSE,Scientific Research Publishing,Open Journal of Nursing,2162-5336,2162-5336,2162-5344,2162-5336,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,NA,http://www.scirp.org/Journal/PaperInformation.aspx?PaperID=73974,FALSE
+du,2016,1429,10.1186/s12884-016-0955-3,FALSE,BioMed Central,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,1471-2393,NA,TRUE,27430590,PMC4949764,ut:000379781400003,https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-016-0955-3,TRUE
+du,2016,1614,10.2147/OAJSM.S101995,FALSE,Dove Medical Press,Open Access Journal of Sports Medicine,1179-1543,NA,1179-1543,1179-1543,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,26937207,PMC4762471,ut:000399933100002,https://www.dovepress.com/the-influence-of-sex-age-and-race-experience-on-pacing-profiles-during-peer-reviewed-article-OAJSM,TRUE
+du,2016,1636,10.2147/OAJSM.S93174,FALSE,Dove Medical Press,Open Access Journal of Sports Medicine,1179-1543,NA,1179-1543,1179-1543,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,26719730,PMC4689292,NA,https://www.dovepress.com/optimal-vo2max-to-mass-ratio-for-predicting-15-km-performance-among-el-peer-reviewed-article-OAJSM,TRUE
+du,2016,1650,10.1136/acupmed-2016-011164,TRUE,BMJ,Acupuncture in Medicine,0964-5284,0964-5284,1759-9873,0964-5284,NA,TRUE,27986648,NA,ut:000407905400003,http://aim.bmj.com/content/early/2016/12/16/acupmed-2016-011164,FALSE
+du,2016,1698,10.1002/ece3.2449,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,2045-7758,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000385626100026,http://onlinelibrary.wiley.com/doi/10.1002/ece3.2449/full,TRUE
+du,2016,1724,10.1186/s12889-016-3726-1,FALSE,BioMed Central,BMC Public Health,1471-2458,NA,1471-2458,1471-2458,http://www.springer.com/tdm,TRUE,27745552,PMC5066281,ut:000385307700001,https://bmcpublichealth.biomedcentral.com/articles/10.1186/s12889-016-3726-1,TRUE
+du,2016,1792,10.1136/bmjopen-2015-010249,FALSE,BMJ,BMJ Open,2044-6055,2044-6055,2044-6055,2044-6055,NA,TRUE,27013595,PMC4809096,ut:000374052300086,http://bmjopen.bmj.com/content/6/3/e010249.full,TRUE
+du,2016,1815,10.1186/s12884-016-1183-6,FALSE,BioMed Central,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,1471-2393,NA,TRUE,28049520,PMC5209800,ut:000391772600001,http://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-016-1183-6,TRUE
+du,2016,1919,10.1186/s12909-016-0532-5,FALSE,BioMed Central,BMC Medical Education,1472-6920,NA,1472-6920,1472-6920,NA,TRUE,26758763,PMC4710021,ut:000367879000002,http://bmcmededuc.biomedcentral.com/articles/10.1186/s12909-016-0532-5,TRUE
+du,2016,1980,10.1186/s12914-016-0082-2,FALSE,BioMed Central,BMC International Health and Human Rights,1472-698X,NA,1472-698X,1472-698X,NA,TRUE,26883321,PMC4754847,ut:000370315600001,https://bmcinthealthhumrights.biomedcentral.com/articles/10.1186/s12914-016-0082-2,TRUE
+du,2016,2271,10.1186/s12913-016-1957-6,FALSE,BioMed Central,BMC Health Services Research,1472-6963,NA,1472-6963,1472-6963,NA,TRUE,28077130,PMC5225615,ut:000391924100001,http://bmchealthservres.biomedcentral.com/articles/10.1186/s12913-016-1957-6,TRUE
+du,2016,2519,10.1016/j.midw.2016.05.009,TRUE,Elsevier,Midwifery,0266-6138,0266-6138,NA,0266-6138,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27428093,NA,ut:000382308900003,http://www.sciencedirect.com/science/article/pii/S0266613816300614,FALSE
+du,2016,2690,10.1111/apa.13417,TRUE,Wiley,Acta Paediatrica,0803-5253,NA,1651-2227,0803-5253,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27059114,PMC5074324,ut:000382742900020,http://onlinelibrary.wiley.com/doi/10.1111/apa.13417/full,FALSE
+du,2016,2764,10.1111/2041-210X.12535,TRUE,Wiley,Methods in Ecology and Evolution,2041-210X,NA,2041-210X,2041-210X,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27478587,PMC4950150,ut:000379957400004,http://onlinelibrary.wiley.com/doi/10.1111/2041-210X.12535/full,FALSE
+du,2016,2794,10.1111/scs.12391,TRUE,Wiley,Scandinavian Journal of Caring Sciences,0283-9318,NA,1471-6712,0283-9318,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27862156,NA,NA,http://onlinelibrary.wiley.com/doi/10.1111/scs.12391/full,FALSE
+du,2016,2852,10.1016/j.diabres.2016.09.015,TRUE,Elsevier,Diabetes Research and Clinical Practice,0168-8227,0168-8227,NA,0168-8227,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27718374,NA,ut:000390460100020,http://www.sciencedirect.com/science/article/pii/S0168822716306064,FALSE
+du,2016,3428,10.1016/j.matchar.2016.10.017,TRUE,Elsevier,Materials Characterization,1044-5803,1044-5803,NA,1044-5803,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000390728300003,http://www.sciencedirect.com/science/article/pii/S1044580316306131,FALSE
+du,2016,4679,10.1111/wvn.12178,TRUE,Wiley,Worldviews on Evidence-Based Nursing,1545-102X,1545-102X,1741-6787,1545-102X,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27741384,NA,ut:000389362800007,http://onlinelibrary.wiley.com/doi/10.1111/wvn.12178/full,FALSE
+du,2016,726,10.1155/2016/6373101,FALSE,Hindawi Publishing Corporation,Journal of Aging Research,2090-2204,2090-2204,2090-2212,2090-2204,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,NA,https://www.hindawi.com/journals/jar/2016/6373101/,TRUE
+foi,2016,2200,10.1007/s10967-016-5062-4,TRUE,Springer,Journal of Radioanalytical and Nuclear Chemistry,0236-5731,0236-5731,1588-2780,0236-5731,http://creativecommons.org/licenses/by/4.0,TRUE,28250544,PMC5306257,ut:000394343200022,NA,FALSE
+gih,2016,2200,10.1007/s00421-016-3428-5,TRUE,Springer,European Journal of Applied Physiology,1439-6319,1439-6319,1439-6327,1439-6319,http://creativecommons.org/licenses/by/4.0,TRUE,27448605,PMC4983295,ut:000384214300018,NA,FALSE
+gu,2010,2630,10.1080/02664760903222208,TRUE,Taylor & Francis,Journal of Applied Statistics,0266-4763,0266-4763,1360-0532,0266-4763,NA,TRUE,NA,NA,ut:000284416000009,NA,FALSE
+gu,2013,2429,10.1080/10439463.2013.817995,TRUE,Taylor & Francis,Policing and Society,1043-9463,1043-9463,1477-2728,1043-9463,NA,TRUE,NA,NA,ut:000347523700001,NA,FALSE
+gu,2013,2429,10.1080/10439463.2013.817996,TRUE,Taylor & Francis,Policing and Society,1043-9463,1043-9463,1477-2728,1043-9463,NA,TRUE,NA,NA,ut:000347523700002,NA,FALSE
+gu,2014,0,10.1159/000369918,FALSE,Karger,Audiology and Neurotology Extra,1664-5537,NA,1664-5537,1664-5537,NA,TRUE,NA,NA,NA,NA,FALSE
+gu,2014,2132,10.1080/16506073.2014.921834,TRUE,Taylor & Francis,Cognitive Behaviour Therapy,1650-6073,1650-6073,1651-2316,1650-6073,NA,TRUE,24911260,PMC4260664,ut:000344862500002,NA,FALSE
+gu,2014,2429,10.1080/2158379X.2014.963381,TRUE,Taylor & Francis,Journal of Political Power,2158-379X,2158-379X,2158-3803,2158-379X,NA,TRUE,NA,NA,NA,NA,FALSE
+gu,2014,2779,10.1111/adb.12202,TRUE,Wiley,Addiction Biology,1355-6215,NA,NA,1355-6215,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25475101,NA,ut:000371148700012,NA,FALSE
+gu,2014,755,10.1159/000362164,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,1664-5464,NA,TRUE,25254036,PMC4164083,NA,NA,TRUE
+gu,2014,755,10.1159/000366119,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,1664-5464,NA,TRUE,25493088,PMC4255994,NA,NA,TRUE
+gu,2015,0,10.1159/000441128,FALSE,Karger,Medical Principles and Practice,1011-7571,1011-7571,1423-0151,1011-7571,NA,TRUE,26698595,NA,ut:000368075600001,NA,FALSE
+gu,2015,0,10.3109/17453674.2015.1135664,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,1745-3674,NA,TRUE,26848766,PMC4900098,ut:000377098700002,NA,TRUE
+gu,2015,1425.1,10.1186/s12889-015-2599-z,FALSE,Springer,BMC Public Health,1471-2458,NA,1471-2458,1471-2458,http://www.springer.com/tdm,TRUE,26689711,PMC4687316,ut:000367069400002,NA,TRUE
+gu,2015,2132,10.3109/00365521.2015.1087588,TRUE,Taylor & Francis,Scandinavian Journal of Gastroenterology,0036-5521,0036-5521,1502-7708,0036-5521,NA,TRUE,26418670,PMC4732462,ut:000364484200012,NA,FALSE
+gu,2015,2429,10.1080/13607863.2015.1083945,TRUE,Taylor & Francis,Aging & Mental Health,1360-7863,1360-7863,1364-6915,1360-7863,NA,TRUE,26381843,PMC4720055,ut:000368520500006,NA,FALSE
+gu,2015,2760,10.1586/14737159.2015.1057124,TRUE,Taylor & Francis,Expert Review of Molecular Diagnostics,1473-7159,1473-7159,1744-8352,1473-7159,NA,TRUE,26132215,PMC4673511,ut:000358295300012,NA,FALSE
+gu,2015,2779,10.1002/gcc.22314,TRUE,Wiley,"Genes, Chromosomes and Cancer",1045-2257,NA,NA,1045-2257,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26493165,PMC5057327,ut:000368259400009,NA,FALSE
+gu,2015,2779,10.1002/gps.4390,TRUE,Wiley,International Journal of Geriatric Psychiatry,0885-6230,NA,NA,0885-6230,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26560405,PMC4908825,ut:000378430100012,NA,FALSE
+gu,2015,2779,10.1002/jbmr.2718,TRUE,Wiley,Journal of Bone and Mineral Research,0884-0431,NA,NA,0884-0431,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26391196,PMC4832265,ut:000373596800021,NA,FALSE
+gu,2015,2779,10.1002/jbmr.2747,TRUE,Wiley,Journal of Bone and Mineral Research,0884-0431,NA,NA,0884-0431,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26588353,NA,ut:000374008200007,NA,FALSE
+gu,2015,2779,10.1111/adb.12277,TRUE,Wiley,Addiction Biology,1355-6215,NA,NA,1355-6215,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26059200,PMC5033010,ut:000371148700023,NA,FALSE
+gu,2015,2779,10.1111/adb.12295,TRUE,Wiley,Addiction Biology,1355-6215,NA,NA,1355-6215,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26303264,PMC5049632,ut:000371148700018,NA,FALSE
+gu,2015,2779,10.1111/apa.13124,TRUE,Wiley,Acta Paediatrica,0803-5253,NA,NA,0803-5253,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26175065,PMC5049485,ut:000367728500017,NA,FALSE
+gu,2015,2779,10.1111/ddi.12394,TRUE,Wiley,Diversity and Distributions,1366-9516,NA,NA,1366-9516,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000372882300004,NA,FALSE
+gu,2015,2779,10.1111/jch.12682,TRUE,Wiley,The Journal of Clinical Hypertension,1524-6175,NA,NA,1524-6175,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26456490,PMC5057328,ut:000369985100004,NA,FALSE
+gu,2015,2779,10.1111/jvh.12464,TRUE,Wiley,Journal of Viral Hepatitis,1352-0504,NA,NA,1352-0504,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26353843,NA,ut:000368945700002,NA,FALSE
+gu,2015,397,10.3109/02813432.2015.1067515,FALSE,Taylor & Francis,Scandinavian Journal of Primary Health Care,0281-3432,0281-3432,1502-7724,0281-3432,NA,TRUE,26194171,PMC4750718,ut:000369749200002,NA,TRUE
+gu,2015,702,10.1080/15476286.2015.1056975,TRUE,Taylor & Francis,RNA Biology,1547-6286,1547-6286,1555-8584,1547-6286,NA,TRUE,26176991,PMC4615768,ut:000359659700006,NA,FALSE
+gu,2015,702,10.1080/2162402X.2015.1041701,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,2162-4011,NA,TRUE,26942055,PMC4760300,ut:000373383600040,NA,FALSE
+gu,2015,702,10.1080/21624054.2015.1096490,TRUE,Taylor & Francis,Worm,2162-4054,NA,2162-4054,2162-4046,NA,TRUE,27123370,PMC4826155,NA,NA,FALSE
+gu,2016,0,10.1080/20004508.2016.1275177,FALSE,Taylor & Francis,Education Inquiry,2000-4508,NA,2000-4508,2000-4508,NA,TRUE,NA,NA,NA,NA,TRUE
+gu,2016,0,10.1080/20004508.2016.1275182,FALSE,Taylor & Francis,Education Inquiry,2000-4508,NA,2000-4508,2000-4508,NA,TRUE,NA,NA,NA,NA,TRUE
+gu,2016,0,10.1093/ckj/sfv152,FALSE,Oxford University Press (OUP),Clinical Kidney Journal,2048-8505,2048-8505,2048-8513,2048-8505,NA,TRUE,26985373,PMC4792626,ut:000386129600009,NA,TRUE
+gu,2016,0,10.1107/S1600576715023444,TRUE,International Union of Crystallography (IUCr),Journal of Applied Crystallography,1600-5767,NA,1600-5767,0021-8898,http://creativecommons.org/licenses/by/2.0/uk/legalcode,TRUE,NA,NA,ut:000369389300006,NA,FALSE
+gu,2016,0,10.1111/eva.12277,FALSE,Wiley,Evolutionary Applications,1752-4571,NA,NA,1752-4571,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27087845,PMC4780386,ut:000368250500010,NA,TRUE
+gu,2016,0,10.1111/pbi.12479,FALSE,Wiley,Plant Biotechnology Journal,1467-7644,NA,NA,1467-7644,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26403330,NA,ut:000373069400006,NA,FALSE
+gu,2016,0,10.1177/2056305115624528,FALSE,SAGE Publications,Social Media + Society,2056-3051,2056-3051,2056-3051,2056-3051,NA,TRUE,NA,NA,NA,NA,TRUE
+gu,2016,0,10.1186/s12884-016-1127-1,FALSE,Springer,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,1471-2393,http://www.springer.com/tdm,TRUE,27793111,PMC5084442,ut:000386393000001,NA,TRUE
+gu,2016,0,10.1186/s12884-016-1178-3,FALSE,Springer,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,1471-2393,http://www.springer.com/tdm,TRUE,27931191,PMC5146820,ut:000389552400001,NA,TRUE
+gu,2016,0,10.1186/s40176-016-0061-3,FALSE,Springer,IZA Journal of Migration,2193-9039,NA,2193-9039,2193-9039,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,TRUE
+gu,2016,0,10.1186/s40536-016-0020-8,FALSE,Springer,Large-scale Assessments in Education,2196-0739,NA,2196-0739,2196-0739,NA,TRUE,NA,NA,NA,NA,TRUE
+gu,2016,0,10.1186/s40536-016-0027-1,FALSE,Springer,Large-scale Assessments in Education,2196-0739,NA,2196-0739,2196-0739,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,TRUE
+gu,2016,0,10.1515/nsad-2016-0020,FALSE,Walter de Gruyter,Nordic Studies on Alcohol and Drugs,1458-6126,NA,1458-6126,1455-0725,NA,TRUE,NA,NA,ut:000379145900005,NA,TRUE
+gu,2016,0,10.4309/jgi.2016.34.2,FALSE,Journal of Gambling Issues,Journal of Gambling Issues,1910-7595,1910-7595,NA,1910-7595,NA,TRUE,NA,NA,NA,NA,FALSE
+gu,2016,1009.1,10.1210/en.2016-1181,TRUE,The Endocrine Society,Endocrinology,0013-7227,0013-7227,1945-7170,0013-7227,NA,TRUE,27254004,PMC4967117,ut:000380746800028,NA,FALSE
+gu,2016,1044,10.1186/s40658-016-0137-4,FALSE,Springer,EJNMMI Physics,2197-7364,NA,2197-7364,2197-7364,NA,TRUE,26782039,PMC4718906,ut:000379210200001,NA,TRUE
+gu,2016,1082.35,10.1016/j.ssmph.2016.08.004,FALSE,Elsevier,SSM - Population Health,2352-8273,2352-8273,NA,2352-8273,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,TRUE
+gu,2016,1121,10.3390/su8121340,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,2071-1050,NA,TRUE,NA,NA,ut:000393315100063,NA,TRUE
+gu,2016,1130,10.14814/phy2.12789,FALSE,Wiley,Physiological Reports,2051-817X,2051-817X,2051-817X,2051-817X,NA,TRUE,27273879,PMC4908486,ut:000380256900005,NA,TRUE
+gu,2016,1157.4,10.1186/s40658-016-0168-x,FALSE,Springer,EJNMMI Physics,2197-7364,NA,2197-7364,2197-7364,http://creativecommons.org/licenses/by/4.0,TRUE,28070731,PMC5222763,ut:000397119500001,NA,TRUE
+gu,2016,1159.6,10.1186/s13104-016-1878-9,FALSE,Springer,BMC Research Notes,1756-0500,NA,1756-0500,1756-0500,NA,TRUE,26843185,PMC4739106,NA,NA,TRUE
+gu,2016,1160,10.1002/ece3.2318,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000386429200027,NA,TRUE
+gu,2016,1165,10.1038/srep20413,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,26846342,PMC4742773,ut:000369382900001,NA,TRUE
+gu,2016,1165,10.1038/srep24717,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,27090401,PMC4835753,ut:000374348500001,NA,TRUE
+gu,2016,1165,10.1038/srep29200,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,27383650,PMC4935877,ut:000379137600001,NA,TRUE
+gu,2016,1165,10.1038/srep31524,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,27528202,PMC4985744,ut:000381460200001,NA,TRUE
+gu,2016,1165,10.1038/srep35279,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,27756898,PMC5069500,ut:000386145700001,NA,TRUE
+gu,2016,1195,10.3389/fncom.2016.00088,FALSE,Frontiers,Frontiers in Computational Neuroscience,1662-5188,NA,1662-5188,1662-5188,NA,TRUE,27601989,PMC4993777,ut:000381727100001,NA,TRUE
+gu,2016,1200,10.1002/iid3.105,FALSE,Wiley,"Immunity, Inflammation and Disease",2050-4527,NA,NA,2050-4527,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000381570000007,NA,TRUE
+gu,2016,1208.5,10.1186/s40658-016-0153-4,FALSE,Springer,EJNMMI Physics,2197-7364,NA,2197-7364,2197-7364,http://creativecommons.org/licenses/by/4.0,TRUE,27491429,PMC4975733,ut:000381142300001,NA,TRUE
+gu,2016,1224,10.1002/ece3.2126,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27516852,PMC4972216,ut:000379342900002,NA,TRUE
+gu,2016,1256,10.1371/journal.pone.0150286,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26981623,PMC4794193,ut:000372574900031,NA,TRUE
+gu,2016,1256,10.1371/journal.pone.0153296,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27077913,PMC4831691,ut:000374131700036,NA,TRUE
+gu,2016,1256,10.1371/journal.pone.0155465,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27192203,PMC4871506,ut:000376286100051,NA,TRUE
+gu,2016,1256,10.1371/journal.pone.0156484,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27243937,PMC4886961,ut:000377146100041,NA,TRUE
+gu,2016,1307,10.1186/s12987-016-0037-y,FALSE,Springer,Fluids and Barriers of the CNS,2045-8118,NA,2045-8118,2045-8118,NA,TRUE,27472944,PMC4967298,ut:000381860500001,NA,TRUE
+gu,2016,1338.81,10.1016/j.pmedr.2016.04.010,FALSE,Elsevier,Preventive Medicine Reports,2211-3355,2211-3355,NA,2211-3355,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27413660,PMC4929080,NA,NA,TRUE
+gu,2016,1341,10.3389/fmars.2016.00011,FALSE,Frontiers,Frontiers in Marine Science,2296-7745,NA,2296-7745,2296-7745,NA,TRUE,NA,NA,NA,NA,TRUE
+gu,2016,1345.5,10.1371/journal.pone.0145890,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26752550,PMC4709062,ut:000367888100030,NA,TRUE
+gu,2016,1345.5,10.1371/journal.pone.0147152,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26766577,PMC4713078,ut:000368459300073,NA,TRUE
+gu,2016,1345.5,10.1371/journal.pone.0149456,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26925974,PMC4771210,ut:000371424200010,NA,TRUE
+gu,2016,1345.5,10.1371/journal.pone.0152198,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27022948,PMC4811441,ut:000373113900028,NA,TRUE
+gu,2016,1345.5,10.1371/journal.pone.0153888,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27100092,PMC4839681,ut:000374898500086,NA,TRUE
+gu,2016,1345.5,10.1371/journal.pone.0155164,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27214132,PMC4876998,ut:000376880200008,NA,TRUE
+gu,2016,1345.5,10.1371/journal.pone.0157160,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27295036,PMC4905676,ut:000377821300026,NA,TRUE
+gu,2016,1345.5,10.1371/journal.pone.0157504,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27299883,PMC4907497,ut:000377822200057,NA,TRUE
+gu,2016,1345.5,10.1371/journal.pone.0158973,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27441551,PMC4956037,ut:000380797500033,NA,TRUE
+gu,2016,1345.5,10.1371/journal.pone.0159105,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27434143,PMC4951030,ut:000380169600033,NA,TRUE
+gu,2016,1345.5,10.1371/journal.pone.0165914,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27812209,PMC5094703,ut:000386910000080,NA,TRUE
+gu,2016,1345.5,10.1371/journal.pone.0167800,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27977703,PMC5158052,ut:000391217400032,NA,TRUE
+gu,2016,1345.5,10.1371/journal.pone.0167965,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27941994,PMC5152857,ut:000392745600041,NA,TRUE
+gu,2016,1351.1,10.3390/v8090259,FALSE,MDPI,Viruses,1999-4915,NA,1999-4915,1999-4915,NA,TRUE,NA,NA,ut:000385396800019,NA,TRUE
+gu,2016,1385.3,10.1371/journal.pone.0156708,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27311019,PMC4911171,ut:000378029800012,NA,TRUE
+gu,2016,1391,10.1371/journal.pone.0154477,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27139195,PMC4854378,ut:000375675700034,NA,TRUE
+gu,2016,1391,10.1371/journal.pone.0154630,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27159398,PMC4861286,ut:000376576700014,NA,TRUE
+gu,2016,1391,10.1371/journal.pone.0155083,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27223117,PMC4880197,ut:000376881700015,NA,TRUE
+gu,2016,1391,10.1371/journal.pone.0155099,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27166587,PMC4864434,ut:000376587300089,NA,TRUE
+gu,2016,1391,10.1371/journal.pone.0155328,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27171440,PMC4865157,ut:000376588600124,NA,TRUE
+gu,2016,1391,10.1371/journal.pone.0158957,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27463968,PMC4963079,ut:000381515900023,NA,TRUE
+gu,2016,1391,10.1371/journal.pone.0158985,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27441602,PMC4956274,ut:000380797500034,NA,TRUE
+gu,2016,1391,10.1371/journal.pone.0159593,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27483138,PMC4970800,ut:000381110700012,NA,TRUE
+gu,2016,1391,10.1371/journal.pone.0160335,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27490719,PMC4973994,ut:000381368900048,NA,TRUE
+gu,2016,1391,10.1371/journal.pone.0161161,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27513955,PMC4981371,ut:000381381100124,NA,TRUE
+gu,2016,1391,10.1371/journal.pone.0161266,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27525655,PMC4985153,ut:000381471100050,NA,TRUE
+gu,2016,1391,10.1371/journal.pone.0161270,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27517693,PMC4982604,ut:000381382100066,NA,TRUE
+gu,2016,1391,10.1371/journal.pone.0161629,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27552229,PMC4994938,ut:000381768800059,NA,TRUE
+gu,2016,1391,10.1371/journal.pone.0162638,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27611867,PMC5017602,ut:000383255900142,NA,TRUE
+gu,2016,1397.7,10.3390/v8040110,FALSE,MDPI,Viruses,1999-4915,NA,1999-4915,1999-4915,NA,TRUE,27110813,PMC4848603,ut:000375157800022,NA,TRUE
+gu,2016,1397.7,10.3390/v8100273,FALSE,MDPI,Viruses,1999-4915,NA,1999-4915,1999-4915,NA,TRUE,NA,NA,ut:000387482200012,NA,TRUE
+gu,2016,1398,10.1038/srep23728,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,NA,TRUE,27020613,PMC4810423,ut:000372949100001,NA,TRUE
+gu,2016,1402.6,10.1186/s12872-016-0400-6,FALSE,Springer,BMC Cardiovascular Disorders,1471-2261,NA,1471-2261,1471-2261,http://www.springer.com/tdm,TRUE,NA,NA,ut:000387923700003,NA,TRUE
+gu,2016,1402.6,10.1186/s12883-016-0753-6,FALSE,Springer,BMC Neurology,1471-2377,NA,1471-2377,1471-2377,http://www.springer.com/tdm,TRUE,NA,NA,ut:000388130000002,NA,TRUE
+gu,2016,1402.6,10.1186/s12886-016-0392-0,FALSE,Springer,BMC Ophthalmology,1471-2415,NA,1471-2415,1471-2415,http://www.springer.com/tdm,TRUE,NA,NA,ut:000391339100001,NA,TRUE
+gu,2016,1403.6,10.1186/s12877-016-0345-8,FALSE,Springer,BMC Geriatrics,1471-2318,NA,1471-2318,1471-2318,NA,TRUE,NA,NA,ut:000384699700001,NA,TRUE
+gu,2016,1403.6,10.1186/s12888-016-1147-4,FALSE,Springer,BMC Psychiatry,1471-244X,NA,1471-244X,1471-244X,http://www.springer.com/tdm,TRUE,NA,NA,ut:000390391400001,NA,TRUE
+gu,2016,1403.6,10.1186/s12889-016-3852-9,FALSE,Springer,BMC Public Health,1471-2458,NA,1471-2458,1471-2458,NA,TRUE,NA,NA,ut:000389387500005,NA,TRUE
+gu,2016,1405.5,10.1186/s12014-016-9104-2,FALSE,Springer,Clinical Proteomics,1542-6416,1542-6416,1559-0275,1542-6416,NA,TRUE,26924951,PMC4768413,ut:000371213000001,NA,TRUE
+gu,2016,1405.5,10.1186/s12859-016-1250-z,FALSE,Springer,BMC Bioinformatics,1471-2105,NA,1471-2105,1471-2105,NA,TRUE,27618934,PMC5020511,ut:000383403300004,NA,TRUE
+gu,2016,1405.5,10.1186/s12872-016-0309-0,FALSE,Springer,BMC Cardiovascular Disorders,1471-2261,NA,1471-2261,1471-2261,http://www.springer.com/tdm,TRUE,27267131,PMC4895810,ut:000377532600001,NA,TRUE
+gu,2016,1405.5,10.1186/s12873-016-0087-0,FALSE,Springer,BMC Emergency Medicine,1471-227X,NA,1471-227X,1471-227X,NA,TRUE,27449526,PMC4957482,ut:000381100000001,NA,TRUE
+gu,2016,1405.5,10.1186/s12880-016-0145-9,FALSE,Springer,BMC Medical Imaging,1471-2342,NA,1471-2342,1471-2342,http://www.springer.com/tdm,TRUE,27400959,PMC4940685,ut:000379858500001,NA,TRUE
+gu,2016,1405.5,10.1186/s12882-016-0251-5,FALSE,Springer,BMC Nephrology,1471-2369,NA,1471-2369,1471-2369,http://www.springer.com/tdm,TRUE,27044423,PMC4820936,ut:000373336900001,NA,TRUE
+gu,2016,1405.5,10.1186/s12883-016-0599-y,FALSE,Springer,BMC Neurology,1471-2377,NA,1471-2377,1471-2377,NA,TRUE,27411309,PMC4942912,NA,NA,TRUE
+gu,2016,1405.5,10.1186/s12889-016-2900-9,FALSE,Springer,BMC Public Health,1471-2458,NA,1471-2458,1471-2458,NA,TRUE,26944255,PMC4779265,ut:000371867000001,NA,TRUE
+gu,2016,1405.5,10.1186/s12889-016-3626-4,FALSE,Springer,BMC Public Health,1471-2458,NA,1471-2458,1471-2458,NA,TRUE,27608963,PMC5017061,ut:000382732700001,NA,TRUE
+gu,2016,1405.5,10.1186/s12889-016-3654-0,FALSE,Springer,BMC Public Health,1471-2458,NA,1471-2458,1471-2458,NA,TRUE,27633778,PMC5025586,ut:000383228600010,NA,TRUE
+gu,2016,1405.5,10.1186/s12890-015-0158-0,FALSE,Springer,BMC Pulmonary Medicine,1471-2466,NA,1471-2466,1471-2466,NA,TRUE,26673917,PMC4681169,ut:000367144600001,NA,TRUE
+gu,2016,1405.5,10.1186/s12912-016-0173-3,FALSE,Springer,BMC Nursing,1472-6955,NA,1472-6955,1472-6955,NA,TRUE,27616936,PMC5017008,ut:000384728400001,NA,TRUE
+gu,2016,1405.5,10.1186/s12967-016-0927-4,FALSE,Springer,Journal of Translational Medicine,1479-5876,NA,1479-5876,1479-5876,NA,TRUE,27320496,PMC4913423,ut:000378045200001,NA,TRUE
+gu,2016,1422.5,10.1371/journal.pone.0152899,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27054573,PMC4824445,ut:000373608000052,NA,TRUE
+gu,2016,1422.5,10.1371/journal.pone.0164435,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27760182,PMC5070875,ut:000386204000036,NA,TRUE
+gu,2016,1422.5,10.1371/journal.pone.0166251,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27861529,PMC5115717,ut:000388350300039,NA,TRUE
+gu,2016,1422.5,10.1371/journal.pone.0166469,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27851775,PMC5112775,ut:000387909300054,NA,TRUE
+gu,2016,1422.5,10.1371/journal.pone.0166918,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27973542,PMC5156420,ut:000392754300016,NA,TRUE
+gu,2016,1422.5,10.1371/journal.pone.0167287,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27907047,PMC5131947,ut:000389482700111,NA,TRUE
+gu,2016,1422.5,10.1371/journal.pone.0167529,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27907124,PMC5132201,ut:000389482700184,NA,TRUE
+gu,2016,1422.5,10.1371/journal.pone.0168128,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27977802,PMC5157998,ut:000391217400064,NA,TRUE
+gu,2016,1425.1,10.1186/s13195-016-0178-x,FALSE,Springer,Alzheimer's Research & Therapy,1758-9193,NA,1758-9193,1758-9193,NA,TRUE,26948580,PMC4780148,ut:000371459900001,NA,TRUE
+gu,2016,1425.9,10.1186/s13195-015-0160-z,FALSE,Springer,Alzheimer's Research & Therapy,1758-9193,NA,1758-9193,1758-9193,NA,TRUE,26689589,PMC4687145,ut:000367217600001,NA,TRUE
+gu,2016,1439.7,10.1186/s12937-016-0160-2,FALSE,Springer,Nutrition Journal,1475-2891,NA,1475-2891,1475-2891,NA,TRUE,27103118,PMC4840851,ut:000374643100002,NA,TRUE
+gu,2016,1479.2,10.1186/s13293-016-0059-9,FALSE,Springer,Biology of Sex Differences,2042-6410,NA,2042-6410,2042-6410,NA,TRUE,26779332,PMC4715328,ut:000368238300001,NA,TRUE
+gu,2016,1482,10.1186/s12859-016-1144-0,FALSE,Springer,BMC Bioinformatics,1471-2105,NA,1471-2105,1471-2105,NA,TRUE,27370569,PMC4930602,ut:000378847600001,NA,TRUE
+gu,2016,1482,10.1186/s12874-016-0167-6,FALSE,Springer,BMC Medical Research Methodology,1471-2288,NA,1471-2288,1471-2288,NA,TRUE,27387456,PMC4937582,ut:000379403600001,NA,TRUE
+gu,2016,1482,10.1186/s12879-016-1628-6,FALSE,Springer,BMC Infectious Diseases,1471-2334,NA,1471-2334,1471-2334,http://www.springer.com/tdm,TRUE,27329293,PMC4915053,ut:000378587100001,NA,TRUE
+gu,2016,1482,10.1186/s12884-016-0969-x,FALSE,Springer,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,1471-2393,NA,TRUE,27473076,PMC4967348,ut:000380788500001,NA,TRUE
+gu,2016,1482,10.1186/s12885-016-2196-2,FALSE,Springer,BMC Cancer,1471-2407,NA,1471-2407,1471-2407,NA,TRUE,26908052,PMC4763409,ut:000371666500004,NA,TRUE
+gu,2016,1482,10.1186/s12890-016-0306-1,FALSE,Springer,BMC Pulmonary Medicine,1471-2466,NA,1471-2466,1471-2466,http://www.springer.com/tdm,TRUE,27842581,PMC5109668,ut:000388036200001,NA,TRUE
+gu,2016,1482,10.1186/s12891-016-0911-4,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,1471-2474,NA,TRUE,26846791,PMC4743196,ut:000369227700002,NA,TRUE
+gu,2016,1482,10.1186/s12891-016-0960-8,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,1471-2474,NA,TRUE,26922375,PMC4769824,ut:000370919900003,NA,TRUE
+gu,2016,1482,10.1186/s12891-016-1112-x,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,1471-2474,http://www.springer.com/tdm,TRUE,27286829,PMC4901501,ut:000378203700001,NA,TRUE
+gu,2016,1482,10.1186/s12891-016-1154-0,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,1471-2474,http://www.springer.com/tdm,TRUE,27406174,PMC4941027,ut:000379715300001,NA,TRUE
+gu,2016,1482,10.1186/s12891-016-1262-x,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,1471-2474,http://www.springer.com/tdm,TRUE,27716136,PMC5050595,ut:000395029400002,NA,TRUE
+gu,2016,1482,10.1186/s12891-016-1315-1,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,1471-2474,http://www.springer.com/tdm,TRUE,27829407,PMC5103594,ut:000395053300004,NA,TRUE
+gu,2016,1482,10.1186/s12891-016-1354-7,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,1471-2474,http://www.springer.com/tdm,TRUE,27955647,PMC5154076,ut:000395057200002,NA,TRUE
+gu,2016,1482,10.1186/s12894-016-0168-0,FALSE,Springer,BMC Urology,1471-2490,NA,1471-2490,1471-2490,NA,TRUE,27531014,PMC4986175,ut:000381355600001,NA,TRUE
+gu,2016,1482,10.1186/s12898-016-0067-y,FALSE,Springer,BMC Ecology,1472-6785,NA,1472-6785,1472-6785,NA,TRUE,26928449,PMC4772348,ut:000370949700001,NA,TRUE
+gu,2016,1482,10.1186/s12944-016-0342-0,FALSE,Springer,Lipids in Health and Disease,1476-511X,NA,1476-511X,1476-511X,NA,TRUE,27671740,PMC5037885,ut:000384581400001,NA,TRUE
+gu,2016,1482,10.1186/s12947-016-0091-2,FALSE,Springer,Cardiovascular Ultrasound,1476-7120,NA,1476-7120,1476-7120,http://www.springer.com/tdm,TRUE,27919286,PMC5139021,ut:000389300700001,NA,TRUE
+gu,2016,1482,10.1186/s40795-016-0094-2,FALSE,Springer,BMC Nutrition,2055-0928,NA,2055-0928,2055-0928,http://www.springer.com/tdm,TRUE,NA,NA,NA,NA,TRUE
+gu,2016,1490.9,10.1039/C6SM00580B,TRUE,Royal Society of Chemistry (RSC),Soft Matter,1744-683X,1744-683X,1744-6848,1744-683X,NA,TRUE,27112965,NA,ut:000379676800011,NA,FALSE
+gu,2016,1490.9,10.3390/ijerph13080836,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,1660-4601,NA,TRUE,27556476,PMC4997522,ut:000382462900091,NA,TRUE
+gu,2016,1503,10.1186/s13195-016-0208-8,FALSE,Springer,Alzheimer's Research & Therapy,1758-9193,NA,1758-9193,1758-9193,NA,TRUE,NA,NA,ut:000384844800001,NA,TRUE
+gu,2016,1503.8,10.1186/s13601-016-0112-0,FALSE,Springer,Clinical and Translational Allergy,2045-7022,NA,2045-7022,2045-7022,NA,TRUE,27493721,PMC4973051,ut:000390119200001,NA,TRUE
+gu,2016,1524.4,10.1098/rstb.2015.0225,TRUE,The Royal Society,Philosophical Transactions of the Royal Society B: Biological Sciences,0962-8436,0962-8436,1471-2970,0962-8436,NA,TRUE,26977065,PMC4810818,ut:000374436100006,NA,FALSE
+gu,2016,1528.4,10.1186/s40164-016-0047-0,FALSE,Springer,Experimental Hematology & Oncology,2162-3619,NA,2162-3619,2162-3619,NA,TRUE,27366593,PMC4928343,ut:000381115600001,NA,TRUE
+gu,2016,1528.4,10.1186/s40164-016-0053-2,FALSE,Springer,Experimental Hematology & Oncology,2162-3619,NA,2162-3619,2162-3619,NA,TRUE,27525194,PMC4982317,ut:000381686500001,NA,TRUE
+gu,2016,1530,10.1002/ece3.2096,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27127613,PMC4842207,ut:000377043200002,NA,TRUE
+gu,2016,1560,10.1093/sysbio/syw064,TRUE,Oxford University Press (OUP),Systematic Biology,1063-5157,1063-5157,1076-836X,1063-5157,NA,TRUE,27486181,NA,ut:000397703800003,NA,FALSE
+gu,2016,1560,10.1093/sysbio/syw066,TRUE,Oxford University Press (OUP),Systematic Biology,1063-5157,1063-5157,1076-836X,1063-5157,NA,TRUE,27616324,NA,ut:000397703800004,NA,FALSE
+gu,2016,1578.5,10.1186/s12884-016-1144-0,FALSE,Springer,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,1471-2393,http://www.springer.com/tdm,TRUE,NA,NA,ut:000387608100001,NA,TRUE
+gu,2016,1594.3,10.1186/s13148-016-0274-6,FALSE,Springer,Clinical Epigenetics,1868-7075,1868-7075,1868-7083,1868-7075,NA,TRUE,NA,NA,ut:000385308500002,NA,TRUE
+gu,2016,1597.3,10.1186/s13643-016-0344-z,FALSE,Springer,Systematic Reviews,2046-4053,NA,2046-4053,2046-4053,http://www.springer.com/tdm,TRUE,NA,NA,NA,NA,TRUE
+gu,2016,1621.3,10.1155/2016/5482087,FALSE,Hindawi Publishing Corporation,Journal of Immunology Research,2314-8861,2314-8861,2314-7156,2314-7156,http://creativecommons.org/licenses/by/4.0/,TRUE,28127567,PMC5227169,ut:000391978300001,NA,TRUE
+gu,2016,1643.3,10.1186/s12909-016-0749-3,FALSE,Springer,BMC Medical Education,1472-6920,NA,1472-6920,1472-6920,http://www.springer.com/tdm,TRUE,27565878,PMC5002212,ut:000383337200003,NA,TRUE
+gu,2016,1643.3,10.1186/s12913-016-1710-1,FALSE,Springer,BMC Health Services Research,1472-6963,NA,1472-6963,1472-6963,http://www.springer.com/tdm,TRUE,27576359,PMC5006424,ut:000382439900001,NA,TRUE
+gu,2016,1646.2,10.1186/s12868-015-0221-z,FALSE,Springer,BMC Neuroscience,1471-2202,NA,1471-2202,1471-2202,NA,TRUE,26608570,PMC4660658,ut:000365337900002,NA,TRUE
+gu,2016,1686.6,10.1186/s12891-016-0947-5,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,1471-2474,NA,TRUE,26932181,PMC4774121,ut:000371387600001,NA,TRUE
+gu,2016,1692,10.1186/s40168-016-0199-5,FALSE,Springer,Microbiome,2049-2618,NA,2049-2618,2049-2618,NA,TRUE,NA,NA,ut:000385047800002,NA,TRUE
+gu,2016,1701.3,10.1080/00219266.2016.1233130,TRUE,Taylor & Francis,Journal of Biological Education,0021-9266,0021-9266,2157-6009,0021-9266,NA,TRUE,NA,NA,NA,NA,FALSE
+gu,2016,1705,10.1161/JAHA.115.003071,FALSE,Wolters Kluwer,Journal of the American Heart Association,2047-9980,2047-9980,2047-9980,2047-9980,NA,TRUE,26908411,PMC4802444,ut:000378131100032,NA,TRUE
+gu,2016,1710,10.5194/hess-20-3719-2016,FALSE,Copernicus Publications,Hydrology and Earth System Sciences,1607-7938,NA,1607-7938,1027-5606,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000384116700001,NA,TRUE
+gu,2016,1740.45,10.1016/j.vaccine.2016.04.055,TRUE,Elsevier,Vaccine,0264-410X,0264-410X,NA,0264-410X,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27133878,NA,ut:000378667900019,NA,FALSE
+gu,2016,1743,10.1186/s12884-016-0836-9,FALSE,Springer,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,1471-2393,NA,TRUE,26951777,PMC4782290,ut:000371575400001,NA,TRUE
+gu,2016,1743,10.1186/s13102-016-0054-9,FALSE,Springer,"BMC Sports Science, Medicine and Rehabilitation",2052-1847,NA,2052-1847,2052-1847,NA,TRUE,27602228,PMC5011845,ut:000386707600001,NA,TRUE
+gu,2016,1743,10.1186/s40842-016-0026-8,FALSE,Springer,Clinical Diabetes and Endocrinology,2055-8260,NA,2055-8260,2055-8260,NA,TRUE,28702241,PMC5471721,NA,NA,TRUE
+gu,2016,1756.8,10.1186/s12859-016-1134-2,FALSE,Springer,BMC Bioinformatics,1471-2105,NA,1471-2105,1471-2105,NA,TRUE,27334112,PMC4917999,ut:000378846600001,NA,TRUE
+gu,2016,1756.8,10.1186/s12863-016-0382-5,FALSE,Springer,BMC Genetics,1471-2156,NA,1471-2156,1471-2156,NA,TRUE,27245440,PMC4886457,ut:000377077500001,NA,TRUE
+gu,2016,1782.4,10.1186/s13075-016-1141-8,FALSE,Springer,Arthritis Research & Therapy,1478-6362,NA,1478-6362,1478-6354,NA,TRUE,NA,NA,ut:000386169500001,NA,FALSE
+gu,2016,1784.3,10.3402/ecrj.v3.30319,FALSE,Taylor & Francis,European Clinical Respiratory Journal,2001-8525,NA,2001-8525,2001-8525,NA,TRUE,27421832,PMC4947195,ut:000381816000001,NA,TRUE
+gu,2016,1788,10.3389/fimmu.2016.00001,FALSE,Frontiers,Frontiers in Immunology,1664-3224,NA,1664-3224,1664-3224,NA,TRUE,26834743,PMC4717187,ut:000368433400001,NA,TRUE
+gu,2016,1788,10.3389/fnbeh.2016.00041,FALSE,Frontiers,Frontiers in Behavioral Neuroscience,1662-5153,NA,1662-5153,1662-5153,NA,TRUE,27014003,PMC4792870,ut:000371975500001,NA,TRUE
+gu,2016,1788,10.3389/fncel.2016.00054,FALSE,Frontiers,Frontiers in Cellular Neuroscience,1662-5102,NA,1662-5102,1662-5102,NA,TRUE,26973467,PMC4777716,ut:000371294100001,NA,TRUE
+gu,2016,1788,10.3389/fpsyg.2016.01012,FALSE,Frontiers,Frontiers in Psychology,1664-1078,NA,1664-1078,1664-1078,NA,TRUE,27445957,PMC4927566,ut:000378787500001,NA,TRUE
+gu,2016,1801,10.1186/s13054-015-1181-5,FALSE,Springer,Critical Care,1364-8535,NA,1364-8535,1364-8535,NA,TRUE,26781032,PMC4717610,ut:000368233700001,NA,TRUE
+gu,2016,1801,10.1186/s13075-016-0917-1,FALSE,Springer,Arthritis Research & Therapy,1478-6362,NA,1478-6362,1478-6354,NA,TRUE,26785608,PMC4718040,ut:000368223300001,NA,FALSE
+gu,2016,1847,10.1111/eva.12335,FALSE,Wiley,Evolutionary Applications,1752-4571,NA,NA,1752-4571,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000387763200007,NA,TRUE
+gu,2016,1893,10.1186/s13075-016-1062-6,FALSE,Springer,Arthritis Research & Therapy,1478-6362,NA,1478-6362,1478-6354,NA,TRUE,27412614,PMC4944470,ut:000379725700003,NA,FALSE
+gu,2016,1893,10.1186/s13075-016-1073-3,FALSE,Springer,Arthritis Research & Therapy,1478-6362,NA,1478-6362,1478-6354,NA,TRUE,27473164,PMC4967304,ut:000381728500002,NA,FALSE
+gu,2016,1927.88,10.1016/j.chiabu.2016.06.001,TRUE,Elsevier,Child Abuse & Neglect,0145-2134,0145-2134,NA,0145-2134,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27286134,NA,ut:000379379300003,NA,FALSE
+gu,2016,1927.88,10.1016/j.worlddev.2016.03.006,TRUE,Elsevier,World Development,0305-750X,0305-750X,NA,0305-750X,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000375628900005,NA,FALSE
+gu,2016,1982,10.1038/ncomms11050,FALSE,Springer,Nature Communications,2041-1723,NA,2041-1723,2041-1723,NA,TRUE,26996674,PMC4802176,ut:000372499700001,NA,TRUE
+gu,2016,2025,10.1371/journal.pgen.1006000,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,1553-7390,http://creativecommons.org/licenses/by/4.0/,TRUE,27171399,PMC4865040,ut:000377197100010,NA,TRUE
+gu,2016,2025,10.1371/journal.pntd.0004312,FALSE,Public Library of Science (PLoS),PLOS Neglected Tropical Diseases,1935-2735,NA,1935-2735,1935-2727,https://creativecommons.org/publicdomain/zero/1.0/,TRUE,26820516,PMC4731218,ut:000372565700029,NA,TRUE
+gu,2016,2083,10.1111/evo.12957,TRUE,Wiley,Evolution,0014-3820,NA,NA,0014-3820,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27196373,PMC5089645,ut:000380023200015,NA,FALSE
+gu,2016,2130,10.1016/j.neurobiolaging.2015.11.010,TRUE,Elsevier,Neurobiology of Aging,0197-4580,0197-4580,NA,0197-4580,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26827644,PMC5125016,ut:000368991300008,NA,FALSE
+gu,2016,2130,10.1093/nar/gkw302,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,0305-1048,NA,TRUE,27112570,PMC4937320,ut:000381210900024,NA,TRUE
+gu,2016,2130,10.1093/nar/gkw468,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,0305-1048,NA,TRUE,27220468,PMC4937333,ut:000381210900034,NA,TRUE
+gu,2016,2130,10.1093/nar/gkw674,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,0305-1048,NA,TRUE,NA,NA,ut:000388016900005,NA,TRUE
+gu,2016,2140.89,10.1371/journal.pgen.1005982,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,1553-7390,http://creativecommons.org/licenses/by/4.0/,TRUE,27082444,PMC4833288,ut:000375231900031,NA,TRUE
+gu,2016,2150,10.1080/00141844.2016.1213760,TRUE,Taylor & Francis,Ethnos,0014-1844,0014-1844,1469-588X,0014-1844,NA,TRUE,NA,NA,NA,NA,FALSE
+gu,2016,2150,10.1080/14623943.2016.1178633,TRUE,Taylor & Francis,Reflective Practice,1462-3943,1462-3943,1470-1103,1462-3943,NA,TRUE,NA,NA,ut:000377026900011,NA,FALSE
+gu,2016,2150,10.1080/17550874.2016.1264017,TRUE,Taylor & Francis,Plant Ecology & Diversity,1755-0874,1755-0874,1755-1668,1755-0874,NA,TRUE,NA,NA,ut:000395073700010,NA,FALSE
+gu,2016,2200,10.1007/s00125-016-4171-5,TRUE,Springer,Diabetologia,0012-186X,0012-186X,1432-0428,0012-186X,http://creativecommons.org/licenses/by/4.0,TRUE,27981357,NA,ut:000394462100020,NA,FALSE
+gu,2016,2200,10.1007/s00167-016-4280-1,TRUE,Springer,"Knee Surgery, Sports Traumatology, Arthroscopy",0942-2056,0942-2056,1433-7347,0942-2056,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000401438900003,NA,FALSE
+gu,2016,2200,10.1007/s00167-016-4387-4,TRUE,Springer,"Knee Surgery, Sports Traumatology, Arthroscopy",0942-2056,0942-2056,1433-7347,0942-2056,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+gu,2016,2200,10.1007/s00167-016-4399-0,TRUE,Springer,"Knee Surgery, Sports Traumatology, Arthroscopy",0942-2056,0942-2056,1433-7347,0942-2056,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000401438900023,NA,FALSE
+gu,2016,2200,10.1007/s00191-016-0478-0,TRUE,Springer,Journal of Evolutionary Economics,0936-9937,0936-9937,1432-1386,0936-9937,http://creativecommons.org/licenses/by/4.0,TRUE,28163393,PMC5253718,ut:000385250000006,NA,FALSE
+gu,2016,2200,10.1007/s00198-016-3738-9,TRUE,Springer,Osteoporosis International,0937-941X,0937-941X,1433-2965,0937-941X,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27585578,PMC5206252,ut:000391390100009,NA,FALSE
+gu,2016,2200,10.1007/s00198-016-3846-6,TRUE,Springer,Osteoporosis International,0937-941X,0937-941X,1433-2965,0937-941X,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27921145,PMC5306148,ut:000394258000040,NA,FALSE
+gu,2016,2200,10.1007/s00216-016-9812-5,TRUE,Springer,Analytical and Bioanalytical Chemistry,1618-2642,1618-2642,1618-2650,1618-2642,http://creativecommons.org/licenses/by/4.0,TRUE,27549796,PMC5012256,ut:000382883300032,NA,FALSE
+gu,2016,2200,10.1007/s00227-016-2984-x,TRUE,Springer,Marine Biology,0025-3162,0025-3162,1432-1793,0025-3162,http://creativecommons.org/licenses/by/4.0,TRUE,27729710,PMC5030223,ut:000386356100015,NA,FALSE
+gu,2016,2200,10.1007/s00265-016-2215-y,TRUE,Springer,Behavioral Ecology and Sociobiology,0340-5443,0340-5443,1432-0762,0340-5443,http://creativecommons.org/licenses/by/4.0,TRUE,27881895,PMC5102978,ut:000387656900012,NA,FALSE
+gu,2016,2200,10.1007/s00266-016-0684-z,TRUE,Springer,Aesthetic Plastic Surgery,0364-216X,0364-216X,1432-5241,0364-216X,http://creativecommons.org/licenses/by/4.0,TRUE,27495261,PMC5030227,ut:000384437600012,NA,FALSE
+gu,2016,2200,10.1007/s00267-016-0786-z,TRUE,Springer,Environmental Management,0364-152X,0364-152X,1432-1009,0364-152X,http://creativecommons.org/licenses/by/4.0,TRUE,27838769,PMC5274640,ut:000394257700005,NA,FALSE
+gu,2016,2200,10.1007/s00268-016-3632-9,TRUE,Springer,World Journal of Surgery,0364-2313,0364-2313,1432-2323,0364-2313,http://creativecommons.org/licenses/by/4.0,TRUE,27417107,PMC5104810,ut:000387709300006,NA,FALSE
+gu,2016,2200,10.1007/s00382-016-3426-7,TRUE,Springer,Climate Dynamics,0930-7575,0930-7575,1432-0894,0930-7575,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000408718200024,NA,FALSE
+gu,2016,2200,10.1007/s00382-016-3452-5,TRUE,Springer,Climate Dynamics,0930-7575,0930-7575,1432-0894,0930-7575,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+gu,2016,2200,10.1007/s00384-016-2628-0,TRUE,Springer,International Journal of Colorectal Disease,0179-1958,0179-1958,1432-1262,0179-1958,http://creativecommons.org/licenses/by/4.0,TRUE,27506432,PMC5031731,ut:000385147000005,NA,FALSE
+gu,2016,2200,10.1007/s00384-016-2636-0,TRUE,Springer,International Journal of Colorectal Disease,0179-1958,0179-1958,1432-1262,0179-1958,http://creativecommons.org/licenses/by/4.0,TRUE,27567926,PMC5285409,ut:000394159500001,NA,FALSE
+gu,2016,2200,10.1007/s00408-016-9937-5,TRUE,Springer,Lung,0341-2040,0341-2040,1432-1750,0341-2040,http://creativecommons.org/licenses/by/4.0,TRUE,27638152,PMC5093197,ut:000387361100015,NA,FALSE
+gu,2016,2200,10.1007/s00420-016-1163-1,TRUE,Springer,International Archives of Occupational and Environmental Health,0340-0131,0340-0131,1432-1246,0340-0131,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000385249600012,NA,FALSE
+gu,2016,2200,10.1007/s00420-016-1180-0,TRUE,Springer,International Archives of Occupational and Environmental Health,0340-0131,0340-0131,1432-1246,0340-0131,http://creativecommons.org/licenses/by/4.0,TRUE,27815725,PMC5263194,ut:000393824400001,NA,FALSE
+gu,2016,2200,10.1007/s00464-016-5096-2,TRUE,Springer,Surgical Endoscopy,0930-2794,0930-2794,1432-2218,0930-2794,http://creativecommons.org/licenses/by/4.0,TRUE,27422249,PMC5315718,ut:000395075000026,NA,FALSE
+gu,2016,2200,10.1007/s00701-016-3040-9,TRUE,Springer,Acta Neurochirurgica,0001-6268,0001-6268,0942-0940,0001-6268,http://creativecommons.org/licenses/by/4.0,TRUE,27928631,PMC5241331,ut:000393022200028,NA,FALSE
+gu,2016,2200,10.1007/s10096-016-2854-y,TRUE,Springer,European Journal of Clinical Microbiology & Infectious Diseases,0934-9723,0934-9723,1435-4373,0934-9723,http://creativecommons.org/licenses/by/4.0,TRUE,27924435,NA,ut:000398838200018,NA,FALSE
+gu,2016,2200,10.1007/s10113-015-0895-x,TRUE,Springer,Regional Environmental Change,1436-3798,1436-3798,1436-378X,1436-3798,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000381212500005,NA,FALSE
+gu,2016,2200,10.1007/s10308-016-0464-z,TRUE,Springer,Asia Europe Journal,1610-2932,1610-2932,1612-1031,1612-1031,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000394368400005,NA,FALSE
+gu,2016,2200,10.1007/s10439-016-1776-2,TRUE,Springer,Annals of Biomedical Engineering,0090-6964,0090-6964,1573-9686,0090-6964,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000404604800012,NA,FALSE
+gu,2016,2200,10.1007/s10545-016-9978-1,TRUE,Springer,Journal of Inherited Metabolic Disease,0141-8955,0141-8955,1573-2665,0141-8955,http://creativecommons.org/licenses/by/4.0,TRUE,27718144,PMC5203857,ut:000391132500011,NA,FALSE
+gu,2016,2200,10.1007/s10639-016-9546-1,TRUE,Springer,Education and Information Technologies,1360-2357,1360-2357,1573-7608,1360-2357,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+gu,2016,2200,10.1007/s10641-016-0550-5,TRUE,Springer,Environmental Biology of Fishes,0378-1909,0378-1909,1573-5133,0378-1909,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388829900008,NA,FALSE
+gu,2016,2200,10.1007/s10689-016-9934-0,TRUE,Springer,Familial Cancer,1389-9600,1389-9600,1573-7292,1389-9600,http://creativecommons.org/licenses/by/4.0,TRUE,27696107,PMC5357488,ut:000398494700005,NA,FALSE
+gu,2016,2200,10.1007/s10763-016-9781-3,TRUE,Springer,International Journal of Science and Mathematics Education,1571-0068,1571-0068,1573-1774,1571-0068,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+gu,2016,2200,10.1007/s10767-016-9241-7,TRUE,Springer,"International Journal of Politics, Culture, and Society",0891-4486,0891-4486,1573-3416,0891-4486,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+gu,2016,2200,10.1007/s10822-016-9926-z,TRUE,Springer,Journal of Computer-Aided Molecular Design,0920-654X,0920-654X,1573-4951,0920-654X,http://creativecommons.org/licenses/by/4.0,TRUE,27460060,PMC5206257,ut:000391459000004,NA,FALSE
+gu,2016,2200,10.1007/s10856-016-5779-1,TRUE,Springer,Journal of Materials Science: Materials in Medicine,0957-4530,0957-4530,1573-4838,0957-4530,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000384473000008,NA,FALSE
+gu,2016,2200,10.1007/s10856-016-5814-2,TRUE,Springer,Journal of Materials Science: Materials in Medicine,0957-4530,0957-4530,1573-4838,0957-4530,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000391394200009,NA,FALSE
+gu,2016,2200,10.1007/s10955-016-1607-8,TRUE,Springer,Journal of Statistical Physics,0022-4715,0022-4715,1572-9613,0022-4715,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000383580100005,NA,FALSE
+gu,2016,2200,10.1007/s10995-016-2199-2,TRUE,Springer,Maternal and Child Health Journal,1092-7875,1092-7875,1573-6628,1092-7875,http://creativecommons.org/licenses/by/4.0,TRUE,28032239,NA,ut:000399410300011,NA,FALSE
+gu,2016,2200,10.1007/s11017-016-9393-5,TRUE,Springer,Theoretical Medicine and Bioethics,1386-7415,1386-7415,1573-1200,1386-7415,http://creativecommons.org/licenses/by/4.0,TRUE,28040857,PMC5325837,ut:000397202300001,NA,FALSE
+gu,2016,2200,10.1007/s11060-016-2202-1,TRUE,Springer,Journal of Neuro-Oncology,0167-594X,0167-594X,1573-7373,0167-594X,http://creativecommons.org/licenses/by/4.0,TRUE,27423645,PMC5020107,ut:000384563800015,NA,FALSE
+gu,2016,2200,10.1007/s11102-016-0764-8,TRUE,Springer,Pituitary,1386-341X,1386-341X,1573-7403,1386-341X,http://creativecommons.org/licenses/by/4.0,TRUE,27743172,PMC5357499,ut:000398474800006,NA,FALSE
+gu,2016,2200,10.1007/s11118-016-9590-x,TRUE,Springer,Potential Analysis,0926-2601,0926-2601,1572-929X,0926-2601,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000399019100003,NA,FALSE
+gu,2016,2200,10.1007/s11229-016-1217-7,TRUE,Springer,Synthese,0039-7857,0039-7857,1573-0964,0039-7857,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+gu,2016,2200,10.1007/s11252-016-0581-x,TRUE,Springer,Urban Ecosystems,1083-8155,1083-8155,1573-1642,1083-8155,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000397021300003,NA,FALSE
+gu,2016,2200,10.1007/s11883-016-0614-1,TRUE,Springer,Current Atherosclerosis Reports,1523-3804,1523-3804,1534-6242,1523-3804,http://creativecommons.org/licenses/by/4.0,TRUE,27613744,PMC5018018,ut:000384570700001,NA,FALSE
+gu,2016,2200,10.1007/s11896-016-9206-9,TRUE,Springer,Journal of Police and Criminal Psychology,0882-0783,0882-0783,1936-6469,0882-0783,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+gu,2016,2200,10.1007/s12187-016-9416-9,TRUE,Springer,Child Indicators Research,1874-897X,1874-897X,1874-8988,1874-897X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+gu,2016,2200,10.1007/s12526-016-0566-2,TRUE,Springer,Marine Biodiversity,1867-1616,1867-1616,1867-1624,1867-1616,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+gu,2016,2200,10.1007/s13280-016-0848-8,TRUE,Springer,Ambio,0044-7447,0044-7447,1654-7209,0044-7447,http://creativecommons.org/licenses/by/4.0,TRUE,27844420,PMC5347527,ut:000397818800007,NA,FALSE
+gu,2016,2200,10.1007/s13361-016-1539-1,TRUE,Springer,Journal of The American Society for Mass Spectrometry,1044-0305,1044-0305,1879-1123,1044-0305,http://creativecommons.org/licenses/by/4.0,TRUE,27873218,PMC5227003,ut:000392319600003,NA,FALSE
+gu,2016,2200,10.1007/s13365-016-0500-1,TRUE,Springer,Journal of NeuroVirology,1355-0284,1355-0284,1538-2443,1355-0284,http://creativecommons.org/licenses/by/4.0,TRUE,27913959,PMC5332498,ut:000396214900013,NA,FALSE
+gu,2016,2200,10.1007/s13437-016-0114-8,TRUE,Springer,WMU Journal of Maritime Affairs,1651-436X,1651-436X,1654-1642,1651-436X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+gu,2016,2200,10.1007/s40141-016-0128-3,TRUE,Springer,Current Physical Medicine and Rehabilitation Reports,2167-4833,NA,2167-4833,2167-4833,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+gu,2016,2200,10.1007/s40368-016-0256-6,TRUE,Springer,European Archives of Paediatric Dentistry,1818-6300,1818-6300,1996-9805,1818-6300,http://creativecommons.org/licenses/by/4.0,TRUE,27830462,PMC5126186,ut:000389467200007,NA,FALSE
+gu,2016,2224.1,10.1186/s13075-016-1037-7,FALSE,Springer,Arthritis Research & Therapy,1478-6362,NA,1478-6362,1478-6354,NA,TRUE,27301320,PMC4908726,ut:000377977600002,NA,FALSE
+gu,2016,223,10.1016/j.dib.2015.12.003,FALSE,Elsevier,Data in Brief,2352-3409,2352-3409,NA,2352-3409,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26862586,PMC4707292,NA,NA,TRUE
+gu,2016,2231.35,10.1016/j.ijrobp.2016.05.007,TRUE,Elsevier,International Journal of Radiation Oncology*Biology*Physics,0360-3016,0360-3016,NA,0360-3016,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27475671,NA,ut:000385521900025,NA,FALSE
+gu,2016,2231.35,10.1016/j.jacl.2016.02.015,TRUE,Elsevier,Journal of Clinical Lipidology,1933-2874,1933-2874,NA,1876-4789,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27578112,NA,ut:000383114900013,NA,FALSE
+gu,2016,2250,10.1093/molbev/msw066,TRUE,Oxford University Press (OUP),Molecular Biology and Evolution,0737-4038,0737-4038,1537-1719,0737-4038,NA,TRUE,27189557,PMC4948705,ut:000380105900004,NA,FALSE
+gu,2016,2275,10.1093/rheumatology/kew192,TRUE,Oxford University Press (OUP),Rheumatology,1462-0324,1462-0324,1462-0332,1462-0324,NA,TRUE,27121779,PMC4957673,ut:000383847200019,NA,FALSE
+gu,2016,2275,10.1093/rpd/ncw041,TRUE,Oxford University Press (OUP),Radiation Protection Dosimetry,0144-8420,0144-8420,1742-3406,0144-8420,NA,TRUE,26994093,PMC4911967,ut:000383492100028,NA,FALSE
+gu,2016,2275,10.1093/rpd/ncw046,TRUE,Oxford University Press (OUP),Radiation Protection Dosimetry,0144-8420,0144-8420,1742-3406,0144-8420,NA,TRUE,27012883,PMC4911968,ut:000383492100040,NA,FALSE
+gu,2016,2320.6,10.1016/j.bbr.2016.04.015,TRUE,Elsevier,Behavioural Brain Research,0166-4328,0166-4328,NA,0166-4328,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27083304,NA,ut:000377833200017,NA,FALSE
+gu,2016,2343,10.3389/fnagi.2016.00225,FALSE,Frontiers,Frontiers in Aging Neuroscience,1663-4365,NA,1663-4365,1663-4365,NA,TRUE,NA,NA,ut:000384611900001,NA,TRUE
+gu,2016,2343,10.3389/fnbeh.2016.00178,FALSE,Frontiers,Frontiers in Behavioral Neuroscience,1662-5153,NA,1662-5153,1662-5153,NA,TRUE,NA,NA,ut:000383767100001,NA,TRUE
+gu,2016,2343,10.3389/fpls.2016.01051,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,1664-462X,NA,TRUE,27489553,PMC4951524,ut:000379906000001,NA,TRUE
+gu,2016,2343,10.3389/fpsyg.2016.01808,FALSE,Frontiers,Frontiers in Psychology,1664-1078,NA,1664-1078,1664-1078,NA,TRUE,NA,NA,ut:000388330000001,NA,TRUE
+gu,2016,2345.1,10.1016/j.jelechem.2016.11.011,TRUE,Elsevier,Journal of Electroanalytical Chemistry,1572-6657,1572-6657,NA,1572-6657,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000390627500001,NA,FALSE
+gu,2016,2345.1,10.1016/j.neuropharm.2016.07.039,TRUE,Elsevier,Neuropharmacology,0028-3908,0028-3908,NA,0028-3908,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27496691,NA,ut:000385318100038,NA,FALSE
+gu,2016,2345.1,10.1016/j.yhbeh.2016.07.008,TRUE,Elsevier,Hormones and Behavior,0018-506X,0018-506X,NA,0018-506X,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27487416,NA,ut:000383819400010,NA,FALSE
+gu,2016,2368.66,10.1002/pro.3046,TRUE,Wiley,Protein Science,0961-8368,NA,NA,0961-8368,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27643892,PMC5119558,ut:000389218500008,NA,FALSE
+gu,2016,2450,10.1093/hmg/ddw341,TRUE,Oxford University Press (OUP),Human Molecular Genetics,0964-6906,0964-6906,1460-2083,0964-6906,NA,TRUE,27742777,NA,ut:000397063300013,NA,FALSE
+gu,2016,2454.48,10.1016/j.psyneuen.2015.11.021,TRUE,Elsevier,Psychoneuroendocrinology,0306-4530,0306-4530,NA,0306-4530,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26724568,NA,ut:000370902500008,NA,FALSE
+gu,2016,246.2,10.1080/23723556.2015.1124174,TRUE,Taylor & Francis,Molecular & Cellular Oncology,2372-3556,NA,2372-3556,2372-3556,NA,TRUE,27308621,PMC4905420,ut:000385247100056,NA,FALSE
+gu,2016,2550,10.1093/eurheartj/ehw221,TRUE,Oxford University Press (OUP),European Heart Journal,0195-668X,0195-668X,1522-9645,0195-668X,NA,TRUE,NA,NA,ut:000403828700017,NA,FALSE
+gu,2016,2597,10.1093/nar/gkw224,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,0305-1048,NA,TRUE,27060140,PMC4914102,ut:000379753100005,NA,TRUE
+gu,2016,2610,10.1371/journal.pmed.1002156,FALSE,Public Library of Science (PLoS),PLOS Medicine,1549-1676,NA,1549-1676,1549-1277,http://creativecommons.org/licenses/by/4.0/,TRUE,27727282,PMC5058554,ut:000387656000020,NA,TRUE
+gu,2016,2627,10.1017/S0007123416000508,TRUE,Cambridge University Press (CUP),British Journal of Political Science,0007-1234,0007-1234,1469-2112,0007-1234,NA,TRUE,NA,NA,NA,NA,FALSE
+gu,2016,2641,10.18632/oncotarget.8508,FALSE,Impact Journals,OncoTarget,1949-2553,NA,1949-2553,1949-2553,NA,TRUE,27049722,PMC5045374,ut:000377742600021,NA,FALSE
+gu,2016,2705.88,10.1016/j.csr.2016.09.005,TRUE,Elsevier,Continental Shelf Research,0278-4343,0278-4343,NA,0278-4343,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000393005500005,NA,FALSE
+gu,2016,2750,10.1007/s00198-015-3445-y,TRUE,Springer,Osteoporosis International,0937-941X,0937-941X,1433-2965,0937-941X,http://creativecommons.org/licenses/by-nc/4.0,TRUE,26659067,PMC4839051,ut:000374564800007,NA,FALSE
+gu,2016,2750,10.1007/s00198-016-3643-2,TRUE,Springer,Osteoporosis International,0937-941X,0937-941X,1433-2965,0937-941X,http://creativecommons.org/licenses/by-nc/4.0,TRUE,NA,NA,ut:000388954600006,NA,FALSE
+gu,2016,2750,10.1007/s12678-016-0310-5,TRUE,Springer,Electrocatalysis,1868-2529,1868-2529,1868-5994,1868-2529,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000378805400008,NA,FALSE
+gu,2016,2779,10.1002/2015JC011451,TRUE,Wiley,Journal of Geophysical Research: Oceans,2169-9275,NA,NA,2169-9275,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000378072700031,NA,FALSE
+gu,2016,2779,10.1002/acr.22868,TRUE,Wiley,Arthritis Care & Research,2151-464X,NA,NA,2151-464X,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26881821,PMC5129496,ut:000387058800007,NA,FALSE
+gu,2016,2779,10.1002/jbmr.2743,TRUE,Wiley,Journal of Bone and Mineral Research,0884-0431,NA,NA,0884-0431,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26572678,PMC4832374,ut:000374008200005,NA,FALSE
+gu,2016,2779,10.1002/jbmr.3006,TRUE,Wiley,Journal of Bone and Mineral Research,0884-0431,NA,NA,0884-0431,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27676223,NA,ut:000398055900008,NA,FALSE
+gu,2016,2779,10.1111/1460-6984.12302,TRUE,Wiley,International Journal of Language & Communication Disorders,1368-2822,NA,NA,1368-2822,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28039933,NA,ut:000408851500003,NA,FALSE
+gu,2016,2779,10.1111/aogs.13054,TRUE,Wiley,Acta Obstetricia et Gynecologica Scandinavica,0001-6349,NA,NA,0001-6349,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27861716,NA,ut:000391980100005,NA,FALSE
+gu,2016,2779,10.1111/apa.13295,TRUE,Wiley,Acta Paediatrica,0803-5253,NA,NA,0803-5253,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26648201,PMC5066675,ut:000371892200021,NA,FALSE
+gu,2016,2779,10.1111/apa.13407,TRUE,Wiley,Acta Paediatrica,0803-5253,NA,NA,0803-5253,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26999007,PMC5074256,ut:000382741100022,NA,FALSE
+gu,2016,2779,10.1111/apa.13531,TRUE,Wiley,Acta Paediatrica,0803-5253,NA,NA,0803-5253,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27426283,PMC5095866,ut:000383619400020,NA,FALSE
+gu,2016,2779,10.1111/bcpt.12613,TRUE,Wiley,Basic & Clinical Pharmacology & Toxicology,1742-7835,NA,NA,1742-7835,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27112967,NA,ut:000385819100007,NA,FALSE
+gu,2016,2779,10.1111/hiv.12431,TRUE,Wiley,HIV Medicine,1464-2662,NA,NA,1464-2662,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27535540,PMC5347969,ut:000395071300009,NA,FALSE
+gu,2016,279.5,10.3390/jfb7010007,FALSE,MDPI,Journal of Functional Biomaterials,2079-4983,NA,2079-4983,2079-4983,NA,TRUE,26999231,PMC4810066,NA,NA,TRUE
+gu,2016,2791,10.1002/ana.24677,TRUE,Wiley,Annals of Neurology,0364-5134,NA,NA,0364-5134,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27130143,PMC5084793,ut:000379939300004,NA,FALSE
+gu,2016,2791,10.1002/jbmr.2509,TRUE,Wiley,Journal of Bone and Mineral Research,0884-0431,NA,NA,0884-0431,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25777580,NA,ut:000359866800017,NA,FALSE
+gu,2016,2791,10.1111/adb.12355,TRUE,Wiley,Addiction Biology,1355-6215,NA,NA,1355-6215,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26769653,NA,ut:000400600700004,NA,FALSE
+gu,2016,2791,10.1111/apa.13350,TRUE,Wiley,Acta Paediatrica,0803-5253,NA,NA,0803-5253,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26833743,PMC5069563,ut:000376265400012,NA,FALSE
+gu,2016,2791,10.1111/azo.12164,TRUE,Wiley,Acta Zoologica,0001-7272,NA,NA,1463-6395,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000397949500010,NA,FALSE
+gu,2016,2796.08,10.1016/j.jcis.2016.09.005,TRUE,Elsevier,Journal of Colloid and Interface Science,0021-9797,0021-9797,NA,0021-9797,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27619384,NA,ut:000385690200028,NA,FALSE
+gu,2016,2800,10.1038/tp.2016.104,FALSE,Springer,Translational Psychiatry,2158-3188,NA,2158-3188,2158-3188,NA,TRUE,27271860,PMC4931602,ut:000383416900006,NA,TRUE
+gu,2016,2800,10.1038/tp.2016.12,FALSE,Springer,Translational Psychiatry,2158-3188,NA,2158-3188,2158-3188,NA,TRUE,27003188,PMC4872438,ut:000373905600002,NA,TRUE
+gu,2016,2842.39,10.1002/dys.1545,TRUE,Wiley,Dyslexia,1076-9242,NA,NA,1076-9242,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27892641,NA,ut:000394961900003,NA,FALSE
+gu,2016,2851,10.1177/0010414015626445,TRUE,SAGE Publications,Comparative Political Studies,0010-4140,0010-4140,1552-3829,0010-4140,NA,TRUE,NA,NA,ut:000400003800003,NA,FALSE
+gu,2016,2900,10.1038/npp.2016.118,TRUE,Springer,Neuropsychopharmacology,0893-133X,0893-133X,1740-634X,0893-133X,NA,TRUE,27388328,PMC5101553,ut:000387570700012,NA,FALSE
+gu,2016,2976.47,10.1016/j.ijcard.2016.06.037,TRUE,Elsevier,International Journal of Cardiology,0167-5273,0167-5273,NA,0167-5273,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27376234,NA,ut:000380817400076,NA,FALSE
+gu,2016,2976.47,10.1016/j.ijcard.2016.07.060,TRUE,Elsevier,International Journal of Cardiology,0167-5273,0167-5273,NA,0167-5273,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27441475,NA,ut:000384692600181,NA,FALSE
+gu,2016,3123.89,10.1016/j.biomaterials.2016.01.034,TRUE,Elsevier,Biomaterials,0142-9612,0142-9612,NA,0142-9612,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26828682,NA,ut:000371367500015,NA,FALSE
+gu,2016,3201.96,10.1016/j.bbadis.2016.11.033,TRUE,Elsevier,Biochimica et Biophysica Acta (BBA) - Molecular Basis of Disease,0925-4439,0925-4439,NA,0925-4439,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27915033,NA,ut:000394190300004,NA,FALSE
+gu,2016,3242,10.1002/jbm.a.35935,TRUE,Wiley,Journal of Biomedical Materials Research Part A,1549-3296,NA,NA,1549-3296,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27750392,PMC5216444,ut:000392506300023,NA,FALSE
+gu,2016,3256,10.1002/2015JC011112,TRUE,Wiley,Journal of Geophysical Research: Oceans,2169-9275,NA,NA,2169-9275,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000373134600022,NA,FALSE
+gu,2016,3256,10.1111/1462-2920.13557,TRUE,Wiley,Environmental Microbiology,1462-2912,NA,NA,1462-2912,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27696654,NA,ut:000392946900023,NA,FALSE
+gu,2016,3300,10.1038/npjpcrm.2015.82,FALSE,Springer,npj Primary Care Respiratory Medicine,2055-1010,NA,2055-1010,2055-1010,http://www.springer.com/tdm,TRUE,26845513,PMC4741287,ut:000369423300001,NA,TRUE
+gu,2016,3355.3,10.1016/j.apergo.2016.06.012,TRUE,Elsevier,Applied Ergonomics,0003-6870,0003-6870,NA,0003-6870,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27633215,NA,ut:000384776100024,NA,FALSE
+gu,2016,3427.45,10.1016/j.rse.2016.11.013,TRUE,Elsevier,Remote Sensing of Environment,0034-4257,0034-4257,NA,0034-4257,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000393005400006,NA,FALSE
+gu,2016,3464.6,10.1136/bmj.i4070,FALSE,BMJ,BMJ,1756-1833,NA,1756-1833,1756-1833,http://www.bmj.org/licenses/tdm/1.0/terms-and-conditions.html,TRUE,27492939,PMC4975020,ut:000381081300003,NA,FALSE
+gu,2016,3474,10.1002/bjs.10230,TRUE,Wiley,British Journal of Surgery,0007-1323,NA,NA,0007-1323,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27548306,PMC5095815,ut:000384671500018,NA,FALSE
+gu,2016,3474,10.1002/jbmr.3002,TRUE,Wiley,Journal of Bone and Mineral Research,0884-0431,NA,NA,0884-0431,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27664946,NA,ut:000398055900006,NA,FALSE
+gu,2016,3474,10.1111/apa.13515,TRUE,Wiley,Acta Paediatrica,0803-5253,NA,NA,0803-5253,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27381249,PMC5129460,ut:000387793000033,NA,FALSE
+gu,2016,3474,10.1111/jgs.14439,TRUE,Wiley,Journal of the American Geriatrics Society,0002-8614,NA,NA,0002-8614,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27689675,NA,ut:000388335600037,NA,FALSE
+gu,2016,3474,10.1111/joim.12514,TRUE,Wiley,Journal of Internal Medicine,0954-6820,NA,NA,0954-6820,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27196563,NA,ut:000386917400008,NA,FALSE
+gu,2016,3474,10.1111/joim.12572,TRUE,Wiley,Journal of Internal Medicine,0954-6820,NA,NA,0954-6820,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27925333,NA,ut:000394893800004,NA,FALSE
+gu,2016,3480.91,10.1016/j.cocis.2016.02.005,TRUE,Elsevier,Current Opinion in Colloid & Interface Science,1359-0294,1359-0294,NA,1359-0294,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000378963200006,NA,FALSE
+gu,2016,354,10.1177/2333393615599168,FALSE,SAGE Publications,Global Qualitative Nursing Research,2333-3936,2333-3936,2333-3936,2333-3936,NA,TRUE,NA,NA,NA,NA,TRUE
+gu,2016,354,10.1177/2333393616630672,FALSE,SAGE Publications,Global Qualitative Nursing Research,2333-3936,NA,2333-3936,2333-3936,NA,TRUE,NA,NA,NA,NA,TRUE
+gu,2016,3571.76,10.1016/j.rmed.2016.10.005,TRUE,Elsevier,Respiratory Medicine,0954-6111,0954-6111,NA,0954-6111,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27817808,NA,ut:000388116100016,NA,FALSE
+gu,2016,3700,10.1038/ncomms11161,FALSE,Springer,Nature Communications,2041-1723,NA,2041-1723,2041-1723,NA,TRUE,27045731,PMC4822045,ut:000373620500001,NA,TRUE
+gu,2016,3700,10.1038/ncomms11447,FALSE,Springer,Nature Communications,2041-1723,NA,2041-1723,2041-1723,NA,TRUE,27186890,PMC4873662,ut:000375929500001,NA,TRUE
+gu,2016,3700,10.1038/ncomms11654,FALSE,Springer,Nature Communications,2041-1723,NA,2041-1723,2041-1723,NA,TRUE,27216227,PMC4890181,ut:000376615600001,NA,TRUE
+gu,2016,3700,10.1038/ncomms12689,FALSE,Springer,Nature Communications,2041-1723,NA,2041-1723,2041-1723,NA,TRUE,27573539,PMC5013605,ut:000384690200001,NA,TRUE
+gu,2016,3706,10.1002/pds.4135,TRUE,Wiley,Pharmacoepidemiology and Drug Safety,1053-8569,NA,NA,1053-8569,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27859947,PMC5248645,ut:000396403600002,NA,FALSE
+gu,2016,400,10.1080/02813432.2016.1248628,FALSE,Taylor & Francis,Scandinavian Journal of Primary Health Care,0281-3432,0281-3432,1502-7724,0281-3432,NA,TRUE,NA,NA,ut:000392540500005,NA,TRUE
+gu,2016,400,10.1080/02813432.2016.1248635,FALSE,Taylor & Francis,Scandinavian Journal of Primary Health Care,0281-3432,0281-3432,1502-7724,0281-3432,NA,TRUE,NA,NA,ut:000392540500014,NA,TRUE
+gu,2016,4053,10.1111/cea.12757,TRUE,Wiley,Clinical & Experimental Allergy,0954-7894,NA,NA,0954-7894,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27159904,NA,ut:000386956900008,NA,FALSE
+gu,2016,4440,10.1038/ncomms12698,FALSE,Springer,Nature Communications,2041-1723,NA,2041-1723,2041-1723,NA,TRUE,27596266,PMC5025876,ut:000385381100001,NA,TRUE
+gu,2016,446.27,10.1016/j.dib.2016.05.065,FALSE,Elsevier,Data in Brief,2352-3409,2352-3409,NA,2352-3409,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27366778,PMC4910300,NA,NA,TRUE
+gu,2016,4462.7,10.1016/j.cmet.2016.05.001,TRUE,Elsevier,Cell Metabolism,1550-4131,1550-4131,NA,1550-4131,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27304513,PMC4911343,ut:000378000600030,NA,FALSE
+gu,2016,521.5,10.1177/2058460116686392,FALSE,SAGE Publications,Acta Radiologica Open,2058-4601,2058-4601,2058-4601,2058-4601,NA,TRUE,28286672,PMC5330413,ut:000390871400006,NA,TRUE
+gu,2016,541.18,10.1016/j.amper.2016.10.001,FALSE,Elsevier,Ampersand,2215-0390,2215-0390,NA,2215-0390,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,TRUE
+gu,2016,580,10.1080/02673843.2015.1137777,FALSE,Taylor & Francis,International Journal of Adolescence and Youth,0267-3843,0267-3843,2164-4527,0267-3843,NA,TRUE,NA,NA,ut:000407699400009,NA,TRUE
+gu,2016,697,10.1080/2162402X.2015.1091147,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,2162-4011,NA,TRUE,27141351,PMC4839365,ut:000373385700025,NA,FALSE
+gu,2016,713.63,10.1080/15548627.2015.1132134,TRUE,Taylor & Francis,Autophagy,1554-8627,1554-8627,1554-8635,1554-8627,NA,TRUE,26727396,PMC4835980,ut:000373982600015,NA,FALSE
+gu,2016,713.63,10.1080/15592294.2016.1138195,TRUE,Taylor & Francis,Epigenetics,1559-2294,1559-2294,1559-2308,1559-2294,NA,TRUE,26786290,PMC4846113,ut:000372742300007,NA,FALSE
+gu,2016,730,10.1080/15476286.2016.1249092,TRUE,Taylor & Francis,RNA Biology,1547-6286,1547-6286,1555-8584,1547-6286,NA,TRUE,27791479,PMC5270547,ut:000392612000009,NA,FALSE
+gu,2016,746.93,10.1080/21624054.2016.1206171,TRUE,Taylor & Francis,Worm,2162-4054,NA,2162-4054,2162-4046,NA,TRUE,27695656,PMC5022664,NA,NA,FALSE
+gu,2016,752,10.1186/s40064-016-2015-x,FALSE,Springer,SpringerPlus,2193-1801,NA,2193-1801,2193-1801,NA,TRUE,27066384,PMC4811841,ut:000373224700001,NA,FALSE
+gu,2016,931.3,10.1177/2325967116667920,FALSE,SAGE Publications,Orthopaedic Journal of Sports Medicine,2325-9671,2325-9671,2325-9671,2325-9671,NA,TRUE,NA,NA,ut:000385550100007,NA,TRUE
+gu,2016,931.3,10.1177/2325967116669708,FALSE,SAGE Publications,Orthopaedic Journal of Sports Medicine,2325-9671,2325-9671,2325-9671,2325-9671,NA,TRUE,NA,NA,NA,NA,TRUE
+gu,2016,932,10.1038/srep28490,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,27329824,PMC4916408,ut:000379997400001,NA,TRUE
+gu,2016,947,10.1002/2015WR018375,TRUE,Wiley,Water Resources Research,0043-1397,NA,NA,0043-1397,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000380100200034,NA,FALSE
+gu,2016,960,10.1093/jhps/hnw023,FALSE,Oxford University Press (OUP),Journal of Hip Preservation Surgery,2054-8397,NA,2054-8397,2054-8397,NA,TRUE,NA,NA,ut:000389764900011,NA,TRUE
+gu,2016,981.79,10.1016/j.giq.2016.01.010,TRUE,Elsevier,Government Information Quarterly,0740-624X,0740-624X,NA,0740-624X,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000372774300002,NA,FALSE
+gu,2017,1345.5,10.1371/journal.pone.0169759,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28061507,PMC5218734,ut:000391641500135,NA,TRUE
+gu,2017,1345.5,10.1371/journal.pone.0170613,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28125727,PMC5268365,ut:000396176100086,NA,TRUE
+gu,2017,1345.5,10.1371/journal.pone.0170754,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28129352,PMC5271333,ut:000396211400039,NA,TRUE
+gu,2017,1345.5,10.1371/journal.pone.0171222,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28152087,PMC5289588,ut:000396161200107,NA,TRUE
+gu,2017,1345.5,10.1371/journal.pone.0171461,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28158314,PMC5291512,ut:000396161700081,NA,TRUE
+gu,2017,1345.5,10.1371/journal.pone.0171797,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28222107,PMC5319760,ut:000394676800018,NA,TRUE
+gu,2017,1345.5,10.1371/journal.pone.0172896,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28249018,PMC5332093,ut:000395983500062,NA,TRUE
+gu,2017,1345.5,10.1371/journal.pone.0173463,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28273158,PMC5342245,ut:000396073700005,NA,TRUE
+gu,2017,1345.5,10.1371/journal.pone.0173492,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28264025,PMC5338833,ut:000396054300066,NA,TRUE
+gu,2017,1345.5,10.1371/journal.pone.0173654,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28288176,PMC5348013,ut:000396092400023,NA,TRUE
+gu,2017,2025,10.1371/journal.pgen.1006628,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,1553-7390,http://creativecommons.org/licenses/by/4.0/,TRUE,28207748,PMC5336301,ut:000396403100019,NA,TRUE
+gu,2017,2343,10.3389/fimmu.2016.00640,FALSE,Frontiers,Frontiers in Immunology,1664-3224,NA,1664-3224,1664-3224,NA,TRUE,28082979,PMC5183738,ut:000390477200002,NA,TRUE
+gu,2017,2343,10.3389/fncel.2016.00286,FALSE,Frontiers,Frontiers in Cellular Neuroscience,1662-5102,NA,1662-5102,1662-5102,NA,TRUE,28018179,PMC5156678,ut:000389789400001,NA,TRUE
+gu,2017,2500,10.1111/joim.12587,TRUE,Wiley,Journal of Internal Medicine,0954-6820,NA,NA,0954-6820,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28097725,NA,ut:000399779700008,NA,FALSE
+hb,2016,2200,10.1007/s10615-016-0606-1,TRUE,Springer,Clinical Social Work Journal,0091-1674,0091-1674,1573-3343,0091-1674,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+hb,2016,2200,10.1007/s11192-016-2194-9,TRUE,Springer,Scientometrics,0138-9130,0138-9130,1588-2861,0138-9130,http://creativecommons.org/licenses/by/4.0,TRUE,28239206,PMC5306087,ut:000394148300010,NA,FALSE
+hhs,2016,2200,10.1007/s10683-016-9496-x,TRUE,Springer,Experimental Economics,1386-4157,1386-4157,1573-6938,1386-4157,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000401066400010,NA,FALSE
+hig,2016,2200,10.1007/s00421-016-3487-7,TRUE,Springer,European Journal of Applied Physiology,1439-6319,1439-6319,1439-6327,1439-6319,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388936600026,NA,FALSE
+hig,2016,2200,10.1007/s10639-016-9536-3,TRUE,Springer,Education and Information Technologies,1360-2357,1360-2357,1573-7608,1360-2357,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+hig,2016,2200,10.1007/s10826-016-0534-2,TRUE,Springer,Journal of Child and Family Studies,1062-1024,1062-1024,1573-2843,1062-1024,http://creativecommons.org/licenses/by/4.0,TRUE,28111516,PMC5219017,ut:000392057900001,NA,FALSE
+hig,2016,2200,10.1007/s11042-016-3817-0,TRUE,Springer,Multimedia Tools and Applications,1380-7501,1380-7501,1573-7721,1380-7501,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000404609900004,NA,FALSE
+hig,2016,2200,10.1007/s11136-016-1373-8,TRUE,Springer,Quality of Life Research,0962-9343,0962-9343,1573-2649,0962-9343,http://creativecommons.org/licenses/by/4.0,TRUE,27506524,PMC5243911,ut:000393571300015,NA,FALSE
+hig,2016,2200,10.1007/s12063-016-0121-0,TRUE,Springer,Operations Management Research,1936-9735,1936-9735,1936-9743,1936-9735,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000400387000003,NA,FALSE
+his,2016,2200,10.1007/s00158-016-1569-0,TRUE,Springer,Structural and Multidisciplinary Optimization,1615-147X,1615-147X,1615-1488,1615-147X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000398951100020,NA,FALSE
+his,2016,2200,10.1007/s10111-016-0399-6,TRUE,Springer,"Cognition, Technology & Work",1435-5558,1435-5558,1435-5566,1435-5558,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000394999300006,NA,FALSE
+his,2016,2200,10.1007/s11119-016-9491-4,TRUE,Springer,Precision Agriculture,1385-2256,1385-2256,1573-1618,1385-2256,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000400083100003,NA,FALSE
+hk,2016,2200,10.1007/s00244-016-0303-7,TRUE,Springer,Archives of Environmental Contamination and Toxicology,0090-4341,0090-4341,1432-0703,0090-4341,http://creativecommons.org/licenses/by/4.0,TRUE,27480162,PMC5014903,ut:000382937100013,NA,FALSE
+hk,2016,2200,10.1007/s11115-016-0368-9,TRUE,Springer,Public Organization Review,1566-7170,1566-7170,1573-7098,1566-7170,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+kau,2016,2200,10.1007/s10346-016-0775-6,TRUE,Springer,Landslides,1612-510X,1612-510X,1612-5118,1612-510X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000401697900023,NA,FALSE
+kau,2016,2200,10.1007/s10955-016-1624-7,TRUE,Springer,Journal of Statistical Physics,0022-4715,0022-4715,1572-9613,0022-4715,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000385182000010,NA,FALSE
+kau,2016,2200,10.1007/s11195-016-9459-3,TRUE,Springer,Sexuality and Disability,0146-1044,0146-1044,1573-6717,0146-1044,http://creativecommons.org/licenses/by/4.0,TRUE,27881887,PMC5102943,ut:000393330700002,NA,FALSE
+kau,2016,2200,10.1007/s13132-016-0411-7,TRUE,Springer,Journal of the Knowledge Economy,1868-7865,1868-7865,1868-7873,1868-7865,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000407744300010,NA,FALSE
+ki,2012,2630,10.1080/09297049.2012.727792,TRUE,Taylor & Francis,Child Neuropsychology,0929-7049,0929-7049,1744-4136,0929-7049,NA,TRUE,23075095,PMC3827673,ut:000326070900006,NA,FALSE
+ki,2013,2429,10.1080/13554794.2013.791861,TRUE,Taylor & Francis,Neurocase,1355-4794,1355-4794,1465-3656,1355-4794,NA,TRUE,23682688,PMC3998094,ut:000334065500004,NA,FALSE
+ki,2014,2429,10.1080/87565641.2014.886691,TRUE,Taylor & Francis,Developmental Neuropsychology,8756-5641,8756-5641,1532-6942,1532-6942,NA,TRUE,24742310,PMC4017272,ut:000334486900002,NA,FALSE
+ki,2014,3040,10.3109/09638288.2014.998780,TRUE,Taylor & Francis,Disability and Rehabilitation,0963-8288,0963-8288,1464-5165,0963-8288,NA,TRUE,25572319,PMC4720053,ut:000369748600011,NA,FALSE
+ki,2014,702,10.4161/15592294.2014.982445,TRUE,Taylor & Francis,Epigenetics,1559-2294,1559-2294,1559-2308,1559-2294,NA,TRUE,25484259,PMC4622000,ut:000349364000001,NA,FALSE
+ki,2014,755,10.1159/000360415,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,1664-5464,NA,TRUE,24847345,PMC4024511,NA,NA,TRUE
+ki,2014,755,10.1159/000363500,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,1664-5464,NA,TRUE,25298777,PMC4176467,NA,NA,TRUE
+ki,2014,755,10.1159/000365091,FALSE,Karger,Nephron Extra,1664-5529,NA,1664-5529,1664-5529,NA,TRUE,25404935,PMC4202611,NA,NA,TRUE
+ki,2014,755,10.1159/000366270,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,1664-5464,NA,TRUE,25538726,PMC4264484,NA,NA,TRUE
+ki,2014,935,10.4161/15384101.2014.964108,TRUE,Taylor & Francis,Cell Cycle,1538-4101,1538-4101,1551-4005,1551-4005,NA,TRUE,25483075,PMC4612677,ut:000348329200009,NA,FALSE
+ki,2014,935,10.4161/15384101.2015.945831,TRUE,Taylor & Francis,Cell Cycle,1538-4101,1538-4101,1551-4005,1551-4005,NA,TRUE,25486360,PMC4615111,ut:000348325300018,NA,FALSE
+ki,2015,0,10.3109/03009734.2015.1040529,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,25947550,PMC4816888,ut:000365684900007,NA,FALSE
+ki,2015,2132,10.1080/09297049.2015.1063595,TRUE,Taylor & Francis,Child Neuropsychology,0929-7049,0929-7049,1744-4136,0929-7049,NA,TRUE,26212755,PMC5214099,ut:000394360700006,NA,FALSE
+ki,2015,2132,10.3109/08958378.2015.1115567,TRUE,Taylor & Francis,Inhalation Toxicology,0895-8378,0895-8378,1091-7691,0895-8378,NA,TRUE,26635308,PMC4732413,ut:000366677600008,NA,FALSE
+ki,2015,3040,10.3109/10408444.2015.1092498,TRUE,Taylor & Francis,Critical Reviews in Toxicology,1040-8444,1040-8444,1547-6898,1040-8444,NA,TRUE,26515429,PMC4819830,ut:000369496900002,NA,FALSE
+ki,2015,702,10.1080/15476286.2015.1110675,TRUE,Taylor & Francis,RNA Biology,1547-6286,1547-6286,1555-8584,1547-6286,NA,TRUE,26669816,PMC4829308,ut:000370963300003,NA,FALSE
+ki,2015,702,10.1080/15548627.2015.1068489,TRUE,Taylor & Francis,Autophagy,1554-8627,1554-8627,1554-8635,1554-8627,NA,TRUE,26259639,PMC4590675,ut:000361629400011,NA,FALSE
+ki,2015,702,10.1080/19491034.2015.1106675,TRUE,Taylor & Francis,Nucleus,1949-1034,1949-1034,1949-1042,1949-1042,NA,TRUE,26734725,PMC4915514,ut:000367800700010,NA,FALSE
+ki,2015,702,10.1080/2162402X.2015.1052213,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,2162-4011,NA,TRUE,26942060,PMC4760332,ut:000373383600033,NA,FALSE
+ki,2015,755,10.1159/000441942,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,1664-5464,NA,TRUE,26955384,PMC4777933,ut:000367324900024,NA,TRUE
+ki,2016,0,10.1080/03009734.2016.1201553,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,NA,NA,ut:000387292600008,NA,FALSE
+ki,2016,0,10.1080/03009734.2016.1208310,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,NA,NA,ut:000387292600010,NA,FALSE
+ki,2016,0,10.1080/03009734.2016.1219432,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,NA,NA,ut:000387292600003,NA,FALSE
+ki,2016,0,10.1080/17453674.2016.1202013,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,1745-3674,NA,TRUE,27331243,PMC5016913,ut:000387526300015,NA,TRUE
+ki,2016,0,10.3109/03009734.2016.1158756,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,27064303,PMC4967266,ut:000381958400007,NA,FALSE
+ki,2016,1473,10.1080/2162402X.2016.1232222,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,2162-4011,NA,TRUE,28123870,PMC5214950,ut:000392846200005,NA,FALSE
+ki,2016,199,10.3109/23320885.2016.1153974,FALSE,Taylor & Francis,Case Reports in Plastic Surgery and Hand Surgery,2332-0885,NA,2332-0885,2332-0885,NA,TRUE,27583262,PMC4996062,ut:000406332200003,NA,FALSE
+ki,2016,2074,10.1080/00016357.2016.1206211,TRUE,Taylor & Francis,Acta Odontologica Scandinavica,0001-6357,0001-6357,1502-3850,0001-6357,NA,TRUE,27409593,PMC4960510,ut:000381408200011,NA,FALSE
+ki,2016,2074,10.1080/10400419.2017.1263507,TRUE,Taylor & Francis,Creativity Research Journal,1040-0419,1040-0419,1532-6934,1040-0419,NA,TRUE,NA,NA,ut:000395125800004,NA,FALSE
+ki,2016,2132,10.3109/08039488.2016.1159331,TRUE,Taylor & Francis,Nordic Journal of Psychiatry,0803-9488,0803-9488,1502-4725,0803-9488,NA,TRUE,27103375,PMC4926784,ut:000379532900011,NA,FALSE
+ki,2016,2132,10.3109/13561820.2016.1143457,TRUE,Taylor & Francis,Journal of Interprofessional Care,1356-1820,1356-1820,1469-9567,1356-1820,NA,TRUE,27152534,PMC4898142,ut:000375903100006,NA,FALSE
+ki,2016,2132,10.3109/13561820.2016.1159184,TRUE,Taylor & Francis,Journal of Interprofessional Care,1356-1820,1356-1820,1469-9567,1356-1820,NA,TRUE,27268309,PMC4926788,ut:000379539100013,NA,FALSE
+ki,2016,2200,10.1007/s00068-016-0730-1,TRUE,Springer,European Journal of Trauma and Emergency Surgery,1863-9933,1863-9933,1863-9941,1863-9933,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+ki,2016,2200,10.1007/s00109-016-1486-0,TRUE,Springer,Journal of Molecular Medicine,0946-2716,0946-2716,1432-1440,0946-2716,http://creativecommons.org/licenses/by/4.0,TRUE,27858116,PMC5225196,ut:000392324200005,NA,FALSE
+ki,2016,2200,10.1007/s00125-016-4074-5,TRUE,Springer,Diabetologia,0012-186X,0012-186X,1432-0428,0012-186X,http://creativecommons.org/licenses/by/4.0,TRUE,27535281,NA,ut:000387596100015,NA,FALSE
+ki,2016,2200,10.1007/s00167-016-4234-7,TRUE,Springer,"Knee Surgery, Sports Traumatology, Arthroscopy",0942-2056,0942-2056,1433-7347,0942-2056,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+ki,2016,2200,10.1007/s00167-016-4270-3,TRUE,Springer,"Knee Surgery, Sports Traumatology, Arthroscopy",0942-2056,0942-2056,1433-7347,0942-2056,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000402729500020,NA,FALSE
+ki,2016,2200,10.1007/s00167-016-4394-5,TRUE,Springer,"Knee Surgery, Sports Traumatology, Arthroscopy",0942-2056,0942-2056,1433-7347,0942-2056,http://creativecommons.org/licenses/by/4.0,TRUE,28004174,NA,ut:000402729500024,NA,FALSE
+ki,2016,2200,10.1007/s00192-016-3119-0,TRUE,Springer,International Urogynecology Journal,0937-3462,0937-3462,1433-3023,0937-3462,http://creativecommons.org/licenses/by/4.0,TRUE,27530518,PMC5306059,ut:000394261200010,NA,FALSE
+ki,2016,2200,10.1007/s00198-016-3818-x,TRUE,Springer,Osteoporosis International,0937-941X,0937-941X,1433-2965,0937-941X,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27844133,PMC5206249,ut:000391390100018,NA,FALSE
+ki,2016,2200,10.1007/s00204-016-1879-4,TRUE,Springer,Archives of Toxicology,0340-5761,0340-5761,1432-0738,0340-5761,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000399875300003,NA,FALSE
+ki,2016,2200,10.1007/s00213-016-4506-4,TRUE,Springer,Psychopharmacology,0033-3158,0033-3158,1432-2072,0033-3158,http://creativecommons.org/licenses/by/4.0,TRUE,28013354,PMC5263201,ut:000393763100016,NA,FALSE
+ki,2016,2200,10.1007/s00223-016-0194-7,TRUE,Springer,Calcified Tissue International,0171-967X,0171-967X,1432-0827,0171-967X,http://creativecommons.org/licenses/by/4.0,TRUE,27671989,PMC5214955,ut:000392023000001,NA,FALSE
+ki,2016,2200,10.1007/s00228-016-2105-2,TRUE,Springer,European Journal of Clinical Pharmacology,0031-6970,0031-6970,1432-1041,0031-6970,http://creativecommons.org/licenses/by/4.0,TRUE,27484241,PMC5021730,ut:000383624500002,NA,FALSE
+ki,2016,2200,10.1007/s00228-016-2152-8,TRUE,Springer,European Journal of Clinical Pharmacology,0031-6970,0031-6970,1432-1041,0031-6970,http://creativecommons.org/licenses/by/4.0,TRUE,27826643,PMC5226983,ut:000392308200010,NA,FALSE
+ki,2016,2200,10.1007/s00234-016-1760-4,TRUE,Springer,Neuroradiology,0028-3940,0028-3940,1432-1920,0028-3940,http://creativecommons.org/licenses/by/4.0,TRUE,27796449,PMC5153414,ut:000390406600004,NA,FALSE
+ki,2016,2200,10.1007/s00238-016-1252-0,TRUE,Springer,European Journal of Plastic Surgery,0930-343X,0930-343X,1435-0130,0930-343X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000401979600008,NA,FALSE
+ki,2016,2200,10.1007/s00259-016-3476-4,TRUE,Springer,European Journal of Nuclear Medicine and Molecular Imaging,1619-7070,1619-7070,1619-7089,1619-7070,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000385161100020,NA,FALSE
+ki,2016,2200,10.1007/s00259-016-3544-9,TRUE,Springer,European Journal of Nuclear Medicine and Molecular Imaging,1619-7070,1619-7070,1619-7089,1619-7070,http://creativecommons.org/licenses/by/4.0,TRUE,27817159,PMC5215309,ut:000392026600019,NA,FALSE
+ki,2016,2200,10.1007/s00262-016-1922-6,TRUE,Springer,"Cancer Immunology, Immunotherapy",0340-7004,0340-7004,1432-0851,0340-7004,http://creativecommons.org/licenses/by/4.0,TRUE,27815572,PMC5222940,ut:000393598500010,NA,FALSE
+ki,2016,2200,10.1007/s00268-016-3705-9,TRUE,Springer,World Journal of Surgery,0364-2313,0364-2313,1432-2323,0364-2313,http://creativecommons.org/licenses/by/4.0,TRUE,27549597,PMC5104803,ut:000387709300034,NA,FALSE
+ki,2016,2200,10.1007/s00277-016-2787-7,TRUE,Springer,Annals of Hematology,0939-5555,0939-5555,1432-0584,0939-5555,http://creativecommons.org/licenses/by/4.0,TRUE,27561898,PMC5040742,ut:000387353500010,NA,FALSE
+ki,2016,2200,10.1007/s00277-016-2859-8,TRUE,Springer,Annals of Hematology,0939-5555,0939-5555,1432-0584,0939-5555,http://creativecommons.org/licenses/by/4.0,TRUE,27807648,PMC5226986,ut:000392305100010,NA,FALSE
+ki,2016,2200,10.1007/s00380-016-0924-9,TRUE,Springer,Heart and Vessels,0910-8327,0910-8327,1615-2573,0910-8327,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000402144200006,NA,FALSE
+ki,2016,2200,10.1007/s00384-016-2678-3,TRUE,Springer,International Journal of Colorectal Disease,0179-1958,0179-1958,1432-1262,0179-1958,http://creativecommons.org/licenses/by/4.0,TRUE,27770250,PMC5285411,ut:000394159500008,NA,FALSE
+ki,2016,2200,10.1007/s00394-016-1298-6,TRUE,Springer,European Journal of Nutrition,1436-6207,1436-6207,1436-6215,1436-6207,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+ki,2016,2200,10.1007/s00405-016-4321-x,TRUE,Springer,European Archives of Oto-Rhino-Laryngology,0937-4477,0937-4477,1434-4726,0937-4477,http://creativecommons.org/licenses/by/4.0,TRUE,27757542,PMC5309288,ut:000394350800032,NA,FALSE
+ki,2016,2200,10.1007/s00406-016-0759-5,TRUE,Springer,European Archives of Psychiatry and Clinical Neuroscience,0940-1334,0940-1334,1433-8491,0940-1334,http://creativecommons.org/licenses/by/4.0,TRUE,28039552,NA,ut:000405673700004,NA,FALSE
+ki,2016,2200,10.1007/s00420-016-1156-0,TRUE,Springer,International Archives of Occupational and Environmental Health,0340-0131,0340-0131,1432-1246,0340-0131,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000385249600008,NA,FALSE
+ki,2016,2200,10.1007/s00420-016-1186-7,TRUE,Springer,International Archives of Occupational and Environmental Health,0340-0131,0340-0131,1432-1246,0340-0131,http://creativecommons.org/licenses/by/4.0,TRUE,27858151,PMC5263190,ut:000393824400006,NA,FALSE
+ki,2016,2200,10.1007/s00421-016-3473-0,TRUE,Springer,European Journal of Applied Physiology,1439-6319,1439-6319,1439-6327,1439-6319,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388936600013,NA,FALSE
+ki,2016,2200,10.1007/s00423-016-1501-5,TRUE,Springer,Langenbeck's Archives of Surgery,1435-2443,1435-2443,1435-2451,1435-2443,http://creativecommons.org/licenses/by/4.0,TRUE,27562317,PMC5143360,ut:000390032200016,NA,FALSE
+ki,2016,2200,10.1007/s00423-016-1512-2,TRUE,Springer,Langenbeck's Archives of Surgery,1435-2443,1435-2443,1435-2451,1435-2443,http://creativecommons.org/licenses/by/4.0,TRUE,27695941,PMC5309267,ut:000394353600012,NA,FALSE
+ki,2016,2200,10.1007/s00423-016-1524-y,TRUE,Springer,Langenbeck's Archives of Surgery,1435-2443,1435-2443,1435-2451,1435-2443,http://creativecommons.org/licenses/by/4.0,TRUE,27761713,PMC5309264,ut:000394353600008,NA,FALSE
+ki,2016,2200,10.1007/s00464-016-5173-6,TRUE,Springer,Surgical Endoscopy,0930-2794,0930-2794,1432-2218,0930-2794,http://creativecommons.org/licenses/by/4.0,TRUE,27572065,PMC5346119,ut:000398176000061,NA,FALSE
+ki,2016,2200,10.1007/s00520-016-3527-1,TRUE,Springer,Supportive Care in Cancer,0941-4355,0941-4355,1433-7339,0941-4355,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27981366,NA,ut:000399153200009,NA,FALSE
+ki,2016,2200,10.1007/s00586-016-4854-0,TRUE,Springer,European Spine Journal,0940-6719,0940-6719,1432-0932,0940-6719,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000403487900010,NA,FALSE
+ki,2016,2200,10.1007/s00586-016-4876-7,TRUE,Springer,European Spine Journal,0940-6719,0940-6719,1432-0932,0940-6719,http://creativecommons.org/licenses/by/4.0,TRUE,27888355,NA,ut:000394212100003,NA,FALSE
+ki,2016,2200,10.1007/s00701-016-3046-3,TRUE,Springer,Acta Neurochirurgica,0001-6268,0001-6268,0942-0940,0001-6268,http://creativecommons.org/licenses/by/4.0,TRUE,27957604,PMC5241347,ut:000393022200003,NA,FALSE
+ki,2016,2200,10.1007/s00726-016-2316-y,TRUE,Springer,Amino Acids,0939-4451,0939-4451,1438-2199,0939-4451,http://creativecommons.org/licenses/by/4.0,TRUE,27573935,PMC5107209,ut:000387713700010,NA,FALSE
+ki,2016,2200,10.1007/s00769-016-1228-6,TRUE,Springer,Accreditation and Quality Assurance,0949-1775,0949-1775,1432-0517,0949-1775,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000382990500007,NA,FALSE
+ki,2016,2200,10.1007/s00784-016-1939-4,TRUE,Springer,Clinical Oral Investigations,1432-6981,1432-6981,1436-3771,1432-6981,http://creativecommons.org/licenses/by/4.0,TRUE,27568306,PMC5318472,ut:000394978300015,NA,FALSE
+ki,2016,2200,10.1007/s10096-016-2842-2,TRUE,Springer,European Journal of Clinical Microbiology & Infectious Diseases,0934-9723,0934-9723,1435-4373,0934-9723,http://creativecommons.org/licenses/by/4.0,TRUE,27909820,NA,ut:000398838200009,NA,FALSE
+ki,2016,2200,10.1007/s10120-016-0654-9,TRUE,Springer,Gastric Cancer,1436-3291,1436-3291,1436-3305,1436-3291,http://creativecommons.org/licenses/by/4.0,TRUE,27718134,PMC5316395,NA,NA,FALSE
+ki,2016,2200,10.1007/s10334-016-0599-3,TRUE,Springer,"Magnetic Resonance Materials in Physics, Biology and Medicine",0968-5243,0968-5243,1352-8661,0968-5243,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000401925200002,NA,FALSE
+ki,2016,2200,10.1007/s10433-016-0394-z,TRUE,Springer,European Journal of Ageing,1613-9372,1613-9372,1613-9380,1613-9372,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000401662900010,NA,FALSE
+ki,2016,2200,10.1007/s10534-016-9959-8,TRUE,Springer,BioMetals,0966-0844,0966-0844,1572-8773,0966-0844,http://creativecommons.org/licenses/by/4.0,TRUE,27530256,PMC5034004,ut:000385252400006,NA,FALSE
+ki,2016,2200,10.1007/s10549-016-3983-9,TRUE,Springer,Breast Cancer Research and Treatment,0167-6806,0167-6806,1573-7217,0167-6806,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000385175900013,NA,FALSE
+ki,2016,2200,10.1007/s10584-016-1753-7,TRUE,Springer,Climatic Change,0165-0009,0165-0009,1573-1480,0165-0009,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000383615200011,NA,FALSE
+ki,2016,2200,10.1007/s10654-016-0204-0,TRUE,Springer,European Journal of Epidemiology,0393-2990,0393-2990,1573-7284,0393-2990,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000386372500001,NA,FALSE
+ki,2016,2200,10.1007/s10803-016-2914-2,TRUE,Springer,Journal of Autism and Developmental Disorders,0162-3257,0162-3257,1573-3432,0162-3257,http://creativecommons.org/licenses/by/4.0,TRUE,27734228,PMC5222913,ut:000392816700007,NA,FALSE
+ki,2016,2200,10.1007/s10865-016-9769-z,TRUE,Springer,Journal of Behavioral Medicine,0160-7715,0160-7715,1573-3521,0160-7715,http://creativecommons.org/licenses/by/4.0,TRUE,27469518,PMC5012257,ut:000382887100017,NA,FALSE
+ki,2016,2200,10.1007/s10875-016-0347-5,TRUE,Springer,Journal of Clinical Immunology,0271-9142,0271-9142,1573-2592,0271-9142,http://creativecommons.org/licenses/by/4.0,TRUE,27873105,PMC5226987,ut:000392298100014,NA,FALSE
+ki,2016,2200,10.1007/s10910-016-0693-9,TRUE,Springer,Journal of Mathematical Chemistry,0259-9791,0259-9791,1572-8897,0259-9791,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392430300017,NA,FALSE
+ki,2016,2200,10.1007/s10910-016-0694-8,TRUE,Springer,Journal of Mathematical Chemistry,0259-9791,0259-9791,1572-8897,0259-9791,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392430300018,NA,FALSE
+ki,2016,2200,10.1007/s10961-016-9490-7,TRUE,Springer,The Journal of Technology Transfer,0892-9912,0892-9912,1573-7047,0892-9912,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000401478900005,NA,FALSE
+ki,2016,2200,10.1007/s10995-016-2202-y,TRUE,Springer,Maternal and Child Health Journal,1092-7875,1092-7875,1573-6628,1092-7875,http://creativecommons.org/licenses/by/4.0,TRUE,28035634,NA,ut:000399410300014,NA,FALSE
+ki,2016,2200,10.1007/s11019-016-9723-4,TRUE,Springer,"Medicine, Health Care and Philosophy",1386-7423,1386-7423,1572-8633,1386-7423,http://creativecommons.org/licenses/by/4.0,TRUE,27581427,PMC5318471,ut:000394981000015,NA,FALSE
+ki,2016,2200,10.1007/s11113-016-9412-2,TRUE,Springer,Population Research and Policy Review,0167-5923,0167-5923,1573-7829,0167-5923,http://creativecommons.org/licenses/by/4.0,TRUE,28190908,PMC5272880,ut:000394268300004,NA,FALSE
+ki,2016,2200,10.1007/s11605-016-3223-y,TRUE,Springer,Journal of Gastrointestinal Surgery,1091-255X,1091-255X,1873-4626,1091-255X,http://creativecommons.org/licenses/by/4.0,TRUE,27649704,PMC5187360,ut:000391489200005,NA,FALSE
+ki,2016,2200,10.1007/s11695-016-2431-6,TRUE,Springer,Obesity Surgery,0960-8923,0960-8923,1708-0428,0960-8923,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000400029400015,NA,FALSE
+ki,2016,2200,10.1007/s11882-016-0652-3,TRUE,Springer,Current Allergy and Asthma Reports,1529-7322,1529-7322,1534-6315,1529-7322,http://creativecommons.org/licenses/by/4.0,TRUE,27645534,PMC5028403,ut:000388591100004,NA,FALSE
+ki,2016,2200,10.1007/s12020-016-1127-y,TRUE,Springer,Endocrine,1355-008X,1355-008X,1559-0100,1355-008X,http://creativecommons.org/licenses/by/4.0,TRUE,27699708,PMC5225211,ut:000394257600038,NA,FALSE
+ki,2016,2200,10.1007/s12062-016-9158-y,TRUE,Springer,Journal of Population Ageing,1874-7884,1874-7884,1874-7876,1874-7876,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+ki,2016,2200,10.1007/s12529-016-9601-8,TRUE,Springer,International Journal of Behavioral Medicine,1070-5503,1070-5503,1532-7558,1070-5503,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+ki,2016,2200,10.1007/s12529-016-9618-z,TRUE,Springer,International Journal of Behavioral Medicine,1070-5503,1070-5503,1532-7558,1070-5503,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+ki,2016,2200,10.1007/s13304-016-0388-6,TRUE,Springer,Updates in Surgery,2038-131X,2038-131X,2038-3312,2038-131X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000387845700008,NA,FALSE
+ki,2016,2200,10.1007/s15010-016-0963-2,TRUE,Springer,Infection,0300-8126,0300-8126,1439-0973,0300-8126,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000402711600006,NA,FALSE
+ki,2016,2200,10.1007/s40258-016-0272-z,TRUE,Springer,Applied Health Economics and Health Policy,1175-5652,1175-5652,1179-1896,1175-5652,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27587010,PMC5253143,ut:000397244700010,NA,FALSE
+ki,2016,2200,10.1007/s40273-016-0461-5,TRUE,Springer,PharmacoEconomics,1170-7690,1170-7690,1179-2027,1170-7690,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27798808,PMC5253157,ut:000393114500010,NA,FALSE
+ki,2016,2200,10.1007/s40520-016-0630-6,TRUE,Springer,Aging Clinical and Experimental Research,1720-8319,NA,1720-8319,1594-0667,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000406606300026,NA,FALSE
 ki,2016,2200,10.1007/s40521-016-0106-0,TRUE,Springer,Current Treatment Options in Allergy,2196-3053,NA,2196-3053,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27942431,PMC5121172,NA,NA,FALSE
-ki,2016,2200,10.1007/s40618-016-0546-1,TRUE,Springer,Journal of Endocrinological Investigation,1720-8386,NA,1720-8386,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27671168,PMC5269462,NA,NA,FALSE
-ki,2016,2200,10.1245/s10434-016-5661-x,TRUE,Springer,Annals of Surgical Oncology,1068-9265,1068-9265,1534-4681,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27822633,PMC5339331,NA,NA,FALSE
-ki,2016,234,10.1080/19490976.2015.1127480,TRUE,Taylor & Francis,Gut Microbes,1949-0976,1949-0976,1949-0984,NA,NA,TRUE,26939855,PMC4856455,NA,NA,FALSE
-ki,2016,397,10.3109/02813432.2015.1132892,FALSE,Taylor & Francis,Scandinavian Journal of Primary Health Care,0281-3432,0281-3432,1502-7724,NA,NA,TRUE,26849465,PMC4911027,NA,NA,TRUE
-ki,2016,468,10.1080/2162402X.2015.1093722,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,NA,NA,TRUE,27467926,PMC4910721,NA,NA,FALSE
-ki,2016,734,10.1080/15476286.2016.1243647,TRUE,Taylor & Francis,RNA Biology,1547-6286,1547-6286,1555-8584,NA,NA,TRUE,27715493,NA,NA,NA,FALSE
-ki,2016,734,10.1080/2162402X.2015.1128613,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,NA,NA,TRUE,27467944,PMC4910727,NA,NA,FALSE
-ki,2016,870,10.1080/09699260.2015.1103497,TRUE,Taylor & Francis,Progress in Palliative Care,0969-9260,0969-9260,1743-291X,NA,NA,TRUE,NA,NA,NA,NA,FALSE
+ki,2016,2200,10.1007/s40618-016-0546-1,TRUE,Springer,Journal of Endocrinological Investigation,1720-8386,NA,1720-8386,0391-4097,http://creativecommons.org/licenses/by/4.0,TRUE,27671168,PMC5269462,ut:000396880500010,NA,FALSE
+ki,2016,2200,10.1245/s10434-016-5661-x,TRUE,Springer,Annals of Surgical Oncology,1068-9265,1068-9265,1534-4681,1068-9265,http://creativecommons.org/licenses/by/4.0,TRUE,27822633,PMC5339331,ut:000398047600041,NA,FALSE
+ki,2016,234,10.1080/19490976.2015.1127480,TRUE,Taylor & Francis,Gut Microbes,1949-0976,1949-0976,1949-0984,1949-0976,NA,TRUE,26939855,PMC4856455,NA,NA,FALSE
+ki,2016,397,10.3109/02813432.2015.1132892,FALSE,Taylor & Francis,Scandinavian Journal of Primary Health Care,0281-3432,0281-3432,1502-7724,0281-3432,NA,TRUE,26849465,PMC4911027,ut:000372023200009,NA,TRUE
+ki,2016,468,10.1080/2162402X.2015.1093722,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,2162-4011,NA,TRUE,27467926,PMC4910721,ut:000379162200004,NA,FALSE
+ki,2016,734,10.1080/15476286.2016.1243647,TRUE,Taylor & Francis,RNA Biology,1547-6286,1547-6286,1555-8584,1547-6286,NA,TRUE,27715493,NA,ut:000406139300013,NA,FALSE
+ki,2016,734,10.1080/2162402X.2015.1128613,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,2162-4011,NA,TRUE,27467944,PMC4910727,ut:000379162200036,NA,FALSE
+ki,2016,870,10.1080/09699260.2015.1103497,TRUE,Taylor & Francis,Progress in Palliative Care,0969-9260,0969-9260,1743-291X,0969-9260,NA,TRUE,NA,NA,ut:000376256700006,NA,FALSE
 ki,2017,0,10.1080/16512235.2017.1281946,FALSE,Taylor & Francis,Microbial Ecology in Health and Disease,NA,NA,NA,NA,NA,FALSE,NA,NA,NA,NA,NA
 ki,2017,0,10.1080/16512235.2017.1281963,FALSE,Taylor & Francis,Microbial Ecology in Health and Disease,NA,NA,NA,NA,NA,FALSE,NA,NA,NA,NA,NA
-kth,2015,0,10.1007/JHEP09(2015)096,FALSE,Springer,Journal of High Energy Physics,1029-8479,NA,1029-8479,NA,NA,TRUE,NA,NA,NA,http://link.springer.com/article/10.1007/JHEP09(2015)096,TRUE
-kth,2015,0,10.1007/s13373-015-0067-9,FALSE,Springer,Bulletin of Mathematical Sciences,1664-3607,1664-3607,1664-3615,NA,NA,TRUE,NA,NA,NA,http://link.springer.com/article/10.1007/s13373-015-0067-9,TRUE
-kth,2015,0,10.1186/s40294-015-0009-0,FALSE,Springer Open,Complex Adaptive Systems Modeling,2194-3206,NA,2194-3206,NA,NA,TRUE,NA,NA,NA,https://casmodeling.springeropen.com/articles/10.1186/s40294-015-0009-0,TRUE
-kth,2015,0,10.3390/catal5041737,FALSE,MDPI,Catalysts,2073-4344,NA,2073-4344,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/2073-4344/5/4/1737,TRUE
-kth,2015,1021,10.3390/en8032165,FALSE,MDPI,Energies,1996-1073,NA,1996-1073,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/1996-1073/8/3/2165,TRUE
-kth,2015,1021,10.3390/en8065287,FALSE,MDPI,Energies,1996-1073,NA,1996-1073,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/1996-1073/8/6/5287,TRUE
-kth,2015,1021,10.3390/su7066336,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/2071-1050/7/6/6336,TRUE
-kth,2015,1021,10.3390/su70811306,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/2071-1050/7/8/11306,TRUE
-kth,2015,1166,10.1016/j.segan.2015.06.002,TRUE,Elsevier,"Sustainable Energy, Grids and Networks",2352-4677,2352-4677,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S2352-4677(15)00039-9,FALSE
-kth,2015,1166,10.1016/j.segan.2015.09.001,TRUE,Elsevier,"Sustainable Energy, Grids and Networks",2352-4677,2352-4677,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S2352-4677(15)00049-1,FALSE
-kth,2015,1191,10.3390/ma8020751,FALSE,MDPI,Materials,1996-1944,NA,1996-1944,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/1996-1944/8/2/751,TRUE
-kth,2015,1258,10.1186/s12934-015-0227-3,FALSE,BioMed Central,Microbial Cell Factories,1475-2859,NA,1475-2859,NA,NA,TRUE,25889453,PMC4415288,NA,https://microbialcellfactories.biomedcentral.com/articles/10.1186/s12934-015-0227-3,TRUE
-kth,2015,1258,10.1186/s12934-015-0236-2,FALSE,BioMed Central,Microbial Cell Factories,1475-2859,NA,1475-2859,NA,NA,TRUE,25889969,PMC4405896,NA,https://microbialcellfactories.biomedcentral.com/articles/10.1186/s12934-015-0236-2,TRUE
-kth,2015,1280,10.1109/JPETS.2015.2445296,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Power and Energy Technology Systems Journal,2332-7707,NA,2332-7707,NA,NA,TRUE,NA,NA,NA,http://ieeexplore.ieee.org/document/7234831/,FALSE
-kth,2015,1280,10.1109/PESGM.2016.7741306,TRUE,Institute of Electrical & Electronics Engineers (IEEE),Power and Energy Society General Meeting,NA,NA,1944-9933,NA,NA,FALSE,NA,NA,NA,http://ieeexplore.ieee.org/document/7741306/,FALSE
-kth,2015,1280,10.1109/TAFFC.2015.2457417,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Affective Computing,1949-3045,1949-3045,NA,NA,NA,TRUE,NA,NA,NA,http://ieeexplore.ieee.org/document/7160715/,FALSE
-kth,2015,1345,10.1016/j.ultrasmedbio.2015.08.012,TRUE,Elsevier,Ultrasound in Medicine & Biology,0301-5629,0301-5629,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26454623,NA,NA,http://www.sciencedirect.com/science/article/pii/S0301-5629(15)00522-0,FALSE
-kth,2015,1360,10.1186/s12880-015-0086-8,FALSE,BioMed Central,BMC Medical Imaging,1471-2342,NA,1471-2342,NA,http://www.springer.com/tdm,TRUE,26459634,PMC4601150,NA,https://bmcmedimaging.biomedcentral.com/articles/10.1186/s12880-015-0086-8,TRUE
-kth,2015,1383,10.1371/JOURNAL.PONE.0119032,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25822973,PMC4379182,NA,http://dx.doi.org/10.1371/journal.pone.0119032,TRUE
-kth,2015,1383,10.1371/JOURNAL.PONE.0130169,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26090859,PMC4474965,NA,http://dx.doi.org/10.1371/journal.pone.0130169,TRUE
-kth,2015,1383,10.1371/JOURNAL.PONE.0140644,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,https://creativecommons.org/publicdomain/zero/1.0/,TRUE,26496191,PMC4619776,NA,http://dx.doi.org/10.1371/journal.pone.0140644,TRUE
-kth,2015,1423.75,10.1186/s12864-015-1686-y,FALSE,BioMed Central,BMC Genomics,1471-2164,NA,1471-2164,NA,NA,TRUE,26109061,PMC4479346,NA,http://bmcgenomics.biomedcentral.com/articles/10.1186/s12864-015-1686-y,TRUE
-kth,2015,1430,10.1109/ACCESS.2015.2414815,FALSE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Access,2169-3536,NA,2169-3536,NA,NA,TRUE,NA,NA,NA,http://ieeexplore.ieee.org/document/7072470/,TRUE
-kth,2015,1483.25,10.1186/s12880-015-0083-y,FALSE,BioMed Central,BMC Medical Imaging,1471-2342,NA,1471-2342,NA,http://www.springer.com/tdm,TRUE,26515510,PMC4627379,NA,http://bmcmedimaging.biomedcentral.com/articles/10.1186/s12880-015-0083-y,TRUE
-kth,2015,1505,10.1109/TASE.2015.2471305,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Automation Science and Engineering,1545-5955,1545-5955,1558-3783,NA,NA,TRUE,NA,NA,NA,http://ieeexplore.ieee.org/document/7254252/,FALSE
-kth,2015,1505,10.1109/TIM.2015.2427731,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Instrumentation and Measurement,0018-9456,0018-9456,1557-9662,NA,NA,TRUE,NA,NA,NA,http://ieeexplore.ieee.org/document/7104121/,FALSE
-kth,2015,1505,10.1109/TITS.2015.2431293,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Intelligent Transportation Systems,1524-9050,1524-9050,1558-0016,NA,NA,TRUE,NA,NA,NA,http://ieeexplore.ieee.org/document/7116534/,FALSE
-kth,2015,1505,10.1109/TVT.2015.2434497,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Vehicular Technology,0018-9545,0018-9545,1939-9359,NA,NA,TRUE,NA,NA,NA,http://ieeexplore.ieee.org/document/7109926/,FALSE
-kth,2015,1595,10.1016/j.visres.2015.03.009,TRUE,Elsevier,Vision Research,0042-6989,0042-6989,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25817716,NA,NA,http://www.sciencedirect.com/science/article/pii/S0042-6989(15)00108-X,FALSE
-kth,2015,1614,10.1016/j.jbiotec.2015.07.006,TRUE,Elsevier,Journal of Biotechnology,0168-1656,0168-1656,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26211737,NA,NA,http://www.sciencedirect.com/science/article/pii/S0168-1656(15)30063-8,FALSE
-kth,2015,1695.75,10.1186/s13068-015-0380-2,FALSE,BioMed Central,Biotechnology for Biofuels,1754-6834,NA,1754-6834,NA,NA,TRUE,26613003,PMC4660834,NA,https://biotechnologyforbiofuels.biomedcentral.com/articles/10.1186/s13068-015-0380-2,TRUE
-kth,2015,1745,10.1186/s12934-015-0355-9,FALSE,BioMed Central,Microbial Cell Factories,1475-2859,NA,1475-2859,NA,NA,TRUE,26474754,PMC4609045,NA,https://microbialcellfactories.biomedcentral.com/articles/10.1186/s12934-015-0355-9,TRUE
-kth,2015,1821,10.3390/s150407294,FALSE,MDPI,Sensors,1424-8220,NA,1424-8220,NA,NA,TRUE,25815449,PMC4431291,NA,http://www.mdpi.com/1424-8220/15/4/7294,TRUE
-kth,2015,1821,10.3390/s150715265,FALSE,MDPI,Sensors,1424-8220,NA,1424-8220,NA,NA,TRUE,26131675,PMC4541830,NA,http://www.mdpi.com/1424-8220/15/7/15265,TRUE
-kth,2015,1826,10.1016/j.medengphy.2014.11.002,TRUE,Elsevier,Medical Engineering and Physics,1350-4533,NA,NA,NA,NA,FALSE,25466260,NA,NA,http://www.sciencedirect.com/science/article/pii/S1350-4533(14)00281-1,FALSE
-kth,2015,185,10.1155/2015/102469,FALSE,Hindawi Publishing Corporation,Mathematical Problems in Engineering,1024-123X,1024-123X,1563-5147,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/102469,TRUE
-kth,2015,185,10.1155/2015/130741,FALSE,Hindawi Publishing Corporation,Science and Technology of Nuclear Installations,1687-6075,1687-6075,1687-6083,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/130741,TRUE
-kth,2015,185,10.1155/2015/156196,FALSE,Hindawi Publishing Corporation,Advances in Condensed Matter Physics,1687-8108,1687-8108,1687-8124,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/156196,TRUE
-kth,2015,185,10.1155/2015/230832,FALSE,Hindawi Publishing Corporation,Evidence-Based Complementary and Alternative Medicine,1741-427X,1741-427X,1741-4288,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,26170872,PMC4478384,NA,http://dx.doi.org/10.1155/2015/230832,TRUE
-kth,2015,185,10.1155/2015/256479,FALSE,Hindawi Publishing Corporation,Journal of Nanomaterials,1687-4110,1687-4110,1687-4129,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/256479,TRUE
-kth,2015,185,10.1155/2015/260703,FALSE,Hindawi Publishing Corporation,BioMed Research International,2314-6133,2314-6133,2314-6141,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,26587533,PMC4637432,NA,http://dx.doi.org/10.1155/2015/260703,TRUE
-kth,2015,185,10.1155/2015/278638,FALSE,Hindawi Publishing Corporation,Science and Technology of Nuclear Installations,1687-6075,1687-6075,1687-6083,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/278638,TRUE
-kth,2015,185,10.1155/2015/296317,FALSE,Hindawi Publishing Corporation,Science and Technology of Nuclear Installations,1687-6075,1687-6075,1687-6083,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/296317,TRUE
-kth,2015,185,10.1155/2015/321354,FALSE,Hindawi Publishing Corporation,Journal of Nanomaterials,1687-4110,1687-4110,1687-4129,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/321354,TRUE
-kth,2015,185,10.1155/2015/346498,FALSE,Hindawi Publishing Corporation,International Journal of Navigation and Observation,1687-5990,1687-5990,1687-6008,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/346498,TRUE
-kth,2015,185,10.1155/2015/390292,FALSE,Hindawi Publishing Corporation,International Journal of Polymer Science,1687-9422,1687-9422,1687-9430,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/390292,TRUE
-kth,2015,185,10.1155/2015/574705,FALSE,Hindawi Publishing Corporation,BioMed Research International,2314-6133,2314-6133,2314-6141,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,26436093,PMC4575986,NA,http://dx.doi.org/10.1155/2015/574705,TRUE
-kth,2015,185,10.1155/2015/613247,FALSE,Hindawi Publishing Corporation,BioMed Research International,2314-6133,2314-6133,2314-6141,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,26557680,PMC4628745,NA,http://dx.doi.org/10.1155/2015/613247,TRUE
-kth,2015,185,10.1155/2015/656323,FALSE,Hindawi Publishing Corporation,BioMed Research International,2314-6133,2314-6133,2314-6141,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,26137489,PMC4468285,NA,http://dx.doi.org/10.1155/2015/656323,TRUE
-kth,2015,185,10.1155/2015/675263,FALSE,Hindawi Publishing Corporation,Discrete Dynamics in Nature and Society,1026-0226,1026-0226,1607-887X,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/675263,TRUE
-kth,2015,185,10.1155/2015/687094,FALSE,Hindawi Publishing Corporation,Journal of Environmental and Public Health,1687-9805,1687-9805,1687-9813,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,26681961,PMC4670874,NA,http://dx.doi.org/10.1155/2015/687094,TRUE
-kth,2015,185,10.1155/2015/693869,FALSE,Hindawi Publishing Corporation,BioMed Research International,2314-6133,2314-6133,2314-6141,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,26413539,PMC4564634,NA,http://dx.doi.org/10.1155/2015/693869,TRUE
-kth,2015,185,10.1155/2015/696098,FALSE,Hindawi Publishing Corporation,Journal of Chemistry,2090-9063,2090-9063,2090-9071,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/696098,TRUE
-kth,2015,185,10.1155/2015/704213,FALSE,Hindawi Publishing Corporation,Mathematical Problems in Engineering,1024-123X,1024-123X,1563-5147,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/704213,TRUE
-kth,2015,185,10.1155/2015/805734,FALSE,Hindawi Publishing Corporation,Mathematical Problems in Engineering,1024-123X,1024-123X,1563-5147,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/805734,TRUE
-kth,2015,185,10.1155/2015/865409,FALSE,Hindawi Publishing Corporation,Abstract and Applied Analysis,1085-3375,1085-3375,1687-0409,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/865409,TRUE
-kth,2015,185,10.1155/2015/898047,FALSE,Hindawi Publishing Corporation,Journal of Sensors,1687-725X,1687-725X,1687-7268,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/898047,TRUE
-kth,2015,185,10.1155/2015/902591,FALSE,Hindawi Publishing Corporation,Journal of Electrical and Computer Engineering,2090-0147,2090-0147,2090-0155,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/902591,TRUE
-kth,2015,185,10.1155/2015/915497,FALSE,Hindawi Publishing Corporation,Mathematical Problems in Engineering,1024-123X,1024-123X,1563-5147,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/915497,TRUE
-kth,2015,185,10.1155/2015/921903,FALSE,Hindawi Publishing Corporation,Journal of Nanomaterials,1687-4110,1687-4110,1687-4129,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/921903,TRUE
-kth,2015,185,10.1155/2015/935309,FALSE,Hindawi Publishing Corporation,Advances in Optical Technologies,1687-6393,1687-6393,1687-6407,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/935309,TRUE
-kth,2015,185,10.1155/2015/974530,FALSE,Hindawi Publishing Corporation,BioMed Research International,2314-6133,2314-6133,2314-6141,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,26421308,PMC4569783,NA,http://dx.doi.org/10.1155/2015/974530,TRUE
-kth,2015,185,10.1155/2015/981759,FALSE,Hindawi Publishing Corporation,Scientific Programming,1058-9244,1058-9244,1875-919X,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/981759,TRUE
-kth,2015,1905,10.1039/C4TA06362G,TRUE,Royal Society of Chemistry (RSC),Journal of Materials Chemistry A,2050-7488,2050-7488,2050-7496,NA,NA,TRUE,NA,NA,NA,http://pubs.rsc.org/en/Content/ArticleLanding/2015/TA/C4TA06362G#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5CC02907D,TRUE,Royal Society of Chemistry (RSC),Chemical Communications,1359-7345,1359-7345,1364-548X,NA,NA,TRUE,25989158,PMC4456355,NA,http://pubs.rsc.org/en/Content/ArticleLanding/2015/CC/C5CC02907D#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5CC04822B,TRUE,Royal Society of Chemistry (RSC),Chemical Communications,1359-7345,1359-7345,1364-548X,NA,NA,TRUE,26291876,NA,NA,http://pubs.rsc.org/en/Content/ArticleLanding/2015/CC/C5CC04822B#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5CP02306H,TRUE,Royal Society of Chemistry (RSC),Physical Chemistry Chemical Physics,1463-9076,1463-9076,1463-9084,NA,NA,TRUE,26111372,NA,NA,http://pubs.rsc.org/en/Content/ArticleLanding/2015/CP/C5CP02306H#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5LC00436E,TRUE,Royal Society of Chemistry (RSC),Lab Chip,1473-0197,1473-0197,1473-0189,NA,NA,TRUE,26126574,NA,NA,http://pubs.rsc.org/en/Content/ArticleLanding/2015/LC/C5LC00436E#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5LC00490J,TRUE,Royal Society of Chemistry (RSC),Lab Chip,1473-0197,1473-0197,1473-0189,NA,NA,TRUE,26156858,NA,NA,http://pubs.rsc.org/en/Content/ArticleLanding/2015/LC/C5LC00490J#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5NR03002A,TRUE,Royal Society of Chemistry (RSC),Nanoscale,2040-3364,2040-3364,2040-3372,NA,NA,TRUE,26176739,NA,NA,http://pubs.rsc.org/en/Content/ArticleLanding/2015/NR/C5NR03002A#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5NR03965G,TRUE,Royal Society of Chemistry (RSC),Nanoscale,2040-3364,2040-3364,2040-3372,NA,NA,TRUE,26370450,NA,NA,http://pubs.rsc.org/en/Content/ArticleLanding/2015/NR/C5NR03965G#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5PY00136F,TRUE,Royal Society of Chemistry (RSC),Polymer Chemistry,1759-9954,1759-9954,1759-9962,NA,NA,TRUE,NA,NA,NA,http://pubs.rsc.org/en/Content/ArticleLanding/2015/PY/C5PY00136F#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5RA01805F,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,NA,NA,TRUE,NA,NA,NA,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA01805F#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5RA04452A,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,NA,NA,TRUE,NA,NA,NA,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA04452A#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5RA06424D,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,NA,NA,TRUE,NA,NA,NA,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA06424D#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5RA09704E,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,NA,NA,TRUE,NA,NA,NA,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA09704E#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5RA16865A,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,NA,NA,TRUE,NA,NA,NA,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA16865A#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5RA18569F,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,NA,NA,TRUE,NA,NA,NA,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA18569F#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5SC03569D,FALSE,Royal Society of Chemistry (RSC),Chemical Science,2041-6520,2041-6520,2041-6539,NA,NA,TRUE,NA,NA,NA,http://pubs.rsc.org/en/content/articlelanding/2016/sc/c5sc03569d#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5TA03120F,TRUE,Royal Society of Chemistry (RSC),Journal of Materials Chemistry A,2050-7488,2050-7488,2050-7496,NA,NA,TRUE,NA,NA,NA,http://pubs.rsc.org/en/Content/ArticleLanding/2015/TA/C5TA03120F#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5TA03646A,TRUE,Royal Society of Chemistry (RSC),Journal of Materials Chemistry A,2050-7488,2050-7488,2050-7496,NA,NA,TRUE,NA,NA,NA,http://pubs.rsc.org/en/Content/ArticleLanding/2015/TA/C5TA03646A#!divAbstract,FALSE
-kth,2015,1916.75,10.1186/s13059-015-0834-7,FALSE,BioMed Central,Genome Biology,1474-760X,NA,1474-760X,NA,NA,TRUE,26667648,PMC4699468,NA,http://genomebiology.biomedcentral.com/articles/10.1186/s13059-015-0834-7,TRUE
-kth,2015,1949,10.1016/j.carbpol.2015.02.059,TRUE,Elsevier,Carbohydrate Polymers,0144-8617,0144-8617,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25857964,NA,NA,http://www.sciencedirect.com/science/article/pii/S0144861715001757,FALSE
-kth,2015,1949,10.1016/j.yrtph.2015.05.027,TRUE,Elsevier,Regulatory Toxicology and Pharmacology,0273-2300,0273-2300,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26032492,NA,NA,http://www.sciencedirect.com/science/article/pii/S0273-2300(15)00142-7,FALSE
-kth,2015,2075,10.1016/j.jcis.2014.12.042,TRUE,Elsevier,Journal of Colloid and Interface Science,0021-9797,0021-9797,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25596372,NA,NA,http://www.sciencedirect.com/science/article/pii/S0021-9797(14)00995-3,FALSE
-kth,2015,2130,10.1093/nar/gkv036,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,NA,NA,TRUE,25618848,PMC4402512,NA,http://nar.oxfordjournals.org/content/43/7/e49,TRUE
-kth,2015,2145,10.1016/j.egypro.2014.11.1019,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)02849-5,FALSE
-kth,2015,2145,10.1016/j.egypro.2014.11.1029,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)02859-8,FALSE
-kth,2015,2145,10.1016/j.egypro.2014.11.1051,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)02881-1,FALSE
-kth,2015,2145,10.1016/j.egypro.2014.11.1175,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)03005-7,FALSE
-kth,2015,2145,10.1016/j.egypro.2014.11.1182,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)03012-4,FALSE
-kth,2015,2145,10.1016/j.egypro.2014.11.938,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)02768-4,FALSE
-kth,2015,2145,10.1016/j.egypro.2014.12.023,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)03052-5,FALSE
-kth,2015,2145,10.1016/j.egypro.2014.12.080,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)03109-9,FALSE
-kth,2015,2145,10.1016/j.egypro.2014.12.107,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)03136-1,FALSE
-kth,2015,2145,10.1016/j.egypro.2014.12.125,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)03154-3,FALSE
-kth,2015,2145,10.1016/j.egypro.2014.12.152,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)03181-6,FALSE
-kth,2015,2145,10.1016/j.egypro.2014.12.217,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)03246-9,FALSE
-kth,2015,2145,10.1016/j.egypro.2014.12.233,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)03262-7,FALSE
-kth,2015,2145,10.1016/j.egypro.2015.02.057,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)00157-5,FALSE
-kth,2015,2145,10.1016/j.egypro.2015.03.067,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)00373-2,FALSE
-kth,2015,2145,10.1016/j.egypro.2015.03.155,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)00461-0,FALSE
-kth,2015,2145,10.1016/j.egypro.2015.03.182,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)00488-9,FALSE
-kth,2015,2145,10.1016/j.egypro.2015.03.196,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)00502-0,FALSE
-kth,2015,2145,10.1016/j.egypro.2015.07.169,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)00937-6,FALSE
-kth,2015,2145,10.1016/j.egypro.2015.07.223,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)00991-1,FALSE
-kth,2015,2145,10.1016/j.egypro.2015.07.257,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)01025-5,FALSE
-kth,2015,2145,10.1016/j.egypro.2015.07.401,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)01169-8,FALSE
-kth,2015,2145,10.1016/j.egypro.2015.07.411,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)01179-0,FALSE
-kth,2015,2145,10.1016/j.egypro.2015.07.426,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)01194-7,FALSE
-kth,2015,2145,10.1016/j.egypro.2015.07.568,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)01336-3,FALSE
-kth,2015,2145,10.1016/j.egypro.2015.11.055,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)01787-7,FALSE
-kth,2015,2145,10.1016/j.egypro.2015.11.413,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)02145-1,FALSE
-kth,2015,2145,10.1016/j.egypro.2015.11.720,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)02452-2,FALSE
-kth,2015,2145,10.1016/j.proeng.2015.08.040,FALSE,Elsevier,Procedia Engineering,1877-7058,1877-7058,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1877-7058(15)01679-3,FALSE
-kth,2015,2145,10.1016/j.proeng.2015.08.043,FALSE,Elsevier,Procedia Engineering,1877-7058,1877-7058,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1877-7058(15)01682-3,FALSE
-kth,2015,2200,10.1007/s00253-015-7118-8,TRUE,Springer,Applied Microbiology and Biotechnology,0175-7598,0175-7598,1432-0614,NA,NA,TRUE,26621798,PMC4803828,NA,http://link.springer.com/article/10.1007/s00253-015-7118-8,FALSE
-kth,2015,2200,10.1007/s10237-015-0692-y,FALSE,Springer,Biomechanics and Modeling in Mechanobiology,1617-7959,1617-7959,1617-7940,NA,NA,TRUE,26104133,PMC4792364,NA,http://link.springer.com/article/10.1007/s10237-015-0692-y,FALSE
-kth,2015,2200,10.1007/s10851-015-0613-9,TRUE,Springer,Journal of Mathematical Imaging and Vision,0924-9907,0924-9907,1573-7683,NA,NA,TRUE,NA,NA,NA,http://link.springer.com/article/10.1007/s10851-015-0613-9,FALSE
-kth,2015,2200,10.1007/s11571-015-9362-0,TRUE,Springer,Cognitive Neurodynamics,1871-4080,1871-4080,1871-4099,NA,NA,TRUE,26834858,PMC4722133,NA,http://link.springer.com/article/10.1007/s11571-015-9362-0,FALSE
-kth,2015,2200,10.1007/s13280-015-0641-0,TRUE,Springer,Ambio,0044-7447,0044-7447,1654-7209,NA,NA,TRUE,25753574,PMC4591234,NA,http://link.springer.com/article/10.1007/s13280-015-0641-0,FALSE
-kth,2015,2200,10.1007/s13280-015-0732-y,TRUE,Springer,Ambio,0044-7447,0044-7447,1654-7209,NA,NA,TRUE,26667059,PMC4678124,NA,http://link.springer.com/article/10.1007/s13280-015-0732-y,FALSE
-kth,2015,2200,10.1007/s13280-015-0735-8,TRUE,Springer,Ambio,0044-7447,0044-7447,1654-7209,NA,NA,TRUE,26667054,PMC4678119,NA,http://link.springer.com/article/10.1007/s13280-015-0735-8,FALSE
-kth,2015,2231,10.1016/j.plantsci.2015.10.002,TRUE,Elsevier,Plant Science,0168-9452,0168-9452,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26706067,NA,NA,http://www.sciencedirect.com/science/article/pii/S0168-9452(15)30086-8,FALSE
-kth,2015,2275,10.1093/forestry/cpv040,TRUE,Oxford University Press (OUP),Forestry,0015-752X,0015-752X,1464-3626,NA,NA,TRUE,NA,NA,NA,http://forestry.oxfordjournals.org/content/early/2015/10/28/forestry.cpv040.short?rss=1,FALSE
-kth,2015,2275,10.1093/jigpal/jzv021,TRUE,Oxford University Press (OUP),Logic Journal of IGPL,1367-0751,1367-0751,1368-9894,NA,NA,TRUE,NA,NA,NA,http://jigpal.oxfordjournals.org/content/early/2015/07/13/jigpal.jzv021.full,FALSE
-kth,2015,2444,10.1016/j.jclepro.2014.04.045,TRUE,Elsevier,Journal of Cleaner Production,0959-6526,0959-6526,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S0959-6526(14)00400-4,FALSE
-kth,2015,2526,10.1080/00423114.2014.889317,TRUE,Taylor & Francis,Vehicle System Dynamics,0042-3114,0042-3114,1744-5159,NA,NA,TRUE,NA,NA,NA,http://www.tandfonline.com/doi/abs/10.1080/00423114.2014.889317,FALSE
+kth,2015,0,10.1007/JHEP09(2015)096,FALSE,Springer,Journal of High Energy Physics,1029-8479,NA,1029-8479,1029-8479,NA,TRUE,NA,NA,ut:000363539300002,http://link.springer.com/article/10.1007/JHEP09(2015)096,TRUE
+kth,2015,0,10.1007/s13373-015-0067-9,FALSE,Springer,Bulletin of Mathematical Sciences,1664-3607,1664-3607,1664-3615,1664-3615,NA,TRUE,NA,NA,ut:000372286800001,http://link.springer.com/article/10.1007/s13373-015-0067-9,TRUE
+kth,2015,0,10.1186/s40294-015-0009-0,FALSE,Springer Open,Complex Adaptive Systems Modeling,2194-3206,NA,2194-3206,2194-3206,NA,TRUE,NA,NA,ut:000376148700001,https://casmodeling.springeropen.com/articles/10.1186/s40294-015-0009-0,TRUE
+kth,2015,0,10.3390/catal5041737,FALSE,MDPI,Catalysts,2073-4344,NA,2073-4344,2073-4344,NA,TRUE,NA,NA,ut:000367535300008,http://www.mdpi.com/2073-4344/5/4/1737,TRUE
+kth,2015,1021,10.3390/en8032165,FALSE,MDPI,Energies,1996-1073,NA,1996-1073,1996-1073,NA,TRUE,NA,NA,ut:000351942000035,http://www.mdpi.com/1996-1073/8/3/2165,TRUE
+kth,2015,1021,10.3390/en8065287,FALSE,MDPI,Energies,1996-1073,NA,1996-1073,1996-1073,NA,TRUE,NA,NA,ut:000357489700033,http://www.mdpi.com/1996-1073/8/6/5287,TRUE
+kth,2015,1021,10.3390/su7066336,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,2071-1050,NA,TRUE,NA,NA,ut:000357593000001,http://www.mdpi.com/2071-1050/7/6/6336,TRUE
+kth,2015,1021,10.3390/su70811306,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,2071-1050,NA,TRUE,NA,NA,ut:000361600500049,http://www.mdpi.com/2071-1050/7/8/11306,TRUE
+kth,2015,1166,10.1016/j.segan.2015.06.002,TRUE,Elsevier,"Sustainable Energy, Grids and Networks",2352-4677,2352-4677,NA,2352-4677,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S2352-4677(15)00039-9,FALSE
+kth,2015,1166,10.1016/j.segan.2015.09.001,TRUE,Elsevier,"Sustainable Energy, Grids and Networks",2352-4677,2352-4677,NA,2352-4677,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S2352-4677(15)00049-1,FALSE
+kth,2015,1191,10.3390/ma8020751,FALSE,MDPI,Materials,1996-1944,NA,1996-1944,1996-1944,NA,TRUE,NA,NA,ut:000352052600026,http://www.mdpi.com/1996-1944/8/2/751,TRUE
+kth,2015,1258,10.1186/s12934-015-0227-3,FALSE,BioMed Central,Microbial Cell Factories,1475-2859,NA,1475-2859,1475-2859,NA,TRUE,25889453,PMC4415288,ut:000353617100001,https://microbialcellfactories.biomedcentral.com/articles/10.1186/s12934-015-0227-3,TRUE
+kth,2015,1258,10.1186/s12934-015-0236-2,FALSE,BioMed Central,Microbial Cell Factories,1475-2859,NA,1475-2859,1475-2859,NA,TRUE,25889969,PMC4405896,ut:000353259300001,https://microbialcellfactories.biomedcentral.com/articles/10.1186/s12934-015-0236-2,TRUE
+kth,2015,1280,10.1109/JPETS.2015.2445296,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Power and Energy Technology Systems Journal,2332-7707,NA,2332-7707,2332-7707,NA,TRUE,NA,NA,NA,http://ieeexplore.ieee.org/document/7234831/,FALSE
+kth,2015,1280,10.1109/PESGM.2016.7741306,TRUE,Institute of Electrical & Electronics Engineers (IEEE),Power and Energy Society General Meeting,NA,NA,1944-9933,1944-9925,NA,FALSE,NA,NA,NA,http://ieeexplore.ieee.org/document/7741306/,FALSE
+kth,2015,1280,10.1109/TAFFC.2015.2457417,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Affective Computing,1949-3045,1949-3045,NA,1949-3045,NA,TRUE,NA,NA,ut:000383995300007,http://ieeexplore.ieee.org/document/7160715/,FALSE
+kth,2015,1345,10.1016/j.ultrasmedbio.2015.08.012,TRUE,Elsevier,Ultrasound in Medicine & Biology,0301-5629,0301-5629,NA,0301-5629,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26454623,NA,ut:000367733800032,http://www.sciencedirect.com/science/article/pii/S0301-5629(15)00522-0,FALSE
+kth,2015,1360,10.1186/s12880-015-0086-8,FALSE,BioMed Central,BMC Medical Imaging,1471-2342,NA,1471-2342,1471-2342,http://www.springer.com/tdm,TRUE,26459634,PMC4601150,ut:000362535400001,https://bmcmedimaging.biomedcentral.com/articles/10.1186/s12880-015-0086-8,TRUE
+kth,2015,1383,10.1371/JOURNAL.PONE.0119032,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25822973,PMC4379182,ut:000352134700031,http://dx.doi.org/10.1371/journal.pone.0119032,TRUE
+kth,2015,1383,10.1371/JOURNAL.PONE.0130169,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26090859,PMC4474965,ut:000356835000093,http://dx.doi.org/10.1371/journal.pone.0130169,TRUE
+kth,2015,1383,10.1371/JOURNAL.PONE.0140644,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,https://creativecommons.org/publicdomain/zero/1.0/,TRUE,26496191,PMC4619776,ut:000363309200025,http://dx.doi.org/10.1371/journal.pone.0140644,TRUE
+kth,2015,1423.75,10.1186/s12864-015-1686-y,FALSE,BioMed Central,BMC Genomics,1471-2164,NA,1471-2164,1471-2164,NA,TRUE,26109061,PMC4479346,ut:000356761400001,http://bmcgenomics.biomedcentral.com/articles/10.1186/s12864-015-1686-y,TRUE
+kth,2015,1430,10.1109/ACCESS.2015.2414815,FALSE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Access,2169-3536,NA,2169-3536,2169-3536,NA,TRUE,NA,NA,ut:000371388200033,http://ieeexplore.ieee.org/document/7072470/,TRUE
+kth,2015,1483.25,10.1186/s12880-015-0083-y,FALSE,BioMed Central,BMC Medical Imaging,1471-2342,NA,1471-2342,1471-2342,http://www.springer.com/tdm,TRUE,26515510,PMC4627379,ut:000363921400001,http://bmcmedimaging.biomedcentral.com/articles/10.1186/s12880-015-0083-y,TRUE
+kth,2015,1505,10.1109/TASE.2015.2471305,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Automation Science and Engineering,1545-5955,1545-5955,1558-3783,1545-5955,NA,TRUE,NA,NA,ut:000362358500002,http://ieeexplore.ieee.org/document/7254252/,FALSE
+kth,2015,1505,10.1109/TIM.2015.2427731,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Instrumentation and Measurement,0018-9456,0018-9456,1557-9662,0018-9456,NA,TRUE,NA,NA,ut:000361487500019,http://ieeexplore.ieee.org/document/7104121/,FALSE
+kth,2015,1505,10.1109/TITS.2015.2431293,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Intelligent Transportation Systems,1524-9050,1524-9050,1558-0016,1524-9050,NA,TRUE,NA,NA,ut:000365958500009,http://ieeexplore.ieee.org/document/7116534/,FALSE
+kth,2015,1505,10.1109/TVT.2015.2434497,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Vehicular Technology,0018-9545,0018-9545,1939-9359,0018-9545,NA,TRUE,NA,NA,ut:000376094500004,http://ieeexplore.ieee.org/document/7109926/,FALSE
+kth,2015,1595,10.1016/j.visres.2015.03.009,TRUE,Elsevier,Vision Research,0042-6989,0042-6989,NA,0042-6989,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25817716,NA,ut:000354149100012,http://www.sciencedirect.com/science/article/pii/S0042-6989(15)00108-X,FALSE
+kth,2015,1614,10.1016/j.jbiotec.2015.07.006,TRUE,Elsevier,Journal of Biotechnology,0168-1656,0168-1656,NA,0168-1656,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26211737,NA,NA,http://www.sciencedirect.com/science/article/pii/S0168-1656(15)30063-8,FALSE
+kth,2015,1695.75,10.1186/s13068-015-0380-2,FALSE,BioMed Central,Biotechnology for Biofuels,1754-6834,NA,1754-6834,1754-6834,NA,TRUE,26613003,PMC4660834,ut:000365784000009,https://biotechnologyforbiofuels.biomedcentral.com/articles/10.1186/s13068-015-0380-2,TRUE
+kth,2015,1745,10.1186/s12934-015-0355-9,FALSE,BioMed Central,Microbial Cell Factories,1475-2859,NA,1475-2859,1475-2859,NA,TRUE,26474754,PMC4609045,ut:000362875500001,https://microbialcellfactories.biomedcentral.com/articles/10.1186/s12934-015-0355-9,TRUE
+kth,2015,1821,10.3390/s150407294,FALSE,MDPI,Sensors,1424-8220,NA,1424-8220,1424-8220,NA,TRUE,25815449,PMC4431291,ut:000354236100011,http://www.mdpi.com/1424-8220/15/4/7294,TRUE
+kth,2015,1821,10.3390/s150715265,FALSE,MDPI,Sensors,1424-8220,NA,1424-8220,1424-8220,NA,TRUE,26131675,PMC4541830,ut:000361788200022,http://www.mdpi.com/1424-8220/15/7/15265,TRUE
+kth,2015,1826,10.1016/j.medengphy.2014.11.002,TRUE,Elsevier,Medical Engineering and Physics,1350-4533,NA,NA,1350-4533,NA,FALSE,25466260,NA,ut:000349585100011,http://www.sciencedirect.com/science/article/pii/S1350-4533(14)00281-1,FALSE
+kth,2015,185,10.1155/2015/102469,FALSE,Hindawi Publishing Corporation,Mathematical Problems in Engineering,1024-123X,1024-123X,1563-5147,1024-123X,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000363165100001,http://dx.doi.org/10.1155/2015/102469,TRUE
+kth,2015,185,10.1155/2015/130741,FALSE,Hindawi Publishing Corporation,Science and Technology of Nuclear Installations,1687-6075,1687-6075,1687-6083,1687-6075,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000360730000001,http://dx.doi.org/10.1155/2015/130741,TRUE
+kth,2015,185,10.1155/2015/156196,FALSE,Hindawi Publishing Corporation,Advances in Condensed Matter Physics,1687-8108,1687-8108,1687-8124,1687-8108,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000352353400001,http://dx.doi.org/10.1155/2015/156196,TRUE
+kth,2015,185,10.1155/2015/230832,FALSE,Hindawi Publishing Corporation,Evidence-Based Complementary and Alternative Medicine,1741-427X,1741-427X,1741-4288,1741-427X,http://creativecommons.org/licenses/by/3.0/,TRUE,26170872,PMC4478384,ut:000356824500001,http://dx.doi.org/10.1155/2015/230832,TRUE
+kth,2015,185,10.1155/2015/256479,FALSE,Hindawi Publishing Corporation,Journal of Nanomaterials,1687-4110,1687-4110,1687-4129,1687-4110,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000363125000001,http://dx.doi.org/10.1155/2015/256479,TRUE
+kth,2015,185,10.1155/2015/260703,FALSE,Hindawi Publishing Corporation,BioMed Research International,2314-6133,2314-6133,2314-6141,2314-6133,http://creativecommons.org/licenses/by/3.0/,TRUE,26587533,PMC4637432,ut:000364668500001,http://dx.doi.org/10.1155/2015/260703,TRUE
+kth,2015,185,10.1155/2015/278638,FALSE,Hindawi Publishing Corporation,Science and Technology of Nuclear Installations,1687-6075,1687-6075,1687-6083,1687-6075,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000359627900001,http://dx.doi.org/10.1155/2015/278638,TRUE
+kth,2015,185,10.1155/2015/296317,FALSE,Hindawi Publishing Corporation,Science and Technology of Nuclear Installations,1687-6075,1687-6075,1687-6083,1687-6075,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,ut:000366430900001,http://dx.doi.org/10.1155/2015/296317,TRUE
+kth,2015,185,10.1155/2015/321354,FALSE,Hindawi Publishing Corporation,Journal of Nanomaterials,1687-4110,1687-4110,1687-4129,1687-4110,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000360743400001,http://dx.doi.org/10.1155/2015/321354,TRUE
+kth,2015,185,10.1155/2015/346498,FALSE,Hindawi Publishing Corporation,International Journal of Navigation and Observation,1687-5990,1687-5990,1687-6008,1687-5990,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/346498,TRUE
+kth,2015,185,10.1155/2015/390292,FALSE,Hindawi Publishing Corporation,International Journal of Polymer Science,1687-9422,1687-9422,1687-9430,1687-9422,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000356264100001,http://dx.doi.org/10.1155/2015/390292,TRUE
+kth,2015,185,10.1155/2015/574705,FALSE,Hindawi Publishing Corporation,BioMed Research International,2314-6133,2314-6133,2314-6141,2314-6133,http://creativecommons.org/licenses/by/3.0/,TRUE,26436093,PMC4575986,ut:000361696200001,http://dx.doi.org/10.1155/2015/574705,TRUE
+kth,2015,185,10.1155/2015/613247,FALSE,Hindawi Publishing Corporation,BioMed Research International,2314-6133,2314-6133,2314-6141,2314-6133,http://creativecommons.org/licenses/by/3.0/,TRUE,26557680,PMC4628745,ut:000364070700001,http://dx.doi.org/10.1155/2015/613247,TRUE
+kth,2015,185,10.1155/2015/656323,FALSE,Hindawi Publishing Corporation,BioMed Research International,2314-6133,2314-6133,2314-6141,2314-6133,http://creativecommons.org/licenses/by/3.0/,TRUE,26137489,PMC4468285,ut:000356307300001,http://dx.doi.org/10.1155/2015/656323,TRUE
+kth,2015,185,10.1155/2015/675263,FALSE,Hindawi Publishing Corporation,Discrete Dynamics in Nature and Society,1026-0226,1026-0226,1607-887X,1026-0226,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000359590800001,http://dx.doi.org/10.1155/2015/675263,TRUE
+kth,2015,185,10.1155/2015/687094,FALSE,Hindawi Publishing Corporation,Journal of Environmental and Public Health,1687-9805,1687-9805,1687-9813,1687-9805,http://creativecommons.org/licenses/by/3.0/,TRUE,26681961,PMC4670874,ut:000214603600024,http://dx.doi.org/10.1155/2015/687094,TRUE
+kth,2015,185,10.1155/2015/693869,FALSE,Hindawi Publishing Corporation,BioMed Research International,2314-6133,2314-6133,2314-6141,2314-6133,http://creativecommons.org/licenses/by/3.0/,TRUE,26413539,PMC4564634,ut:000360748700001,http://dx.doi.org/10.1155/2015/693869,TRUE
+kth,2015,185,10.1155/2015/696098,FALSE,Hindawi Publishing Corporation,Journal of Chemistry,2090-9063,2090-9063,2090-9071,2090-9071,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000363184100001,http://dx.doi.org/10.1155/2015/696098,TRUE
+kth,2015,185,10.1155/2015/704213,FALSE,Hindawi Publishing Corporation,Mathematical Problems in Engineering,1024-123X,1024-123X,1563-5147,1024-123X,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000365234900001,http://dx.doi.org/10.1155/2015/704213,TRUE
+kth,2015,185,10.1155/2015/805734,FALSE,Hindawi Publishing Corporation,Mathematical Problems in Engineering,1024-123X,1024-123X,1563-5147,1024-123X,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000360544500001,http://dx.doi.org/10.1155/2015/805734,TRUE
+kth,2015,185,10.1155/2015/865409,FALSE,Hindawi Publishing Corporation,Abstract and Applied Analysis,1085-3375,1085-3375,1687-0409,1085-3375,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/865409,TRUE
+kth,2015,185,10.1155/2015/898047,FALSE,Hindawi Publishing Corporation,Journal of Sensors,1687-725X,1687-725X,1687-7268,1687-725X,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000355139500001,http://dx.doi.org/10.1155/2015/898047,TRUE
+kth,2015,185,10.1155/2015/902591,FALSE,Hindawi Publishing Corporation,Journal of Electrical and Computer Engineering,2090-0147,2090-0147,2090-0155,2090-0147,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000214756700069,http://dx.doi.org/10.1155/2015/902591,TRUE
+kth,2015,185,10.1155/2015/915497,FALSE,Hindawi Publishing Corporation,Mathematical Problems in Engineering,1024-123X,1024-123X,1563-5147,1024-123X,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000364064300001,http://dx.doi.org/10.1155/2015/915497,TRUE
+kth,2015,185,10.1155/2015/921903,FALSE,Hindawi Publishing Corporation,Journal of Nanomaterials,1687-4110,1687-4110,1687-4129,1687-4110,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000363630700001,http://dx.doi.org/10.1155/2015/921903,TRUE
+kth,2015,185,10.1155/2015/935309,FALSE,Hindawi Publishing Corporation,Advances in Optical Technologies,1687-6393,1687-6393,1687-6407,1687-6393,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/935309,TRUE
+kth,2015,185,10.1155/2015/974530,FALSE,Hindawi Publishing Corporation,BioMed Research International,2314-6133,2314-6133,2314-6141,2314-6133,http://creativecommons.org/licenses/by/3.0/,TRUE,26421308,PMC4569783,ut:000361248100001,http://dx.doi.org/10.1155/2015/974530,TRUE
+kth,2015,185,10.1155/2015/981759,FALSE,Hindawi Publishing Corporation,Scientific Programming,1058-9244,1058-9244,1875-919X,1058-9244,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000364899300001,http://dx.doi.org/10.1155/2015/981759,TRUE
+kth,2015,1905,10.1039/C4TA06362G,TRUE,Royal Society of Chemistry (RSC),Journal of Materials Chemistry A,2050-7488,2050-7488,2050-7496,2050-7496,NA,TRUE,NA,NA,ut:000351845400042,http://pubs.rsc.org/en/Content/ArticleLanding/2015/TA/C4TA06362G#!divAbstract,FALSE
+kth,2015,1905,10.1039/C5CC02907D,TRUE,Royal Society of Chemistry (RSC),Chemical Communications,1359-7345,1359-7345,1364-548X,1359-7345,NA,TRUE,25989158,PMC4456355,ut:000355631700017,http://pubs.rsc.org/en/Content/ArticleLanding/2015/CC/C5CC02907D#!divAbstract,FALSE
+kth,2015,1905,10.1039/C5CC04822B,TRUE,Royal Society of Chemistry (RSC),Chemical Communications,1359-7345,1359-7345,1364-548X,1359-7345,NA,TRUE,26291876,NA,ut:000361540200024,http://pubs.rsc.org/en/Content/ArticleLanding/2015/CC/C5CC04822B#!divAbstract,FALSE
+kth,2015,1905,10.1039/C5CP02306H,TRUE,Royal Society of Chemistry (RSC),Physical Chemistry Chemical Physics,1463-9076,1463-9076,1463-9084,1463-9076,NA,TRUE,26111372,NA,ut:000357808500034,http://pubs.rsc.org/en/Content/ArticleLanding/2015/CP/C5CP02306H#!divAbstract,FALSE
+kth,2015,1905,10.1039/C5LC00436E,TRUE,Royal Society of Chemistry (RSC),Lab Chip,1473-0197,1473-0197,1473-0189,1473-0189,NA,TRUE,26126574,NA,ut:000358022900015,http://pubs.rsc.org/en/Content/ArticleLanding/2015/LC/C5LC00436E#!divAbstract,FALSE
+kth,2015,1905,10.1039/C5LC00490J,TRUE,Royal Society of Chemistry (RSC),Lab Chip,1473-0197,1473-0197,1473-0189,1473-0189,NA,TRUE,26156858,NA,ut:000358609500011,http://pubs.rsc.org/en/Content/ArticleLanding/2015/LC/C5LC00490J#!divAbstract,FALSE
+kth,2015,1905,10.1039/C5NR03002A,TRUE,Royal Society of Chemistry (RSC),Nanoscale,2040-3364,2040-3364,2040-3372,2040-3364,NA,TRUE,26176739,NA,ut:000358615200036,http://pubs.rsc.org/en/Content/ArticleLanding/2015/NR/C5NR03002A#!divAbstract,FALSE
+kth,2015,1905,10.1039/C5NR03965G,TRUE,Royal Society of Chemistry (RSC),Nanoscale,2040-3364,2040-3364,2040-3372,2040-3364,NA,TRUE,26370450,NA,ut:000361834100058,http://pubs.rsc.org/en/Content/ArticleLanding/2015/NR/C5NR03965G#!divAbstract,FALSE
+kth,2015,1905,10.1039/C5PY00136F,TRUE,Royal Society of Chemistry (RSC),Polymer Chemistry,1759-9954,1759-9954,1759-9962,1759-9954,NA,TRUE,NA,NA,ut:000353348700010,http://pubs.rsc.org/en/Content/ArticleLanding/2015/PY/C5PY00136F#!divAbstract,FALSE
+kth,2015,1905,10.1039/C5RA01805F,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000351556800015,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA01805F#!divAbstract,FALSE
+kth,2015,1905,10.1039/C5RA04452A,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000355703700096,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA04452A#!divAbstract,FALSE
+kth,2015,1905,10.1039/C5RA06424D,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000356865500076,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA06424D#!divAbstract,FALSE
+kth,2015,1905,10.1039/C5RA09704E,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000357805500021,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA09704E#!divAbstract,FALSE
+kth,2015,1905,10.1039/C5RA16865A,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000361116500020,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA16865A#!divAbstract,FALSE
+kth,2015,1905,10.1039/C5RA18569F,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000364073700059,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA18569F#!divAbstract,FALSE
+kth,2015,1905,10.1039/C5SC03569D,FALSE,Royal Society of Chemistry (RSC),Chemical Science,2041-6520,2041-6520,2041-6539,2041-6520,NA,TRUE,NA,NA,ut:000372614800020,http://pubs.rsc.org/en/content/articlelanding/2016/sc/c5sc03569d#!divAbstract,FALSE
+kth,2015,1905,10.1039/C5TA03120F,TRUE,Royal Society of Chemistry (RSC),Journal of Materials Chemistry A,2050-7488,2050-7488,2050-7496,2050-7496,NA,TRUE,NA,NA,ut:000359459900033,http://pubs.rsc.org/en/Content/ArticleLanding/2015/TA/C5TA03120F#!divAbstract,FALSE
+kth,2015,1905,10.1039/C5TA03646A,TRUE,Royal Society of Chemistry (RSC),Journal of Materials Chemistry A,2050-7488,2050-7488,2050-7496,2050-7496,NA,TRUE,NA,NA,ut:000358211700048,http://pubs.rsc.org/en/Content/ArticleLanding/2015/TA/C5TA03646A#!divAbstract,FALSE
+kth,2015,1916.75,10.1186/s13059-015-0834-7,FALSE,BioMed Central,Genome Biology,1474-760X,NA,1474-760X,1474-7596,NA,TRUE,26667648,PMC4699468,ut:000366898100001,http://genomebiology.biomedcentral.com/articles/10.1186/s13059-015-0834-7,TRUE
+kth,2015,1949,10.1016/j.carbpol.2015.02.059,TRUE,Elsevier,Carbohydrate Polymers,0144-8617,0144-8617,NA,0144-8617,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25857964,NA,ut:000353604200012,http://www.sciencedirect.com/science/article/pii/S0144861715001757,FALSE
+kth,2015,1949,10.1016/j.yrtph.2015.05.027,TRUE,Elsevier,Regulatory Toxicology and Pharmacology,0273-2300,0273-2300,NA,0273-2300,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26032492,NA,ut:000360255700003,http://www.sciencedirect.com/science/article/pii/S0273-2300(15)00142-7,FALSE
+kth,2015,2075,10.1016/j.jcis.2014.12.042,TRUE,Elsevier,Journal of Colloid and Interface Science,0021-9797,0021-9797,NA,0021-9797,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25596372,NA,ut:000350006700011,http://www.sciencedirect.com/science/article/pii/S0021-9797(14)00995-3,FALSE
+kth,2015,2130,10.1093/nar/gkv036,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,0305-1048,NA,TRUE,25618848,PMC4402512,ut:000354722500007,http://nar.oxfordjournals.org/content/43/7/e49,TRUE
+kth,2015,2145,10.1016/j.egypro.2014.11.1019,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)02849-5,FALSE
+kth,2015,2145,10.1016/j.egypro.2014.11.1029,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)02859-8,FALSE
+kth,2015,2145,10.1016/j.egypro.2014.11.1051,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)02881-1,FALSE
+kth,2015,2145,10.1016/j.egypro.2014.11.1175,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)03005-7,FALSE
+kth,2015,2145,10.1016/j.egypro.2014.11.1182,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)03012-4,FALSE
+kth,2015,2145,10.1016/j.egypro.2014.11.938,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)02768-4,FALSE
+kth,2015,2145,10.1016/j.egypro.2014.12.023,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)03052-5,FALSE
+kth,2015,2145,10.1016/j.egypro.2014.12.080,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)03109-9,FALSE
+kth,2015,2145,10.1016/j.egypro.2014.12.107,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)03136-1,FALSE
+kth,2015,2145,10.1016/j.egypro.2014.12.125,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)03154-3,FALSE
+kth,2015,2145,10.1016/j.egypro.2014.12.152,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)03181-6,FALSE
+kth,2015,2145,10.1016/j.egypro.2014.12.217,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)03246-9,FALSE
+kth,2015,2145,10.1016/j.egypro.2014.12.233,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(14)03262-7,FALSE
+kth,2015,2145,10.1016/j.egypro.2015.02.057,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)00157-5,FALSE
+kth,2015,2145,10.1016/j.egypro.2015.03.067,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)00373-2,FALSE
+kth,2015,2145,10.1016/j.egypro.2015.03.155,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)00461-0,FALSE
+kth,2015,2145,10.1016/j.egypro.2015.03.182,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)00488-9,FALSE
+kth,2015,2145,10.1016/j.egypro.2015.03.196,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)00502-0,FALSE
+kth,2015,2145,10.1016/j.egypro.2015.07.169,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)00937-6,FALSE
+kth,2015,2145,10.1016/j.egypro.2015.07.223,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)00991-1,FALSE
+kth,2015,2145,10.1016/j.egypro.2015.07.257,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)01025-5,FALSE
+kth,2015,2145,10.1016/j.egypro.2015.07.401,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)01169-8,FALSE
+kth,2015,2145,10.1016/j.egypro.2015.07.411,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)01179-0,FALSE
+kth,2015,2145,10.1016/j.egypro.2015.07.426,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)01194-7,FALSE
+kth,2015,2145,10.1016/j.egypro.2015.07.568,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)01336-3,FALSE
+kth,2015,2145,10.1016/j.egypro.2015.11.055,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)01787-7,FALSE
+kth,2015,2145,10.1016/j.egypro.2015.11.413,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)02145-1,FALSE
+kth,2015,2145,10.1016/j.egypro.2015.11.720,FALSE,Elsevier,Energy Procedia,1876-6102,1876-6102,NA,1876-6102,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1876-6102(15)02452-2,FALSE
+kth,2015,2145,10.1016/j.proeng.2015.08.040,FALSE,Elsevier,Procedia Engineering,1877-7058,1877-7058,NA,1877-7058,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1877-7058(15)01679-3,FALSE
+kth,2015,2145,10.1016/j.proeng.2015.08.043,FALSE,Elsevier,Procedia Engineering,1877-7058,1877-7058,NA,1877-7058,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1877-7058(15)01682-3,FALSE
+kth,2015,2200,10.1007/s00253-015-7118-8,TRUE,Springer,Applied Microbiology and Biotechnology,0175-7598,0175-7598,1432-0614,0175-7598,NA,TRUE,26621798,PMC4803828,ut:000373744200014,http://link.springer.com/article/10.1007/s00253-015-7118-8,FALSE
+kth,2015,2200,10.1007/s10237-015-0692-y,FALSE,Springer,Biomechanics and Modeling in Mechanobiology,1617-7959,1617-7959,1617-7940,1617-7940,NA,TRUE,26104133,PMC4792364,ut:000372165100006,http://link.springer.com/article/10.1007/s10237-015-0692-y,FALSE
+kth,2015,2200,10.1007/s10851-015-0613-9,TRUE,Springer,Journal of Mathematical Imaging and Vision,0924-9907,0924-9907,1573-7683,0924-9907,NA,TRUE,NA,NA,ut:000372282800004,http://link.springer.com/article/10.1007/s10851-015-0613-9,FALSE
+kth,2015,2200,10.1007/s11571-015-9362-0,TRUE,Springer,Cognitive Neurodynamics,1871-4080,1871-4080,1871-4099,1871-4080,NA,TRUE,26834858,PMC4722133,ut:000368535200002,http://link.springer.com/article/10.1007/s11571-015-9362-0,FALSE
+kth,2015,2200,10.1007/s13280-015-0641-0,TRUE,Springer,Ambio,0044-7447,0044-7447,1654-7209,0044-7447,NA,TRUE,25753574,PMC4591234,ut:000362290300003,http://link.springer.com/article/10.1007/s13280-015-0641-0,FALSE
+kth,2015,2200,10.1007/s13280-015-0732-y,TRUE,Springer,Ambio,0044-7447,0044-7447,1654-7209,0044-7447,NA,TRUE,26667059,PMC4678124,ut:000366623100006,http://link.springer.com/article/10.1007/s13280-015-0732-y,FALSE
+kth,2015,2200,10.1007/s13280-015-0735-8,TRUE,Springer,Ambio,0044-7447,0044-7447,1654-7209,0044-7447,NA,TRUE,26667054,PMC4678119,ut:000366623100001,http://link.springer.com/article/10.1007/s13280-015-0735-8,FALSE
+kth,2015,2231,10.1016/j.plantsci.2015.10.002,TRUE,Elsevier,Plant Science,0168-9452,0168-9452,NA,0168-9452,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26706067,NA,ut:000367487500015,http://www.sciencedirect.com/science/article/pii/S0168-9452(15)30086-8,FALSE
+kth,2015,2275,10.1093/forestry/cpv040,TRUE,Oxford University Press (OUP),Forestry,0015-752X,0015-752X,1464-3626,0015-752X,NA,TRUE,NA,NA,ut:000370970000003,http://forestry.oxfordjournals.org/content/early/2015/10/28/forestry.cpv040.short?rss=1,FALSE
+kth,2015,2275,10.1093/jigpal/jzv021,TRUE,Oxford University Press (OUP),Logic Journal of IGPL,1367-0751,1367-0751,1368-9894,1367-0751,NA,TRUE,NA,NA,ut:000363059700001,http://jigpal.oxfordjournals.org/content/early/2015/07/13/jigpal.jzv021.full,FALSE
+kth,2015,2444,10.1016/j.jclepro.2014.04.045,TRUE,Elsevier,Journal of Cleaner Production,0959-6526,0959-6526,NA,0959-6526,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000356990800045,http://www.sciencedirect.com/science/article/pii/S0959-6526(14)00400-4,FALSE
+kth,2015,2526,10.1080/00423114.2014.889317,TRUE,Taylor & Francis,Vehicle System Dynamics,0042-3114,0042-3114,1744-5159,0042-3114,NA,TRUE,NA,NA,ut:000337583100006,http://www.tandfonline.com/doi/abs/10.1080/00423114.2014.889317,FALSE
 kth,2015,2570,10.1016/j.ijsbe.2015.07.004,FALSE,Elsevier,International Journal of Sustainable Built Environment,2212-6090,2212-6090,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S2212-6090(15)00032-1,TRUE
-kth,2015,2570,10.1016/j.jrmge.2015.08.005,FALSE,Elsevier,Journal of Rock Mechanics and Geotechnical Engineering,1674-7755,1674-7755,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1674-7755(15)00108-0,TRUE
-kth,2015,2570,10.1016/j.sbspro.2015.11.522,FALSE,Elsevier,Procedia - Social and Behavioral Sciences,1877-0428,1877-0428,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1877-0428(15)05877-2,FALSE
-kth,2015,2678,10.1016/j.jbiomech.2015.08.027,TRUE,Elsevier,Journal of Biomechanics,0021-9290,0021-9290,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26482731,NA,NA,http://www.sciencedirect.com/science/article/pii/S0021-9290(15)00527-8,FALSE
-kth,2015,2959,10.1016/j.compscitech.2015.07.004,TRUE,Elsevier,Composites Science and Technology,0266-3538,0266-3538,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S0266353815300348,FALSE
-kth,2015,448,10.1016/j.softx.2015.06.001,FALSE,Elsevier,SoftwareX,2352-7110,2352-7110,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S2352-7110(15)00005-9,TRUE
-kth,2015,850,10.1140/epjti/s40485-015-0014-x,FALSE,Springer Open,EPJ Techniques and Instrumentation,2195-7045,2195-7045,NA,NA,NA,TRUE,NA,NA,NA,https://epjtechniquesandinstrumentation.springeropen.com/articles/10.1140/epjti/s40485-015-0014-x,TRUE
-kth,2015,923,10.3390/su7033430,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/2071-1050/7/3/3430,TRUE
-kth,2015,923,10.3390/su7043637,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/2071-1050/7/4/3637,TRUE
-kth,2015,930,10.1186/s40163-015-0027-4,FALSE,Springer,Crime Science,2193-7680,NA,2193-7680,NA,NA,TRUE,NA,NA,NA,https://crimesciencejournal.springeropen.com/articles/10.1186/s40163-015-0027-4,TRUE
-kth,2015,935,10.1186/s13638-015-0480-5,FALSE,Springer Open,EURASIP Journal on Wireless Communications and Networking,1687-1499,NA,1687-1499,NA,NA,TRUE,NA,NA,NA,http://link.springer.com/article/10.1186/s13638-015-0480-5,TRUE
-kth,2015,981.75,10.1186/s13634-015-0215-0,FALSE,Springer,EURASIP Journal on Advances in Signal Processing,1687-6180,NA,1687-6180,NA,NA,TRUE,NA,NA,NA,http://asp.eurasipjournals.springeropen.com/articles/10.1186/s13634-015-0215-0,TRUE
-kth,2015,990,10.1109/JEDS.2015.2443172,FALSE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Journal of the Electron Devices Society,2168-6734,NA,2168-6734,NA,NA,TRUE,NA,NA,NA,http://ieeexplore.ieee.org/document/7120903/,TRUE
-kth,2015,990,10.1109/JPHOT.2015.2428245,FALSE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Photonics Journal,1943-0655,NA,1943-0655,NA,NA,TRUE,NA,NA,NA,http://ieeexplore.ieee.org/document/7098342/,TRUE
-kth,2016,0,10.3390/ma9030127,FALSE,MDPI,Materials,1996-1944,NA,1996-1944,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/1996-1944/9/3/127,TRUE
-kth,2016,0,10.3390/ma9050313,FALSE,MDPI,Materials,1996-1944,NA,1996-1944,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/1996-1944/9/5/313,TRUE
-kth,2016,0,10.3390/mi7100192,FALSE,MDPI,Micromachines,2072-666X,NA,2072-666X,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/2072-666X/7/10/192,TRUE
-kth,2016,0,10.3390/molecules21030366,FALSE,MDPI,Molecules,1420-3049,NA,1420-3049,NA,NA,TRUE,26999090,NA,NA,http://www.mdpi.com/1420-3049/21/3/366,TRUE
-kth,2016,0,10.3390/w8020059,FALSE,MDPI,Water,2073-4441,NA,2073-4441,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/2073-4441/8/2/59,TRUE
-kth,2016,1072,10.3390/en9121080,FALSE,MDPI,Energies,1996-1073,NA,1996-1073,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/1996-1073/9/12/1080,TRUE
-kth,2016,1072,10.3390/ma10010057,FALSE,MDPI,Materials,1996-1944,NA,1996-1944,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/1996-1944/10/1/57,TRUE
-kth,2016,1267,10.1371/JOURNAL.PONE.0166149,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27870854,PMC5117611,NA,http://dx.doi.org/10.1371/journal.pone.0166149,TRUE
-kth,2016,1527,10.3390/s16030344,FALSE,MDPI,Sensors,1424-8220,NA,1424-8220,NA,NA,TRUE,27005623,PMC4813919,NA,http://www.mdpi.com/1424-8220/16/3/344,TRUE
-kth,2016,1707,10.1155/2016/6279571,FALSE,Hindawi Publishing Corporation,Advances in Materials Science and Engineering,1687-8434,1687-8434,1687-8442,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2016/6279571,TRUE
-kth,2016,2142.1,10.1016/j.apacoust.2016.04.004,TRUE,Elsevier,Applied Acoustics,0003-682X,0003-682X,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1016/j.apacoust.2016.04.004,FALSE
-kth,2016,2200,10.1007/s00030-016-0406-x,TRUE,Springer,Nonlinear Differential Equations and Applications NoDEA,1021-9722,1021-9722,1420-9004,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s00041-016-9507-5,TRUE,Springer,Journal of Fourier Analysis and Applications,1069-5869,1069-5869,1531-5851,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s00220-016-2749-x,TRUE,Springer,Communications in Mathematical Physics,0010-3616,0010-3616,1432-0916,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s00421-016-3499-3,TRUE,Springer,European Journal of Applied Physiology,1439-6319,1439-6319,1439-6327,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27837370,PMC5306326,NA,NA,FALSE
-kth,2016,2200,10.1007/s00466-016-1317-8,TRUE,Springer,Computational Mechanics,0178-7675,0178-7675,1432-0924,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s00707-016-1748-5,TRUE,Springer,Acta Mechanica,0001-5970,0001-5970,1619-6937,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s10040-016-1504-x,TRUE,Springer,Hydrogeology Journal,1431-2174,1431-2174,1435-0157,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s10237-016-0855-5,TRUE,Springer,Biomechanics and Modeling in Mechanobiology,1617-7959,1617-7959,1617-7940,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s10291-016-0572-7,TRUE,Springer,GPS Solutions,1080-5370,1080-5370,1521-1886,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s10444-016-9484-x,TRUE,Springer,Advances in Computational Mathematics,1019-7168,1019-7168,1572-9044,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s10544-016-0097-4,TRUE,Springer,Biomedical Microdevices,1387-2176,1387-2176,1572-8781,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27444649,PMC4956691,NA,NA,FALSE
-kth,2016,2200,10.1007/s10546-016-0190-5,TRUE,Springer,Boundary-Layer Meteorology,0006-8314,0006-8314,1573-1472,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s10570-016-1061-4,TRUE,Springer,Cellulose,0969-0239,0969-0239,1572-882X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s10570-016-1179-4,TRUE,Springer,Cellulose,0969-0239,0969-0239,1572-882X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s10693-016-0258-x,TRUE,Springer,Journal of Financial Services Research,0920-8550,0920-8550,1573-0735,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s10706-016-0069-8,TRUE,Springer,Geotechnical and Geological Engineering,0960-3182,0960-3182,1573-1529,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s10845-016-1258-2,TRUE,Springer,Journal of Intelligent Manufacturing,0956-5515,0956-5515,1572-8145,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s10853-016-0333-6,TRUE,Springer,Journal of Materials Science,0022-2461,0022-2461,1573-4803,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s10886-016-0790-z,TRUE,Springer,Journal of Chemical Ecology,0098-0331,0098-0331,1573-1561,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27896555,PMC5148791,NA,NA,FALSE
-kth,2016,2200,10.1007/s11012-016-0558-0,TRUE,Springer,Meccanica,0025-6455,0025-6455,1572-9648,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s11051-016-3597-5,TRUE,Springer,Journal of Nanoparticle Research,1388-0764,1388-0764,1572-896X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s11107-016-0676-6,TRUE,Springer,Photonic Network Communications,1387-974X,1387-974X,1572-8188,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s11116-016-9731-5,TRUE,Springer,Transportation,0049-4488,0049-4488,1572-9435,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s11118-016-9603-9,TRUE,Springer,Potential Analysis,0926-2601,0926-2601,1572-929X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s11225-016-9681-0,TRUE,Springer,Studia Logica,0039-3215,0039-3215,1572-8730,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s11249-016-0716-5,TRUE,Springer,Tribology Letters,1023-8883,1023-8883,1573-2711,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s11249-016-0775-7,TRUE,Springer,Tribology Letters,1023-8883,1023-8883,1573-2711,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s11265-016-1204-8,TRUE,Springer,Journal of Signal Processing Systems,1939-8018,1939-8018,1939-8115,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s11340-016-0240-4,TRUE,Springer,Experimental Mechanics,0014-4851,0014-4851,1741-2765,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s11367-016-1218-2,TRUE,Springer,The International Journal of Life Cycle Assessment,0948-3349,0948-3349,1614-7502,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s11661-016-3800-4,TRUE,Springer,Metallurgical and Materials Transactions A,1073-5623,1073-5623,1543-1940,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s11661-016-3839-2,TRUE,Springer,Metallurgical and Materials Transactions A,1073-5623,1073-5623,1543-1940,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s11663-016-0760-4,TRUE,Springer,Metallurgical and Materials Transactions B,1073-5615,1073-5615,1543-1916,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s11663-016-0768-9,TRUE,Springer,Metallurgical and Materials Transactions B,1073-5615,1073-5615,1543-1916,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s11663-016-0780-0,TRUE,Springer,Metallurgical and Materials Transactions B,1073-5615,1073-5615,1543-1916,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s11663-016-0788-5,TRUE,Springer,Metallurgical and Materials Transactions B,1073-5615,1073-5615,1543-1916,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s11663-016-0819-2,TRUE,Springer,Metallurgical and Materials Transactions B,1073-5615,1073-5615,1543-1916,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s11664-016-5161-6,TRUE,Springer,Journal of Electronic Materials,0361-5235,0361-5235,1543-186X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s11665-016-2294-y,TRUE,Springer,Journal of Materials Engineering and Performance,1059-9495,1059-9495,1544-1024,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s12469-016-0150-y,TRUE,Springer,Public Transport,1866-749X,1866-749X,1613-7159,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s13361-016-1460-7,TRUE,Springer,Journal of The American Society for Mass Spectrometry,1044-0305,1044-0305,1879-1123,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1007/s40831-016-0088-y,TRUE,Springer,Journal of Sustainable Metallurgy,2199-3823,2199-3823,2199-3831,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1140/epjd/e2016-70425-9,TRUE,Springer,The European Physical Journal D,1434-6060,1434-6060,1434-6079,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,2200,10.1617/s11527-016-0871-z,TRUE,Springer,Materials and Structures,1359-5997,1359-5997,1871-6873,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-kth,2016,230,10.3390/resources5030027,FALSE,MDPI,Resources,2079-9276,NA,2079-9276,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/2079-9276/5/3/27,TRUE
-kth,2016,644,10.3390/en9050315,FALSE,MDPI,Energies,1996-1073,NA,1996-1073,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/1996-1073/9/5/315,TRUE
-kth,2016,766,10.3390/catal6060090,FALSE,MDPI,Catalysts,2073-4344,NA,2073-4344,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/2073-4344/6/6/90,TRUE
-kth,2016,766,10.3390/mi7080134,FALSE,MDPI,Micromachines,2072-666X,NA,2072-666X,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/2072-666X/7/8/134,TRUE
-kth,2016,853,10.1155/2016/4729128,FALSE,Hindawi Publishing Corporation,Modelling and Simulation in Engineering,1687-5591,1687-5591,1687-5605,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2016/4729128,TRUE
-kth,2016,853,10.1155/2016/6735971,FALSE,Hindawi Publishing Corporation,Journal of Combustion,2090-1968,2090-1968,2090-1976,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2016/6735971,TRUE
-kth,2016,853,10.1155/2016/8181260,FALSE,Hindawi Publishing Corporation,Advances in Tribology,1687-5915,1687-5915,1687-5923,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2016/8181260,TRUE
-kth,2016,919,10.3390/su8040388,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/2071-1050/8/4/388,TRUE
-kth,2016,919,10.3390/su8060550,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/2071-1050/8/6/550,TRUE
-kth,2016,919,10.3390/su8111080,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/2071-1050/8/11/1080,TRUE
-kth,2016,919,10.3390/su8121227,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/2071-1050/8/12/1227,TRUE
-lakemedelsverket,2016,2200,10.1007/s13181-016-0584-2,TRUE,Springer,Journal of Medical Toxicology,1556-9039,1556-9039,1937-6995,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27638057,PMC5330960,NA,NA,FALSE
-liu,2012,468,10.1080/21663831.2012.749814,FALSE,Taylor & Francis,Materials Research Letters,2166-3831,NA,2166-3831,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-liu,2013,2429,10.1080/08351813.2013.753710,TRUE,Taylor & Francis,Research on Language & Social Interaction,0835-1813,0835-1813,1532-7973,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-liu,2013,413,10.1080/21663831.2013.865105,FALSE,Taylor & Francis,Materials Research Letters,2166-3831,NA,2166-3831,NA,NA,TRUE,NA,NA,NA,NA,FALSE
+kth,2015,2570,10.1016/j.jrmge.2015.08.005,FALSE,Elsevier,Journal of Rock Mechanics and Geotechnical Engineering,1674-7755,1674-7755,NA,1674-7755,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000214105400005,http://www.sciencedirect.com/science/article/pii/S1674-7755(15)00108-0,TRUE
+kth,2015,2570,10.1016/j.sbspro.2015.11.522,FALSE,Elsevier,Procedia - Social and Behavioral Sciences,1877-0428,1877-0428,NA,1877-0428,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1877-0428(15)05877-2,FALSE
+kth,2015,2678,10.1016/j.jbiomech.2015.08.027,TRUE,Elsevier,Journal of Biomechanics,0021-9290,0021-9290,NA,0021-9290,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26482731,NA,ut:000366064000006,http://www.sciencedirect.com/science/article/pii/S0021-9290(15)00527-8,FALSE
+kth,2015,2959,10.1016/j.compscitech.2015.07.004,TRUE,Elsevier,Composites Science and Technology,0266-3538,0266-3538,NA,0266-3538,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000362132900037,http://www.sciencedirect.com/science/article/pii/S0266353815300348,FALSE
+kth,2015,448,10.1016/j.softx.2015.06.001,FALSE,Elsevier,SoftwareX,2352-7110,2352-7110,NA,2352-7110,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S2352-7110(15)00005-9,TRUE
+kth,2015,850,10.1140/epjti/s40485-015-0014-x,FALSE,Springer Open,EPJ Techniques and Instrumentation,2195-7045,2195-7045,NA,2195-7045,NA,TRUE,NA,NA,ut:000358290800003,https://epjtechniquesandinstrumentation.springeropen.com/articles/10.1140/epjti/s40485-015-0014-x,TRUE
+kth,2015,923,10.3390/su7033430,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,2071-1050,NA,TRUE,NA,NA,ut:000351843400057,http://www.mdpi.com/2071-1050/7/3/3430,TRUE
+kth,2015,923,10.3390/su7043637,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,2071-1050,NA,TRUE,NA,NA,ut:000353715400006,http://www.mdpi.com/2071-1050/7/4/3637,TRUE
+kth,2015,930,10.1186/s40163-015-0027-4,FALSE,Springer,Crime Science,2193-7680,NA,2193-7680,2193-7680,NA,TRUE,NA,NA,NA,https://crimesciencejournal.springeropen.com/articles/10.1186/s40163-015-0027-4,TRUE
+kth,2015,935,10.1186/s13638-015-0480-5,FALSE,Springer Open,EURASIP Journal on Wireless Communications and Networking,1687-1499,NA,1687-1499,1687-1472,NA,TRUE,NA,NA,ut:000365807800002,http://link.springer.com/article/10.1186/s13638-015-0480-5,TRUE
+kth,2015,981.75,10.1186/s13634-015-0215-0,FALSE,Springer,EURASIP Journal on Advances in Signal Processing,1687-6180,NA,1687-6180,1687-6172,NA,TRUE,NA,NA,ut:000360573500001,http://asp.eurasipjournals.springeropen.com/articles/10.1186/s13634-015-0215-0,TRUE
+kth,2015,990,10.1109/JEDS.2015.2443172,FALSE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Journal of the Electron Devices Society,2168-6734,NA,2168-6734,2168-6734,NA,TRUE,NA,NA,ut:000369885000002,http://ieeexplore.ieee.org/document/7120903/,TRUE
+kth,2015,990,10.1109/JPHOT.2015.2428245,FALSE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Photonics Journal,1943-0655,NA,1943-0655,1943-0647,NA,TRUE,NA,NA,ut:000360358300035,http://ieeexplore.ieee.org/document/7098342/,TRUE
+kth,2016,0,10.3390/ma9030127,FALSE,MDPI,Materials,1996-1944,NA,1996-1944,1996-1944,NA,TRUE,NA,NA,ut:000373805400072,http://www.mdpi.com/1996-1944/9/3/127,TRUE
+kth,2016,0,10.3390/ma9050313,FALSE,MDPI,Materials,1996-1944,NA,1996-1944,1996-1944,NA,TRUE,NA,NA,ut:000378628500008,http://www.mdpi.com/1996-1944/9/5/313,TRUE
+kth,2016,0,10.3390/mi7100192,FALSE,MDPI,Micromachines,2072-666X,NA,2072-666X,2072-666X,NA,TRUE,NA,NA,ut:000389131300022,http://www.mdpi.com/2072-666X/7/10/192,TRUE
+kth,2016,0,10.3390/molecules21030366,FALSE,MDPI,Molecules,1420-3049,NA,1420-3049,1420-3049,NA,TRUE,26999090,NA,ut:000373802200117,http://www.mdpi.com/1420-3049/21/3/366,TRUE
+kth,2016,0,10.3390/w8020059,FALSE,MDPI,Water,2073-4441,NA,2073-4441,2073-4441,NA,TRUE,NA,NA,ut:000371828400020,http://www.mdpi.com/2073-4441/8/2/59,TRUE
+kth,2016,1072,10.3390/en9121080,FALSE,MDPI,Energies,1996-1073,NA,1996-1073,1996-1073,NA,TRUE,NA,NA,ut:000392402700081,http://www.mdpi.com/1996-1073/9/12/1080,TRUE
+kth,2016,1072,10.3390/ma10010057,FALSE,MDPI,Materials,1996-1944,NA,1996-1944,1996-1944,NA,TRUE,NA,NA,ut:000394838800057,http://www.mdpi.com/1996-1944/10/1/57,TRUE
+kth,2016,1267,10.1371/JOURNAL.PONE.0166149,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27870854,PMC5117611,ut:000388846400006,http://dx.doi.org/10.1371/journal.pone.0166149,TRUE
+kth,2016,1527,10.3390/s16030344,FALSE,MDPI,Sensors,1424-8220,NA,1424-8220,1424-8220,NA,TRUE,27005623,PMC4813919,ut:000373713600015,http://www.mdpi.com/1424-8220/16/3/344,TRUE
+kth,2016,1707,10.1155/2016/6279571,FALSE,Hindawi Publishing Corporation,Advances in Materials Science and Engineering,1687-8434,1687-8434,1687-8442,1687-8434,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,ut:000380314700001,http://dx.doi.org/10.1155/2016/6279571,TRUE
+kth,2016,2142.1,10.1016/j.apacoust.2016.04.004,TRUE,Elsevier,Applied Acoustics,0003-682X,0003-682X,NA,0003-682X,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000377837700008,http://dx.doi.org/10.1016/j.apacoust.2016.04.004,FALSE
+kth,2016,2200,10.1007/s00030-016-0406-x,TRUE,Springer,Nonlinear Differential Equations and Applications NoDEA,1021-9722,1021-9722,1420-9004,1021-9722,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000385149000005,NA,FALSE
+kth,2016,2200,10.1007/s00041-016-9507-5,TRUE,Springer,Journal of Fourier Analysis and Applications,1069-5869,1069-5869,1531-5851,1069-5869,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+kth,2016,2200,10.1007/s00220-016-2749-x,TRUE,Springer,Communications in Mathematical Physics,0010-3616,0010-3616,1432-0916,0010-3616,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392061000007,NA,FALSE
+kth,2016,2200,10.1007/s00421-016-3499-3,TRUE,Springer,European Journal of Applied Physiology,1439-6319,1439-6319,1439-6327,1439-6319,http://creativecommons.org/licenses/by/4.0,TRUE,27837370,PMC5306326,ut:000394313300007,NA,FALSE
+kth,2016,2200,10.1007/s00466-016-1317-8,TRUE,Springer,Computational Mechanics,0178-7675,0178-7675,1432-0924,0178-7675,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000385167200003,NA,FALSE
+kth,2016,2200,10.1007/s00707-016-1748-5,TRUE,Springer,Acta Mechanica,0001-5970,0001-5970,1619-6937,0001-5970,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000395107300021,NA,FALSE
+kth,2016,2200,10.1007/s10040-016-1504-x,TRUE,Springer,Hydrogeology Journal,1431-2174,1431-2174,1435-0157,1431-2174,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000401787800015,NA,FALSE
+kth,2016,2200,10.1007/s10237-016-0855-5,TRUE,Springer,Biomechanics and Modeling in Mechanobiology,1617-7959,1617-7959,1617-7940,1617-7940,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000400977300007,NA,FALSE
+kth,2016,2200,10.1007/s10291-016-0572-7,TRUE,Springer,GPS Solutions,1080-5370,1080-5370,1521-1886,1080-5370,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000403949500002,NA,FALSE
+kth,2016,2200,10.1007/s10444-016-9484-x,TRUE,Springer,Advances in Computational Mathematics,1019-7168,1019-7168,1572-9044,1019-7168,NA,TRUE,NA,NA,ut:000392330500010,NA,FALSE
+kth,2016,2200,10.1007/s10544-016-0097-4,TRUE,Springer,Biomedical Microdevices,1387-2176,1387-2176,1572-8781,1387-2176,http://creativecommons.org/licenses/by/4.0,TRUE,27444649,PMC4956691,ut:000381117500019,NA,FALSE
+kth,2016,2200,10.1007/s10546-016-0190-5,TRUE,Springer,Boundary-Layer Meteorology,0006-8314,0006-8314,1573-1472,0006-8314,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388586100003,NA,FALSE
+kth,2016,2200,10.1007/s10570-016-1061-4,TRUE,Springer,Cellulose,0969-0239,0969-0239,1572-882X,0969-0239,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388961200009,NA,FALSE
+kth,2016,2200,10.1007/s10570-016-1179-4,TRUE,Springer,Cellulose,0969-0239,0969-0239,1572-882X,0969-0239,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000394145500006,NA,FALSE
+kth,2016,2200,10.1007/s10693-016-0258-x,TRUE,Springer,Journal of Financial Services Research,0920-8550,0920-8550,1573-0735,0920-8550,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+kth,2016,2200,10.1007/s10706-016-0069-8,TRUE,Springer,Geotechnical and Geological Engineering,0960-3182,0960-3182,1573-1529,0960-3182,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000384332200024,NA,FALSE
+kth,2016,2200,10.1007/s10845-016-1258-2,TRUE,Springer,Journal of Intelligent Manufacturing,0956-5515,0956-5515,1572-8145,0956-5515,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+kth,2016,2200,10.1007/s10853-016-0333-6,TRUE,Springer,Journal of Materials Science,0022-2461,0022-2461,1573-4803,0022-2461,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000386785600026,NA,FALSE
+kth,2016,2200,10.1007/s10886-016-0790-z,TRUE,Springer,Journal of Chemical Ecology,0098-0331,0098-0331,1573-1561,0098-0331,http://creativecommons.org/licenses/by/4.0,TRUE,27896555,PMC5148791,ut:000390040400004,NA,FALSE
+kth,2016,2200,10.1007/s11012-016-0558-0,TRUE,Springer,Meccanica,0025-6455,0025-6455,1572-9648,0025-6455,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388980100009,NA,FALSE
+kth,2016,2200,10.1007/s11051-016-3597-5,TRUE,Springer,Journal of Nanoparticle Research,1388-0764,1388-0764,1572-896X,1388-0764,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000384553900003,NA,FALSE
+kth,2016,2200,10.1007/s11107-016-0676-6,TRUE,Springer,Photonic Network Communications,1387-974X,1387-974X,1572-8188,1387-974X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000390023700008,NA,FALSE
+kth,2016,2200,10.1007/s11116-016-9731-5,TRUE,Springer,Transportation,0049-4488,0049-4488,1572-9435,0049-4488,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+kth,2016,2200,10.1007/s11118-016-9603-9,TRUE,Springer,Potential Analysis,0926-2601,0926-2601,1572-929X,0926-2601,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000399829500004,NA,FALSE
+kth,2016,2200,10.1007/s11225-016-9681-0,TRUE,Springer,Studia Logica,0039-3215,0039-3215,1572-8730,0039-3215,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000394273900003,NA,FALSE
+kth,2016,2200,10.1007/s11249-016-0716-5,TRUE,Springer,Tribology Letters,1023-8883,1023-8883,1573-2711,1023-8883,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000382392200001,NA,FALSE
+kth,2016,2200,10.1007/s11249-016-0775-7,TRUE,Springer,Tribology Letters,1023-8883,1023-8883,1573-2711,1023-8883,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000389604800008,NA,FALSE
+kth,2016,2200,10.1007/s11265-016-1204-8,TRUE,Springer,Journal of Signal Processing Systems,1939-8018,1939-8018,1939-8115,1939-8115,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000399451800005,NA,FALSE
+kth,2016,2200,10.1007/s11340-016-0240-4,TRUE,Springer,Experimental Mechanics,0014-4851,0014-4851,1741-2765,0014-4851,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000394428900012,NA,FALSE
+kth,2016,2200,10.1007/s11367-016-1218-2,TRUE,Springer,The International Journal of Life Cycle Assessment,0948-3349,0948-3349,1614-7502,0948-3349,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000403557600007,NA,FALSE
+kth,2016,2200,10.1007/s11661-016-3800-4,TRUE,Springer,Metallurgical and Materials Transactions A,1073-5623,1073-5623,1543-1940,1073-5623,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000387856000036,NA,FALSE
+kth,2016,2200,10.1007/s11661-016-3839-2,TRUE,Springer,Metallurgical and Materials Transactions A,1073-5623,1073-5623,1543-1940,1073-5623,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000391492200001,NA,FALSE
+kth,2016,2200,10.1007/s11663-016-0760-4,TRUE,Springer,Metallurgical and Materials Transactions B,1073-5615,1073-5615,1543-1916,1073-5615,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000384548800003,NA,FALSE
+kth,2016,2200,10.1007/s11663-016-0768-9,TRUE,Springer,Metallurgical and Materials Transactions B,1073-5615,1073-5615,1543-1916,1073-5615,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000389800800036,NA,FALSE
+kth,2016,2200,10.1007/s11663-016-0780-0,TRUE,Springer,Metallurgical and Materials Transactions B,1073-5615,1073-5615,1543-1916,1073-5615,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000389800800037,NA,FALSE
+kth,2016,2200,10.1007/s11663-016-0788-5,TRUE,Springer,Metallurgical and Materials Transactions B,1073-5615,1073-5615,1543-1916,1073-5615,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392295500049,NA,FALSE
+kth,2016,2200,10.1007/s11663-016-0819-2,TRUE,Springer,Metallurgical and Materials Transactions B,1073-5615,1073-5615,1543-1916,1073-5615,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392295500021,NA,FALSE
+kth,2016,2200,10.1007/s11664-016-5161-6,TRUE,Springer,Journal of Electronic Materials,0361-5235,0361-5235,1543-186X,0361-5235,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000398937900075,NA,FALSE
+kth,2016,2200,10.1007/s11665-016-2294-y,TRUE,Springer,Journal of Materials Engineering and Performance,1059-9495,1059-9495,1544-1024,1059-9495,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000385404800033,NA,FALSE
+kth,2016,2200,10.1007/s12469-016-0150-y,TRUE,Springer,Public Transport,1866-749X,1866-749X,1613-7159,1613-7159,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+kth,2016,2200,10.1007/s13361-016-1460-7,TRUE,Springer,Journal of The American Society for Mass Spectrometry,1044-0305,1044-0305,1879-1123,1044-0305,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000385158400002,NA,FALSE
+kth,2016,2200,10.1007/s40831-016-0088-y,TRUE,Springer,Journal of Sustainable Metallurgy,2199-3823,2199-3823,2199-3831,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000400824500010,NA,FALSE
+kth,2016,2200,10.1140/epjd/e2016-70425-9,TRUE,Springer,The European Physical Journal D,1434-6060,1434-6060,1434-6079,1434-6060,NA,TRUE,NA,NA,ut:000398264200001,NA,FALSE
+kth,2016,2200,10.1617/s11527-016-0871-z,TRUE,Springer,Materials and Structures,1359-5997,1359-5997,1871-6873,1359-5997,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000385022400013,NA,FALSE
+kth,2016,230,10.3390/resources5030027,FALSE,MDPI,Resources,2079-9276,NA,2079-9276,2079-9276,NA,TRUE,NA,NA,ut:000385526200005,http://www.mdpi.com/2079-9276/5/3/27,TRUE
+kth,2016,644,10.3390/en9050315,FALSE,MDPI,Energies,1996-1073,NA,1996-1073,1996-1073,NA,TRUE,NA,NA,ut:000377263400007,http://www.mdpi.com/1996-1073/9/5/315,TRUE
+kth,2016,766,10.3390/catal6060090,FALSE,MDPI,Catalysts,2073-4344,NA,2073-4344,2073-4344,NA,TRUE,NA,NA,ut:000378839100015,http://www.mdpi.com/2073-4344/6/6/90,TRUE
+kth,2016,766,10.3390/mi7080134,FALSE,MDPI,Micromachines,2072-666X,NA,2072-666X,2072-666X,NA,TRUE,NA,NA,ut:000382467700006,http://www.mdpi.com/2072-666X/7/8/134,TRUE
+kth,2016,853,10.1155/2016/4729128,FALSE,Hindawi Publishing Corporation,Modelling and Simulation in Engineering,1687-5591,1687-5591,1687-5605,1687-5605,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,ut:000382691500001,http://dx.doi.org/10.1155/2016/4729128,TRUE
+kth,2016,853,10.1155/2016/6735971,FALSE,Hindawi Publishing Corporation,Journal of Combustion,2090-1968,2090-1968,2090-1976,2090-1976,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,ut:000386829400001,http://dx.doi.org/10.1155/2016/6735971,TRUE
+kth,2016,853,10.1155/2016/8181260,FALSE,Hindawi Publishing Corporation,Advances in Tribology,1687-5915,1687-5915,1687-5923,1687-5915,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,ut:000388858800001,http://dx.doi.org/10.1155/2016/8181260,TRUE
+kth,2016,919,10.3390/su8040388,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,2071-1050,NA,TRUE,NA,NA,ut:000375155800098,http://www.mdpi.com/2071-1050/8/4/388,TRUE
+kth,2016,919,10.3390/su8060550,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,2071-1050,NA,TRUE,NA,NA,ut:000378776800047,http://www.mdpi.com/2071-1050/8/6/550,TRUE
+kth,2016,919,10.3390/su8111080,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,2071-1050,NA,TRUE,NA,NA,ut:000389316200003,http://www.mdpi.com/2071-1050/8/11/1080,TRUE
+kth,2016,919,10.3390/su8121227,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,2071-1050,NA,TRUE,NA,NA,ut:000389317100018,http://www.mdpi.com/2071-1050/8/12/1227,TRUE
+lakemedelsverket,2016,2200,10.1007/s13181-016-0584-2,TRUE,Springer,Journal of Medical Toxicology,1556-9039,1556-9039,1937-6995,1556-9039,http://creativecommons.org/licenses/by/4.0,TRUE,27638057,PMC5330960,NA,NA,FALSE
+liu,2012,468,10.1080/21663831.2012.749814,FALSE,Taylor & Francis,Materials Research Letters,2166-3831,NA,2166-3831,2166-3831,NA,TRUE,NA,NA,ut:000209767300006,NA,FALSE
+liu,2013,2429,10.1080/08351813.2013.753710,TRUE,Taylor & Francis,Research on Language & Social Interaction,0835-1813,0835-1813,1532-7973,0835-1813,NA,TRUE,NA,NA,ut:000322633100001,NA,FALSE
+liu,2013,413,10.1080/21663831.2013.865105,FALSE,Taylor & Francis,Materials Research Letters,2166-3831,NA,2166-3831,2166-3831,NA,TRUE,NA,NA,ut:000209767800006,NA,FALSE
 liu,2014,1239,10.1080/21693277.2014.898219,FALSE,Taylor & Francis,Production & Manufacturing Research,NA,NA,NA,NA,NA,FALSE,NA,NA,NA,NA,NA
-liu,2014,2429,10.1080/1943815X.2014.921629,FALSE,Taylor & Francis,Journal of Integrative Environmental Sciences,1943-815X,1943-815X,1943-8168,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-liu,2014,372,10.1080/21663831.2014.944676,FALSE,Taylor & Francis,Materials Research Letters,2166-3831,NA,2166-3831,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-liu,2014,702,10.4161/pri.29239,TRUE,Taylor & Francis,Prion,1933-6896,1933-6896,1933-690X,NA,NA,TRUE,25495506,PMC4601348,NA,NA,FALSE
-liu,2015,2132,10.1080/10400435.2015.1092182,TRUE,Taylor & Francis,Assistive Technology,1040-0435,1040-0435,1949-3614,NA,NA,TRUE,26496529,PMC4867850,NA,NA,FALSE
-liu,2015,234,10.1080/19336896.2015.1065373,TRUE,Taylor & Francis,Prion,1933-6896,1933-6896,1933-690X,NA,NA,TRUE,26218890,PMC4601310,NA,NA,FALSE
-liu,2015,2429,10.1080/17530350.2015.1108215,TRUE,Taylor & Francis,Journal of Cultural Economy,1753-0350,1753-0350,1753-0369,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-liu,2015,755,10.1159/000440816,FALSE,Karger,Nephron Extra,1664-5529,NA,1664-5529,NA,NA,TRUE,26648973,PMC4662277,NA,NA,TRUE
-liu,2016,0,10.1080/17453674.2016.1205172,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,NA,NA,TRUE,27357416,PMC5016903,NA,NA,TRUE
-liu,2016,0,10.1080/17453674.2016.1269273,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,NA,NA,TRUE,27998203,PMC5251253,NA,NA,TRUE
-liu,2016,0,10.1080/17453674.2016.1274587,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,NA,NA,TRUE,28128005,NA,NA,NA,TRUE
-liu,2016,1169,10.1080/2331205X.2016.1239796,FALSE,Taylor & Francis,Cogent Medicine,2331-205X,NA,2331-205X,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-liu,2016,2074,10.3109/17518423.2015.1132281,TRUE,Taylor & Francis,Developmental Neurorehabilitation,1751-8423,1751-8423,1751-8431,NA,NA,TRUE,26930111,NA,NA,NA,FALSE
-liu,2016,2132,10.1080/08856257.2016.1187878,TRUE,Taylor & Francis,European Journal of Special Needs Education,0885-6257,0885-6257,1469-591X,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2132,10.1080/09537287.2016.1220649,TRUE,Taylor & Francis,Production Planning & Control,0953-7287,0953-7287,1366-5871,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2132,10.1080/14992027.2016.1219775,TRUE,Taylor & Francis,International Journal of Audiology,1499-2027,1499-2027,1708-8186,NA,NA,TRUE,27589015,PMC5044772,NA,NA,FALSE
-liu,2016,2132,10.1080/17405904.2016.1213178,TRUE,Taylor & Francis,Critical Discourse Studies,1740-5904,1740-5904,1740-5912,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2132,10.1080/17518423.2016.1211769,TRUE,Taylor & Francis,Developmental Neurorehabilitation,1751-8423,1751-8423,1751-8431,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2132,10.1080/21679169.2016.1181208,TRUE,Taylor & Francis,European Journal of Physiotherapy,2167-9169,2167-9169,2167-9177,NA,NA,TRUE,28251037,PMC5309865,NA,NA,FALSE
-liu,2016,2200,10.1007/s00158-016-1547-6,TRUE,Springer,Structural and Multidisciplinary Optimization,1615-147X,1615-147X,1615-1488,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s00158-016-1548-5,TRUE,Springer,Structural and Multidisciplinary Optimization,1615-147X,1615-147X,1615-1488,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s00167-016-4294-8,TRUE,Springer,"Knee Surgery, Sports Traumatology, Arthroscopy",0942-2056,0942-2056,1433-7347,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s00187-016-0240-7,TRUE,Springer,Journal of Management Control,2191-4761,2191-4761,2191-477X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s00209-016-1797-4,TRUE,Springer,Mathematische Zeitschrift,0025-5874,0025-5874,1432-1823,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s00213-016-4385-8,TRUE,Springer,Psychopharmacology,0033-3158,0033-3158,1432-2072,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27515665,PMC5021736,NA,NA,FALSE
-liu,2016,2200,10.1007/s00268-016-3828-z,TRUE,Springer,World Journal of Surgery,0364-2313,0364-2313,1432-2323,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s00366-016-0476-8,TRUE,Springer,Engineering with Computers,0177-0667,0177-0667,1435-5663,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s00425-016-2585-4,TRUE,Springer,Planta,0032-0935,0032-0935,1432-2048,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27562524,PMC5052319,NA,NA,FALSE
-liu,2016,2200,10.1007/s00520-016-3394-9,TRUE,Springer,Supportive Care in Cancer,0941-4355,0941-4355,1433-7339,NA,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27596267,PMC5127854,NA,NA,FALSE
-liu,2016,2200,10.1007/s00520-016-3406-9,TRUE,Springer,Supportive Care in Cancer,0941-4355,0941-4355,1433-7339,NA,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27637479,PMC5196011,NA,NA,FALSE
-liu,2016,2200,10.1007/s00787-016-0919-1,TRUE,Springer,European Child & Adolescent Psychiatry,1018-8827,1018-8827,1435-165X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s00894-016-3085-y,TRUE,Springer,Journal of Molecular Modeling,1610-2940,1610-2940,0948-5023,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27553304,PMC4995225,NA,NA,FALSE
-liu,2016,2200,10.1007/s10067-016-3470-z,TRUE,Springer,Clinical Rheumatology,0770-3198,0770-3198,1434-9949,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27832385,PMC5323479,NA,NA,FALSE
-liu,2016,2200,10.1007/s10111-016-0390-2,TRUE,Springer,"Cognition, Technology & Work",1435-5558,1435-5558,1435-5566,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s10470-016-0872-4,TRUE,Springer,Analog Integrated Circuits and Signal Processing,0925-1030,0925-1030,1573-1979,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s10472-016-9521-y,TRUE,Springer,Annals of Mathematics and Artificial Intelligence,1012-2443,1012-2443,1573-7470,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s10549-016-4007-5,TRUE,Springer,Breast Cancer Research and Treatment,0167-6806,0167-6806,1573-7217,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27722840,PMC5065613,NA,NA,FALSE
-liu,2016,2200,10.1007/s10578-016-0684-x,TRUE,Springer,Child Psychiatry & Human Development,0009-398X,0009-398X,1573-3327,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s10728-016-0333-3,TRUE,Springer,Health Care Analysis,1065-3058,1065-3058,1573-3394,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27734213,PMC5313590,NA,NA,FALSE
-liu,2016,2200,10.1007/s10798-016-9383-y,TRUE,Springer,International Journal of Technology and Design Education,0957-7572,0957-7572,1573-1804,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s10798-016-9384-x,TRUE,Springer,International Journal of Technology and Design Education,0957-7572,0957-7572,1573-1804,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s10798-016-9392-x,TRUE,Springer,International Journal of Technology and Design Education,0957-7572,0957-7572,1573-1804,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s10803-016-2986-z,TRUE,Springer,Journal of Autism and Developmental Disorders,0162-3257,0162-3257,1573-3432,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28005233,PMC5352767,NA,NA,FALSE
-liu,2016,2200,10.1007/s10806-016-9646-3,TRUE,Springer,Journal of Agricultural and Environmental Ethics,1187-7863,1187-7863,1573-322X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s10853-016-0262-4,TRUE,Springer,Journal of Materials Science,0022-2461,0022-2461,1573-4803,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s10915-016-0303-9,TRUE,Springer,Journal of Scientific Computing,0885-7474,0885-7474,1573-7691,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s10926-016-9671-0,TRUE,Springer,Journal of Occupational Rehabilitation,1053-0487,1053-0487,1573-3688,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27704343,PMC5104761,NA,NA,FALSE
-liu,2016,2200,10.1007/s10961-016-9536-x,TRUE,Springer,The Journal of Technology Transfer,0892-9912,0892-9912,1573-7047,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s11118-016-9580-z,TRUE,Springer,Potential Analysis,0926-2601,0926-2601,1572-929X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s11249-016-0805-5,TRUE,Springer,Tribology Letters,1023-8883,1023-8883,1573-2711,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s11666-016-0486-5,TRUE,Springer,Journal of Thermal Spray Technology,1059-9630,1059-9630,1544-1016,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s40726-016-0042-4,TRUE,Springer,Current Pollution Reports,2198-6592,NA,2198-6592,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,2200,10.1007/s40750-016-0052-x,TRUE,Springer,Adaptive Human Behavior and Physiology,2198-7335,NA,2198-7335,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,372,10.1080/21663831.2016.1157525,FALSE,Taylor & Francis,Materials Research Letters,2166-3831,NA,2166-3831,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,413,10.1080/21663831.2016.1245682,FALSE,Taylor & Francis,Materials Research Letters,2166-3831,NA,2166-3831,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-liu,2016,421,10.1080/21693277.2016.1200502,FALSE,Taylor & Francis,Production & Manufacturing Research,2169-3277,NA,2169-3277,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-liu,2017,1016.8,NA,FALSE,Taylor & Francis,International Journal of Burns and Trauma,2160-2026,NA,NA,NA,NA,FALSE,NA,NA,NA,http://www.ijbt.org/IJBT_V7N1.html  Int J Burn Trauma 2017;7(1):6-11,FALSE
-liu,2017,1045,10.1038/s41598-017-06457-9,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28765593,PMC5539109,NA,NA,TRUE
+liu,2014,2429,10.1080/1943815X.2014.921629,FALSE,Taylor & Francis,Journal of Integrative Environmental Sciences,1943-815X,1943-815X,1943-8168,1943-815X,NA,TRUE,NA,NA,ut:000337948900003,NA,FALSE
+liu,2014,372,10.1080/21663831.2014.944676,FALSE,Taylor & Francis,Materials Research Letters,2166-3831,NA,2166-3831,2166-3831,NA,TRUE,NA,NA,ut:000372215500003,NA,FALSE
+liu,2014,702,10.4161/pri.29239,TRUE,Taylor & Francis,Prion,1933-6896,1933-6896,1933-690X,1933-6896,NA,TRUE,25495506,PMC4601348,ut:000348376000006,NA,FALSE
+liu,2015,2132,10.1080/10400435.2015.1092182,TRUE,Taylor & Francis,Assistive Technology,1040-0435,1040-0435,1949-3614,1040-0435,NA,TRUE,26496529,PMC4867850,ut:000376031400004,NA,FALSE
+liu,2015,234,10.1080/19336896.2015.1065373,TRUE,Taylor & Francis,Prion,1933-6896,1933-6896,1933-690X,1933-6896,NA,TRUE,26218890,PMC4601310,ut:000359713000004,NA,FALSE
+liu,2015,2429,10.1080/17530350.2015.1108215,TRUE,Taylor & Francis,Journal of Cultural Economy,1753-0350,1753-0350,1753-0369,1753-0350,NA,TRUE,NA,NA,NA,NA,FALSE
+liu,2015,755,10.1159/000440816,FALSE,Karger,Nephron Extra,1664-5529,NA,1664-5529,1664-5529,NA,TRUE,26648973,PMC4662277,ut:000365682800001,NA,TRUE
+liu,2016,0,10.1080/17453674.2016.1205172,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,1745-3674,NA,TRUE,27357416,PMC5016903,ut:000387526300005,NA,TRUE
+liu,2016,0,10.1080/17453674.2016.1269273,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,1745-3674,NA,TRUE,27998203,PMC5251253,ut:000392736200001,NA,TRUE
+liu,2016,0,10.1080/17453674.2016.1274587,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,1745-3674,NA,TRUE,28128005,NA,ut:000399484400018,NA,TRUE
+liu,2016,1169,10.1080/2331205X.2016.1239796,FALSE,Taylor & Francis,Cogent Medicine,2331-205X,NA,2331-205X,2331-205X,NA,TRUE,NA,NA,NA,NA,TRUE
+liu,2016,2074,10.3109/17518423.2015.1132281,TRUE,Taylor & Francis,Developmental Neurorehabilitation,1751-8423,1751-8423,1751-8431,1751-8423,NA,TRUE,26930111,NA,ut:000399489800003,NA,FALSE
+liu,2016,2132,10.1080/08856257.2016.1187878,TRUE,Taylor & Francis,European Journal of Special Needs Education,0885-6257,0885-6257,1469-591X,0885-6257,NA,TRUE,NA,NA,ut:000385511800006,NA,FALSE
+liu,2016,2132,10.1080/09537287.2016.1220649,TRUE,Taylor & Francis,Production Planning & Control,0953-7287,0953-7287,1366-5871,0953-7287,NA,TRUE,NA,NA,ut:000384468200004,NA,FALSE
+liu,2016,2132,10.1080/14992027.2016.1219775,TRUE,Taylor & Francis,International Journal of Audiology,1499-2027,1499-2027,1708-8186,1499-2027,NA,TRUE,27589015,PMC5044772,ut:000384319900004,NA,FALSE
+liu,2016,2132,10.1080/17405904.2016.1213178,TRUE,Taylor & Francis,Critical Discourse Studies,1740-5904,1740-5904,1740-5912,1740-5904,NA,TRUE,NA,NA,ut:000396840800003,NA,FALSE
+liu,2016,2132,10.1080/17518423.2016.1211769,TRUE,Taylor & Francis,Developmental Neurorehabilitation,1751-8423,1751-8423,1751-8431,1751-8423,NA,TRUE,NA,NA,ut:000406527400008,NA,FALSE
+liu,2016,2132,10.1080/21679169.2016.1181208,TRUE,Taylor & Francis,European Journal of Physiotherapy,2167-9169,2167-9169,2167-9177,2167-9169,NA,TRUE,28251037,PMC5309865,ut:000390401100004,NA,FALSE
+liu,2016,2200,10.1007/s00158-016-1547-6,TRUE,Springer,Structural and Multidisciplinary Optimization,1615-147X,1615-147X,1615-1488,1615-147X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000398114200014,NA,FALSE
+liu,2016,2200,10.1007/s00158-016-1548-5,TRUE,Springer,Structural and Multidisciplinary Optimization,1615-147X,1615-147X,1615-1488,1615-147X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000398951100015,NA,FALSE
+liu,2016,2200,10.1007/s00167-016-4294-8,TRUE,Springer,"Knee Surgery, Sports Traumatology, Arthroscopy",0942-2056,0942-2056,1433-7347,0942-2056,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000401438900004,NA,FALSE
+liu,2016,2200,10.1007/s00187-016-0240-7,TRUE,Springer,Journal of Management Control,2191-4761,2191-4761,2191-477X,2191-4761,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+liu,2016,2200,10.1007/s00209-016-1797-4,TRUE,Springer,Mathematische Zeitschrift,0025-5874,0025-5874,1432-1823,0025-5874,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000405599900014,NA,FALSE
+liu,2016,2200,10.1007/s00213-016-4385-8,TRUE,Springer,Psychopharmacology,0033-3158,0033-3158,1432-2072,0033-3158,http://creativecommons.org/licenses/by/4.0,TRUE,27515665,PMC5021736,ut:000383672500006,NA,FALSE
+liu,2016,2200,10.1007/s00268-016-3828-z,TRUE,Springer,World Journal of Surgery,0364-2313,0364-2313,1432-2323,0364-2313,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000399693400021,NA,FALSE
+liu,2016,2200,10.1007/s00366-016-0476-8,TRUE,Springer,Engineering with Computers,0177-0667,0177-0667,1435-5663,0177-0667,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000398468100012,NA,FALSE
+liu,2016,2200,10.1007/s00425-016-2585-4,TRUE,Springer,Planta,0032-0935,0032-0935,1432-2048,0032-0935,http://creativecommons.org/licenses/by/4.0,TRUE,27562524,PMC5052319,ut:000385251200001,NA,FALSE
+liu,2016,2200,10.1007/s00520-016-3394-9,TRUE,Springer,Supportive Care in Cancer,0941-4355,0941-4355,1433-7339,0941-4355,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27596267,PMC5127854,ut:000389354500020,NA,FALSE
+liu,2016,2200,10.1007/s00520-016-3406-9,TRUE,Springer,Supportive Care in Cancer,0941-4355,0941-4355,1433-7339,0941-4355,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27637479,PMC5196011,ut:000391615500007,NA,FALSE
+liu,2016,2200,10.1007/s00787-016-0919-1,TRUE,Springer,European Child & Adolescent Psychiatry,1018-8827,1018-8827,1435-165X,1018-8827,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000399701900007,NA,FALSE
+liu,2016,2200,10.1007/s00894-016-3085-y,TRUE,Springer,Journal of Molecular Modeling,1610-2940,1610-2940,0948-5023,0948-5023,http://creativecommons.org/licenses/by/4.0,TRUE,27553304,PMC4995225,ut:000382748100024,NA,FALSE
+liu,2016,2200,10.1007/s10067-016-3470-z,TRUE,Springer,Clinical Rheumatology,0770-3198,0770-3198,1434-9949,0770-3198,http://creativecommons.org/licenses/by/4.0,TRUE,27832385,PMC5323479,ut:000394989700002,NA,FALSE
+liu,2016,2200,10.1007/s10111-016-0390-2,TRUE,Springer,"Cognition, Technology & Work",1435-5558,1435-5558,1435-5566,1435-5558,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000386502500001,NA,FALSE
+liu,2016,2200,10.1007/s10470-016-0872-4,TRUE,Springer,Analog Integrated Circuits and Signal Processing,0925-1030,0925-1030,1573-1979,0925-1030,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000391922200005,NA,FALSE
+liu,2016,2200,10.1007/s10472-016-9521-y,TRUE,Springer,Annals of Mathematics and Artificial Intelligence,1012-2443,1012-2443,1573-7470,1012-2443,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000382884300003,NA,FALSE
+liu,2016,2200,10.1007/s10549-016-4007-5,TRUE,Springer,Breast Cancer Research and Treatment,0167-6806,0167-6806,1573-7217,0167-6806,http://creativecommons.org/licenses/by/4.0,TRUE,27722840,PMC5065613,ut:000386370400012,NA,FALSE
+liu,2016,2200,10.1007/s10578-016-0684-x,TRUE,Springer,Child Psychiatry & Human Development,0009-398X,0009-398X,1573-3327,0009-398X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+liu,2016,2200,10.1007/s10728-016-0333-3,TRUE,Springer,Health Care Analysis,1065-3058,1065-3058,1573-3394,1065-3058,http://creativecommons.org/licenses/by/4.0,TRUE,27734213,PMC5313590,ut:000395099900002,NA,FALSE
+liu,2016,2200,10.1007/s10798-016-9383-y,TRUE,Springer,International Journal of Technology and Design Education,0957-7572,0957-7572,1573-1804,0957-7572,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+liu,2016,2200,10.1007/s10798-016-9384-x,TRUE,Springer,International Journal of Technology and Design Education,0957-7572,0957-7572,1573-1804,0957-7572,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+liu,2016,2200,10.1007/s10798-016-9392-x,TRUE,Springer,International Journal of Technology and Design Education,0957-7572,0957-7572,1573-1804,0957-7572,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+liu,2016,2200,10.1007/s10803-016-2986-z,TRUE,Springer,Journal of Autism and Developmental Disorders,0162-3257,0162-3257,1573-3432,0162-3257,http://creativecommons.org/licenses/by/4.0,TRUE,28005233,PMC5352767,ut:000396815400014,NA,FALSE
+liu,2016,2200,10.1007/s10806-016-9646-3,TRUE,Springer,Journal of Agricultural and Environmental Ethics,1187-7863,1187-7863,1573-322X,1187-7863,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388117900008,NA,FALSE
+liu,2016,2200,10.1007/s10853-016-0262-4,TRUE,Springer,Journal of Materials Science,0022-2461,0022-2461,1573-4803,0022-2461,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000383102400009,NA,FALSE
+liu,2016,2200,10.1007/s10915-016-0303-9,TRUE,Springer,Journal of Scientific Computing,0885-7474,0885-7474,1573-7691,0885-7474,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000398062500015,NA,FALSE
+liu,2016,2200,10.1007/s10926-016-9671-0,TRUE,Springer,Journal of Occupational Rehabilitation,1053-0487,1053-0487,1573-3688,1053-0487,http://creativecommons.org/licenses/by/4.0,TRUE,27704343,PMC5104761,ut:000392946000008,NA,FALSE
+liu,2016,2200,10.1007/s10961-016-9536-x,TRUE,Springer,The Journal of Technology Transfer,0892-9912,0892-9912,1573-7047,0892-9912,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+liu,2016,2200,10.1007/s11118-016-9580-z,TRUE,Springer,Potential Analysis,0926-2601,0926-2601,1572-929X,0926-2601,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392303500011,NA,FALSE
+liu,2016,2200,10.1007/s11249-016-0805-5,TRUE,Springer,Tribology Letters,1023-8883,1023-8883,1573-2711,1023-8883,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000397039300023,NA,FALSE
+liu,2016,2200,10.1007/s11666-016-0486-5,TRUE,Springer,Journal of Thermal Spray Technology,1059-9630,1059-9630,1544-1016,1059-9630,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392060300014,NA,FALSE
+liu,2016,2200,10.1007/s40726-016-0042-4,TRUE,Springer,Current Pollution Reports,2198-6592,NA,2198-6592,2198-6592,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+liu,2016,2200,10.1007/s40750-016-0052-x,TRUE,Springer,Adaptive Human Behavior and Physiology,2198-7335,NA,2198-7335,2198-7335,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000407116000005,NA,FALSE
+liu,2016,372,10.1080/21663831.2016.1157525,FALSE,Taylor & Francis,Materials Research Letters,2166-3831,NA,2166-3831,2166-3831,NA,TRUE,NA,NA,ut:000385011000004,NA,FALSE
+liu,2016,413,10.1080/21663831.2016.1245682,FALSE,Taylor & Francis,Materials Research Letters,2166-3831,NA,2166-3831,2166-3831,NA,TRUE,NA,NA,ut:000405591300002,NA,FALSE
+liu,2016,421,10.1080/21693277.2016.1200502,FALSE,Taylor & Francis,Production & Manufacturing Research,2169-3277,NA,2169-3277,2169-3277,NA,TRUE,NA,NA,ut:000379824300001,NA,TRUE
+liu,2017,1016.8,NA,FALSE,Taylor & Francis,International Journal of Burns and Trauma,2160-2026,NA,NA,2160-2026,NA,FALSE,NA,NA,NA,http://www.ijbt.org/IJBT_V7N1.html  Int J Burn Trauma 2017;7(1):6-11,FALSE
+liu,2017,1045,10.1038/s41598-017-06457-9,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://creativecommons.org/licenses/by/4.0,TRUE,28765593,PMC5539109,ut:000406764200045,NA,TRUE
 liu,2017,1109.7,10.1108/JKM-10-2016-0438,TRUE,NA,NA,NA,NA,NA,NA,NA,FALSE,NA,NA,NA,NA,NA
-liu,2017,1121,10.1016/j.invent.2017.01.001,FALSE,Elsevier,Internet Interventions,2214-7829,2214-7829,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,TRUE
-liu,2017,1121,10.1016/j.invent.2017.03.002,FALSE,Elsevier,Internet Interventions,2214-7829,2214-7829,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,TRUE
-liu,2017,1163.3,10.1063/1.4974461,FALSE,AIP Publishing,AIP Advances,2158-3226,NA,2158-3226,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-liu,2017,1165,10.1038/srep39773,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,28004789,PMC5177919,NA,NA,TRUE
-liu,2017,1244,10.3390/en10010100,FALSE,MDPI,Energies,1996-1073,NA,1996-1073,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-liu,2017,1264,10.1126/sciadv.1600327,FALSE,American Association for the Advancement of Science (AAAS),Science Advances,2375-2548,NA,2375-2548,NA,NA,TRUE,28138542,PMC5266480,NA,NA,TRUE
-liu,2017,1288,10.1371/journal.pone.0166548,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27875555,PMC5119770,NA,NA,TRUE
-liu,2017,1288,10.1371/journal.pone.0171714,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28182733,PMC5300157,NA,NA,TRUE
-liu,2017,1300,10.1371/journal.pone.0178614,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28609475,PMC5469470,NA,NA,TRUE
-liu,2017,1300,10.1371/journal.pone.0178729,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28570682,PMC5453572,NA,NA,TRUE
-liu,2017,1300.9,10.1242/bio.022749,FALSE,The Company of Biologists,Biology Open,2046-6390,NA,2046-6390,NA,http://creativecommons.org/licenses/by/3.0,TRUE,28711868,PMC5550906,NA,NA,TRUE
-liu,2017,1305,10.1038/s41598-017-01052-4,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28446745,PMC5430933,NA,NA,TRUE
-liu,2017,1305,10.1038/s41598-017-01846-6,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28500342,PMC5432006,NA,NA,TRUE
-liu,2017,1305,10.1038/s41598-017-03089-x,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28592851,PMC5462838,NA,NA,TRUE
-liu,2017,1305,10.1038/s41598-017-03236-4,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28607425,PMC5468340,NA,NA,TRUE
-liu,2017,1305,10.1038/s41598-017-04041-9,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28634361,PMC5478663,NA,NA,TRUE
-liu,2017,1305,10.1038/s41598-017-04339-8,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28638144,PMC5479795,NA,NA,TRUE
-liu,2017,1305,10.1038/s41598-017-06339-0,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28740184,PMC5524911,NA,NA,TRUE
-liu,2017,1305,10.1038/s41598-017-07129-4,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28811496,NA,NA,NA,TRUE
-liu,2017,1305,10.1038/srep42132,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,NA,TRUE,28176841,PMC5296865,NA,NA,TRUE
-liu,2017,1305,10.1038/srep42733,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,NA,TRUE,28198437,PMC5309876,NA,NA,TRUE
-liu,2017,1305,10.1038/srep43209,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,NA,TRUE,28233795,PMC5324097,NA,NA,TRUE
-liu,2017,1305,10.1038/srep44390,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,NA,TRUE,28290508,PMC5349532,NA,NA,TRUE
-liu,2017,1305,10.1038/srep46092,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,NA,TRUE,28382949,PMC5382674,NA,NA,TRUE
-liu,2017,1305,10.1038/srep46428,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,NA,TRUE,28462921,PMC5411961,NA,NA,TRUE
-liu,2017,1305,10.1038/srep46618,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,NA,TRUE,28425452,PMC5397859,NA,NA,TRUE
-liu,2017,1316,10.1371/journal.pone.0177795,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28520793,PMC5433745,NA,NA,TRUE
-liu,2017,1325,10.1371/journal.pone.0177004,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28481924,PMC5421773,NA,NA,TRUE
-liu,2017,1338,10.3390/e19060257,FALSE,MDPI,Entropy,1099-4300,NA,1099-4300,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-liu,2017,1342,10.1371/journal.pone.0172797,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28264197,PMC5339395,NA,NA,TRUE
-liu,2017,1342,10.1371/journal.pone.0174475,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28350877,PMC5370125,NA,NA,TRUE
-liu,2017,1344.9,10.1186/s12887-017-0864-2,FALSE,Springer,BMC Pediatrics,1471-2431,NA,1471-2431,NA,NA,TRUE,28431506,PMC5401349,NA,NA,TRUE
-liu,2017,1355,10.1371/journal.pone.0173897,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28296934,PMC5352000,NA,NA,TRUE
-liu,2017,1355,10.1371/journal.pone.0174177,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28329022,PMC5362084,NA,NA,TRUE
-liu,2017,1357,10.1371/journal.pone.0174880,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28448590,PMC5407645,NA,NA,TRUE
-liu,2017,1361.5,10.1021/acs.jpcc.7b01758,TRUE,American Chemical Society (ACS),The Journal of Physical Chemistry C,1932-7447,1932-7447,1932-7455,NA,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,NA,NA,NA,NA,FALSE
-liu,2017,1413,10.1016/j.nicl.2017.06.001,FALSE,Elsevier,NeuroImage: Clinical,2213-1582,2213-1582,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,28649489,PMC5470568,NA,NA,TRUE
-liu,2017,1513,10.1186/s13034-017-0146-7,FALSE,Springer,Child and Adolescent Psychiatry and Mental Health,1753-2000,NA,1753-2000,NA,NA,TRUE,28265299,PMC5331746,NA,NA,TRUE
-liu,2017,1516,10.1186/s12864-017-3488-x,FALSE,Springer,BMC Genomics,1471-2164,NA,1471-2164,NA,NA,TRUE,28100167,PMC5242001,NA,NA,TRUE
-liu,2017,1519.5,10.1186/s12906-017-1844-7,FALSE,Springer,BMC Complementary and Alternative Medicine,1472-6882,NA,1472-6882,NA,NA,TRUE,28693538,PMC5504801,NA,NA,TRUE
-liu,2017,1522.6,10.1186/s12891-017-1581-6,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,NA,NA,TRUE,28623897,PMC5474047,NA,NA,TRUE
-liu,2017,1537.5,10.1186/s12944-017-0505-7,FALSE,Springer,Lipids in Health and Disease,1476-511X,NA,1476-511X,NA,NA,TRUE,28606089,PMC5469054,NA,NA,TRUE
-liu,2017,1551,10.1097/MD.0000000000006130,TRUE,Wolters Kluwer,Medicine,0025-7974,0025-7974,NA,NA,NA,TRUE,28248866,PMC5340439,NA,NA,TRUE
-liu,2017,1560,10.1088/1367-2630/aa5f8e,FALSE,IOP Publishing,New Journal of Physics,1367-2630,NA,1367-2630,NA,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,NA,NA,TRUE
-liu,2017,1565,10.1186/s13063-017-1898-3,FALSE,Springer,Trials,1745-6215,NA,1745-6215,NA,NA,TRUE,28372563,PMC5379716,NA,NA,TRUE
-liu,2017,1566,10.1038/srep43512,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,NA,TRUE,28266628,PMC5339898,NA,NA,TRUE
-liu,2017,1566,10.1038/srep45864,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,NA,TRUE,28361922,PMC5374464,NA,NA,TRUE
-liu,2017,1569.1,10.1186/s12889-017-4357-x,FALSE,Springer,BMC Public Health,1471-2458,NA,1471-2458,NA,NA,TRUE,28490328,PMC5426082,NA,NA,TRUE
-liu,2017,1578,NA,TRUE,Springer,JoVE - Journal of Visualized Experiments,1940-087X,NA,NA,NA,NA,FALSE,NA,NA,NA,https://www.jove.com/video/56279/imaging-amyloid-tissues-stained-with-luminescent-conjugated,FALSE
-liu,2017,1591.5,10.1186/s12872-017-0512-7,FALSE,Springer,BMC Cardiovascular Disorders,1471-2261,NA,1471-2261,NA,NA,TRUE,28288580,PMC5348799,NA,NA,TRUE
-liu,2017,1613,10.3390/ijms18050943,FALSE,MDPI,International Journal of Molecular Sciences,1422-0067,NA,1422-0067,NA,NA,TRUE,28468237,PMC5454856,NA,NA,TRUE
-liu,2017,1619.6,10.1186/s12872-017-0557-7,FALSE,Springer,BMC Cardiovascular Disorders,1471-2261,NA,1471-2261,NA,NA,TRUE,28545400,PMC5445354,NA,NA,TRUE
-liu,2017,1642,10.1002/brb3.763,TRUE,Wiley,Brain and Behavior,2162-3279,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,28828222,NA,NA,NA,TRUE
-liu,2017,1694.6,10.3389/fchem.2017.00028,FALSE,Frontiers,Frontiers in Chemistry,2296-2646,NA,2296-2646,NA,NA,TRUE,28487854,PMC5403830,NA,NA,TRUE
-liu,2017,1722.5,10.1534/g3.116.028308,FALSE,Genetics Society of America,G3: Genes|Genomes|Genetics,2160-1836,NA,2160-1836,NA,NA,TRUE,27678519,PMC5144961,NA,NA,TRUE
-liu,2017,1750.8,10.1186/s13049-017-0395-8,FALSE,Springer,"Scandinavian Journal of Trauma, Resuscitation and Emergency Medicine",1757-7241,NA,1757-7241,NA,NA,TRUE,28526053,PMC5438497,NA,NA,TRUE
-liu,2017,1757,10.1364/OE.25.008192,TRUE,Optical Society of America (OSA),Optics Express,1094-4087,NA,1094-4087,NA,NA,TRUE,28380934,NA,NA,NA,FALSE
-liu,2017,1784,10.1177/1687814017695174,TRUE,SAGE Publications,Advances in Mechanical Engineering,1687-8140,1687-8140,1687-8140,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-liu,2017,1823.9,10.3389/fphys.2017.00043,FALSE,Frontiers,Frontiers in Physiology,1664-042X,NA,1664-042X,NA,NA,TRUE,28220076,PMC5292575,NA,NA,TRUE
-liu,2017,1830,10.1016/j.npep.2017.03.005,TRUE,Elsevier,Neuropeptides,0143-4179,0143-4179,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,28434790,NA,NA,NA,FALSE
-liu,2017,1837.4,10.1186/s12991-017-0137-3,FALSE,Springer,Annals of General Psychiatry,1744-859X,NA,1744-859X,NA,NA,TRUE,28250802,PMC5324239,NA,NA,TRUE
-liu,2017,1848.4,10.1534/g3.116.037721,FALSE,Genetics Society of America,G3: Genes|Genomes|Genetics,2160-1836,NA,2160-1836,NA,NA,TRUE,27974436,PMC5295596,NA,NA,TRUE
-liu,2017,1891.7,10.1186/s11556-017-0171-9,FALSE,Springer,European Review of Aging and Physical Activity,1813-7253,1813-7253,1861-6909,NA,NA,TRUE,28203305,PMC5303292,NA,NA,TRUE
-liu,2017,1900,10.1136/bmjopen-2016-014230,FALSE,BMJ,BMJ Open,2044-6055,2044-6055,2044-6055,NA,NA,TRUE,28645953,NA,NA,NA,TRUE
-liu,2017,1934,10.1088/1361-6463/aa57bc,TRUE,IOP Publishing,Journal of Physics D: Applied Physics,0022-3727,0022-3727,1361-6463,NA,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,NA,NA,FALSE
-liu,2017,1939,10.1371/journal.pntd.0005390,FALSE,Public Library of Science (PLoS),PLOS Neglected Tropical Diseases,1935-2735,NA,1935-2735,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28192437,PMC5325601,NA,NA,TRUE
-liu,2017,1940,10.1371/journal.pcbi.1005608,FALSE,Public Library of Science (PLoS),PLOS Computational Biology,1553-7358,NA,1553-7358,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28640810,PMC5501685,NA,NA,TRUE
-liu,2017,1974.9,10.1063/1.4977812,TRUE,AIP Publishing,Journal of Applied Physics,0021-8979,0021-8979,1089-7550,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,NA,NA,FALSE
-liu,2017,1993,10.1097/PTS.0000000000000369,TRUE,Wolters Kluwer,Journal of Patient Safety,1549-8417,1549-8417,NA,NA,NA,TRUE,28234728,NA,NA,NA,FALSE
-liu,2017,1994.6,10.1155/2017/5806351,FALSE,Hindawi Publishing Corporation,Evidence-Based Complementary and Alternative Medicine,1741-427X,1741-427X,1741-4288,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28270851,PMC5320299,NA,NA,TRUE
-liu,2017,2007,10.1371/journal.pgen.1006729,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28414802,PMC5411104,NA,NA,TRUE
-liu,2017,2030.5,10.2147/JPR.S119845,FALSE,Dove Medical Press,Journal of Pain Research,1178-7090,NA,1178-7090,NA,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,NA,NA,NA,NA,TRUE
-liu,2017,2030.5,10.2147/JPR.S138113,FALSE,Dove Medical Press,Journal of Pain Research,1178-7090,NA,1178-7090,NA,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,28761374,PMC5522674,NA,NA,TRUE
-liu,2017,2059.9,10.2147/JPR.S128597,FALSE,Dove Medical Press,Journal of Pain Research,1178-7090,NA,1178-7090,NA,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,28435317,PMC5388344,NA,NA,TRUE
-liu,2017,2078.9,10.2147/JPR.S125667,FALSE,Dove Medical Press,Journal of Pain Research,1178-7090,NA,1178-7090,NA,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,28331360,PMC5356922,NA,NA,TRUE
-liu,2017,2150,10.1080/07292473.2017.1326584,TRUE,Taylor & Francis,War & Society,0729-2473,0729-2473,2042-4345,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-liu,2017,2150,10.1080/08351813.2017.1301293,TRUE,Taylor & Francis,Research on Language and Social Interaction,0835-1813,0835-1813,1532-7973,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-liu,2017,2151.1,10.3389/fcimb.2017.00278,FALSE,Frontiers,Frontiers in Cellular and Infection Microbiology,2235-2988,NA,2235-2988,NA,NA,TRUE,28695112,PMC5483443,NA,NA,TRUE
-liu,2017,2174,10.1044/2016_JSLHR-H-16-0160,TRUE,American Speech Language Hearing Association,Journal of Speech Language and Hearing Research,1092-4388,1092-4388,NA,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28651255,NA,NA,NA,FALSE
-liu,2017,2174,10.2196/jmir.7101,FALSE,JMIR Publications,Journal of Medical Internet Research,1438-8871,NA,1438-8871,NA,NA,TRUE,28619700,PMC5491899,NA,NA,TRUE
-liu,2017,2215,10.1093/sf/sox043,TRUE,Oxford University Press (OUP),Social Forces,0037-7732,0037-7732,1534-7605,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-liu,2017,2236.7,10.3389/fpsyg.2017.00460,FALSE,Frontiers,Frontiers in Psychology,1664-1078,NA,1664-1078,NA,NA,TRUE,28424641,PMC5372824,NA,NA,TRUE
-liu,2017,2345,10.1016/j.bbi.2016.12.007,TRUE,Elsevier,"Brain, Behavior, and Immunity",0889-1591,0889-1591,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27940259,PMC5325121,NA,NA,FALSE
-liu,2017,2345.1,10.3389/fpsyg.2017.00368,FALSE,Frontiers,Frontiers in Psychology,1664-1078,NA,1664-1078,NA,NA,TRUE,28348542,PMC5346541,NA,NA,TRUE
-liu,2017,2463,10.1073/pnas.1617758114,TRUE,National Academy of Sciences,Proceedings of the National Academy of Sciences,0027-8424,0027-8424,1091-6490,NA,http://www.pnas.org/site/misc/userlicense.xhtml,TRUE,28420793,PMC5422791,NA,NA,FALSE
-liu,2017,2500,10.1002/cphc.201700126,TRUE,Wiley,ChemPhysChem,1439-4235,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28295951,PMC5484993,NA,NA,FALSE
-liu,2017,2530,10.1073/pnas.1616456114,TRUE,National Academy of Sciences,Proceedings of the National Academy of Sciences,0027-8424,0027-8424,1091-6490,NA,http://www.pnas.org/site/misc/userlicense.xhtml,TRUE,28242683,PMC5358360,NA,NA,FALSE
-liu,2017,2541,10.18632/oncotarget.15547,FALSE,Impact Journals,OncoTarget,1949-2553,NA,1949-2553,NA,NA,TRUE,28430630,PMC5444764,NA,NA,FALSE
-liu,2017,2629.1,10.1172/JCI90678,FALSE,American Society for Clinical Investigation,Journal of Clinical Investigation,0021-9738,0021-9738,1558-8238,NA,NA,TRUE,28287401,PMC5373882,NA,NA,FALSE
-liu,2017,2641.1,10.1158/2326-6066.CIR-16-0150,TRUE,American Association for Cancer Research (AACR),Cancer Immunology Research,2326-6066,2326-6066,2326-6074,NA,NA,TRUE,28159748,NA,NA,NA,FALSE
-liu,2017,2691,10.1016/j.amjms.2017.05.013,TRUE,Elsevier,The American Journal of the Medical Sciences,0002-9629,0002-9629,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-liu,2017,2778,10.1126/sciadv.1700345,FALSE,American Association for the Advancement of Science (AAAS),Science Advances,2375-2548,NA,2375-2548,NA,NA,TRUE,28695197,NA,NA,NA,TRUE
-liu,2017,2960,10.1016/j.sab.2017.03.002,TRUE,Elsevier,Spectrochimica Acta Part B: Atomic Spectroscopy,0584-8547,0584-8547,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-liu,2017,3011,10.18632/oncotarget.1798,FALSE,Impact Journals,OncoTarget,1949-2553,NA,1949-2553,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-liu,2017,3246,10.1126/sciadv.1700642,FALSE,American Association for the Advancement of Science (AAAS),Science Advances,2375-2548,NA,2375-2548,NA,NA,TRUE,28776034,PMC5517111,NA,NA,TRUE
-liu,2017,3270.6,10.1242/dmm.029637,FALSE,The Company of Biologists,Disease Models & Mechanisms,1754-8403,1754-8403,1754-8411,NA,http://creativecommons.org/licenses/by/3.0,TRUE,28615189,NA,NA,NA,TRUE
-liu,2017,3700,10.1038/ncomms14214,FALSE,Springer,Nature Communications,2041-1723,NA,2041-1723,NA,NA,TRUE,28139738,PMC5290323,NA,NA,TRUE
-liu,2017,3700,10.1038/ncomms15401,FALSE,Springer,Nature Communications,2041-1723,NA,2041-1723,NA,NA,TRUE,28530227,PMC5458147,NA,NA,TRUE
-liu,2017,375,10.1093/omcr/omx003,FALSE,Oxford University Press (OUP),Oxford Medical Case Reports,2053-8855,NA,2053-8855,NA,NA,TRUE,28473916,PMC5410880,NA,NA,TRUE
-liu,2017,3750,10.1002/jmri.25691,TRUE,Wiley,Journal of Magnetic Resonance Imaging,1053-1807,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28295788,NA,NA,NA,FALSE
-liu,2017,3750,10.1002/mrm.26574,TRUE,Wiley,Magnetic Resonance in Medicine,0740-3194,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28074541,NA,NA,NA,FALSE
-liu,2017,435,10.1080/21663831.2017.1343207,FALSE,Taylor & Francis,Materials Research Letters,2166-3831,NA,2166-3831,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-liu,2017,4440,10.1038/ncomms14949,FALSE,Springer,Nature Communications,2041-1723,NA,2041-1723,NA,NA,TRUE,28440271,PMC5413966,NA,NA,TRUE
-liu,2017,471,10.1016/j.dib.2016.12.046,FALSE,Elsevier,Data in Brief,2352-3409,2352-3409,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,28070549,PMC5219593,NA,NA,TRUE
-liu,2017,652,10.1042/BSR20160514,FALSE,Portland Press,Bioscience Reports,0144-8463,0144-8463,1573-4935,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27986865,PMC5271673,NA,NA,FALSE
-liu,2017,717,10.3390/app7040383,FALSE,MDPI,Applied Sciences,2076-3417,NA,2076-3417,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-liu,2017,987,10.1016/j.jbef.2017.04.002,TRUE,Elsevier,Journal of Behavioral and Experimental Finance,2214-6350,2214-6350,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-liu,2017,987,10.1097/QMH.0000000000000133,TRUE,Wolters Kluwer,Quality Management in Health Care,1063-8628,1063-8628,NA,NA,NA,TRUE,28375953,PMC5381467,NA,NA,FALSE
-lnu,2016,2200,10.1007/s00107-016-1102-6,TRUE,Springer,European Journal of Wood and Wood Products,0018-3768,0018-3768,1436-736X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lnu,2016,2200,10.1007/s00792-016-0882-2,TRUE,Springer,Extremophiles,1431-0651,1431-0651,1433-4909,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lnu,2016,2200,10.1007/s10086-016-1595-y,TRUE,Springer,Journal of Wood Science,1435-0211,1435-0211,1611-4663,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lnu,2016,2200,10.1007/s10615-016-0613-2,TRUE,Springer,Clinical Social Work Journal,0091-1674,0091-1674,1573-3343,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lnu,2016,2200,10.1007/s10896-016-9856-5,TRUE,Springer,Journal of Family Violence,0885-7482,0885-7482,1573-2851,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28163366,PMC5250674,NA,NA,FALSE
-lnu,2016,2200,10.1007/s10974-016-9458-0,TRUE,Springer,Journal of Muscle Research and Cell Motility,0142-4319,0142-4319,1573-2657,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27864648,NA,NA,NA,FALSE
-lnu,2016,2200,10.1007/s10997-016-9359-z,TRUE,Springer,Journal of Management & Governance,1385-3457,1385-3457,1572-963X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lnu,2016,2200,10.1007/s11135-016-0390-6,TRUE,Springer,Quality & Quantity,0033-5177,0033-5177,1573-7845,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lnu,2016,2200,10.1007/s11266-016-9815-z,TRUE,Springer,VOLUNTAS: International Journal of Voluntary and Nonprofit Organizations,0957-8765,0957-8765,1573-7888,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lnu,2016,2200,10.1007/s12122-016-9233-4,TRUE,Springer,Journal of Labor Research,0195-3613,0195-3613,1936-4768,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ltu,2012,2630,10.1080/02827581.2012.656142,TRUE,Taylor & Francis,Scandinavian Journal of Forest Research,0282-7581,0282-7581,1651-1891,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-ltu,2012,2630,10.1080/17480272.2012.699461,TRUE,Taylor & Francis,Wood Material Science and Engineering,1748-0272,1748-0272,1748-0280,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-ltu,2013,2630,10.1080/03585522.2012.693272,TRUE,Taylor & Francis,Scandinavian Economic History Review,0358-5522,0358-5522,1750-2837,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-ltu,2014,234,10.4161/bioe.36328,TRUE,Taylor & Francis,Bioengineered,2165-5979,2165-5979,2165-5987,NA,NA,TRUE,25424444,PMC4601276,NA,NA,FALSE
-ltu,2014,2429,10.1080/0013791X.2014.952466,TRUE,Taylor & Francis,The Engineering Economist,0013-791X,0013-791X,1547-2701,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-ltu,2014,2429,10.1080/17480930.2014.942519,TRUE,Taylor & Francis,"International Journal of Mining, Reclamation and Environment",1748-0930,1748-0930,1748-0949,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-ltu,2015,2429,10.1080/14783363.2015.1068587,TRUE,Taylor & Francis,Total Quality Management & Business Excellence,1478-3363,1478-3363,1478-3371,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-ltu,2016,2132,10.1080/03719553.2016.1224048,TRUE,Taylor & Francis,Mineral Processing and Extractive Metallurgy,0371-9553,0371-9553,1743-2855,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-ltu,2016,2200,10.1007/s00163-016-0238-z,TRUE,Springer,Research in Engineering Design,0934-9839,0934-9839,1435-6066,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ltu,2016,2200,10.1007/s00500-016-2425-2,TRUE,Springer,Soft Computing,1432-7643,1432-7643,1433-7479,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ltu,2016,2200,10.1007/s10113-016-1077-1,TRUE,Springer,Regional Environmental Change,1436-3798,1436-3798,1436-378X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ltu,2016,2200,10.1007/s10115-016-1012-2,TRUE,Springer,Knowledge and Information Systems,0219-1377,0219-1377,0219-3116,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ltu,2016,2200,10.1007/s11071-016-2994-8,TRUE,Springer,Nonlinear Dynamics,0924-090X,0924-090X,1573-269X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ltu,2016,2200,10.1007/s11242-016-0781-0,TRUE,Springer,Transport in Porous Media,0169-3913,0169-3913,1573-1634,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ltu,2016,2200,10.1007/s11249-016-0727-2,TRUE,Springer,Tribology Letters,1023-8883,1023-8883,1573-2711,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ltu,2016,2200,10.1007/s11249-016-0785-5,TRUE,Springer,Tribology Letters,1023-8883,1023-8883,1573-2711,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ltu,2016,2200,10.1007/s11249-016-0790-8,TRUE,Springer,Tribology Letters,1023-8883,1023-8883,1573-2711,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ltu,2016,2200,10.1007/s12119-016-9386-6,TRUE,Springer,Sexuality & Culture,1095-5143,1095-5143,1936-4822,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ltu,2016,2200,10.1007/s12289-016-1314-7,TRUE,Springer,International Journal of Material Forming,1960-6206,1960-6206,1960-6214,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-ltu,2016,2200,10.1007/s13399-016-0225-7,TRUE,Springer,Biomass Conversion and Biorefinery,2190-6815,2190-6815,2190-6823,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+liu,2017,1121,10.1016/j.invent.2017.01.001,FALSE,Elsevier,Internet Interventions,2214-7829,2214-7829,NA,2214-7829,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,TRUE
+liu,2017,1121,10.1016/j.invent.2017.03.002,FALSE,Elsevier,Internet Interventions,2214-7829,2214-7829,NA,2214-7829,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,TRUE
+liu,2017,1163.3,10.1063/1.4974461,FALSE,AIP Publishing,AIP Advances,2158-3226,NA,2158-3226,2158-3226,NA,TRUE,NA,NA,ut:000395789900073,NA,TRUE
+liu,2017,1165,10.1038/srep39773,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,28004789,PMC5177919,ut:000390867800001,NA,TRUE
+liu,2017,1244,10.3390/en10010100,FALSE,MDPI,Energies,1996-1073,NA,1996-1073,1996-1073,NA,TRUE,NA,NA,ut:000392422500100,NA,TRUE
+liu,2017,1264,10.1126/sciadv.1600327,FALSE,American Association for the Advancement of Science (AAAS),Science Advances,2375-2548,NA,2375-2548,2375-2548,NA,TRUE,28138542,PMC5266480,ut:000393789900001,NA,TRUE
+liu,2017,1288,10.1371/journal.pone.0166548,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27875555,PMC5119770,ut:000388886000017,NA,TRUE
+liu,2017,1288,10.1371/journal.pone.0171714,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28182733,PMC5300157,ut:000394231800095,NA,TRUE
+liu,2017,1300,10.1371/journal.pone.0178614,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28609475,PMC5469470,ut:000403274700010,NA,TRUE
+liu,2017,1300,10.1371/journal.pone.0178729,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28570682,PMC5453572,ut:000402611800112,NA,TRUE
+liu,2017,1300.9,10.1242/bio.022749,FALSE,The Company of Biologists,Biology Open,2046-6390,NA,2046-6390,2046-6390,http://creativecommons.org/licenses/by/3.0,TRUE,28711868,PMC5550906,ut:000405569500010,NA,TRUE
+liu,2017,1305,10.1038/s41598-017-01052-4,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://creativecommons.org/licenses/by/4.0,TRUE,28446745,PMC5430933,ut:000400334800006,NA,TRUE
+liu,2017,1305,10.1038/s41598-017-01846-6,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://creativecommons.org/licenses/by/4.0,TRUE,28500342,PMC5432006,ut:000401262400017,NA,TRUE
+liu,2017,1305,10.1038/s41598-017-03089-x,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://creativecommons.org/licenses/by/4.0,TRUE,28592851,PMC5462838,ut:000402879800027,NA,TRUE
+liu,2017,1305,10.1038/s41598-017-03236-4,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://creativecommons.org/licenses/by/4.0,TRUE,28607425,PMC5468340,ut:000403081900097,NA,TRUE
+liu,2017,1305,10.1038/s41598-017-04041-9,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://creativecommons.org/licenses/by/4.0,TRUE,28634361,PMC5478663,ut:000403643900077,NA,TRUE
+liu,2017,1305,10.1038/s41598-017-04339-8,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://creativecommons.org/licenses/by/4.0,TRUE,28638144,PMC5479795,ut:000403840000006,NA,TRUE
+liu,2017,1305,10.1038/s41598-017-06339-0,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://creativecommons.org/licenses/by/4.0,TRUE,28740184,PMC5524911,ut:000406260100018,NA,TRUE
+liu,2017,1305,10.1038/s41598-017-07129-4,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://creativecommons.org/licenses/by/4.0,TRUE,28811496,NA,ut:000407569300001,NA,TRUE
+liu,2017,1305,10.1038/srep42132,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,NA,TRUE,28176841,PMC5296865,ut:000393555000001,NA,TRUE
+liu,2017,1305,10.1038/srep42733,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,NA,TRUE,28198437,PMC5309876,ut:000394294800001,NA,TRUE
+liu,2017,1305,10.1038/srep43209,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,NA,TRUE,28233795,PMC5324097,ut:000395174200001,NA,TRUE
+liu,2017,1305,10.1038/srep44390,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,NA,TRUE,28290508,PMC5349532,ut:000396229500001,NA,TRUE
+liu,2017,1305,10.1038/srep46092,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,NA,TRUE,28382949,PMC5382674,ut:000398550200001,NA,TRUE
+liu,2017,1305,10.1038/srep46428,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,NA,TRUE,28462921,PMC5411961,ut:000400451400001,NA,TRUE
+liu,2017,1305,10.1038/srep46618,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,NA,TRUE,28425452,PMC5397859,ut:000399747000001,NA,TRUE
+liu,2017,1316,10.1371/journal.pone.0177795,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28520793,PMC5433745,ut:000401485500071,NA,TRUE
+liu,2017,1325,10.1371/journal.pone.0177004,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28481924,PMC5421773,ut:000401313700027,NA,TRUE
+liu,2017,1338,10.3390/e19060257,FALSE,MDPI,Entropy,1099-4300,NA,1099-4300,1099-4300,NA,TRUE,NA,NA,ut:000404454500020,NA,TRUE
+liu,2017,1342,10.1371/journal.pone.0172797,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28264197,PMC5339395,ut:000396054300018,NA,TRUE
+liu,2017,1342,10.1371/journal.pone.0174475,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28350877,PMC5370125,ut:000399174400048,NA,TRUE
+liu,2017,1344.9,10.1186/s12887-017-0864-2,FALSE,Springer,BMC Pediatrics,1471-2431,NA,1471-2431,1471-2431,NA,TRUE,28431506,PMC5401349,ut:000399640600001,NA,TRUE
+liu,2017,1355,10.1371/journal.pone.0173897,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28296934,PMC5352000,ut:000396311700075,NA,TRUE
+liu,2017,1355,10.1371/journal.pone.0174177,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28329022,PMC5362084,ut:000399094700065,NA,TRUE
+liu,2017,1357,10.1371/journal.pone.0174880,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28448590,PMC5407645,ut:000400383600006,NA,TRUE
+liu,2017,1361.5,10.1021/acs.jpcc.7b01758,TRUE,American Chemical Society (ACS),The Journal of Physical Chemistry C,1932-7447,1932-7447,1932-7455,1932-7447,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,NA,NA,ut:000399629000022,NA,FALSE
+liu,2017,1413,10.1016/j.nicl.2017.06.001,FALSE,Elsevier,NeuroImage: Clinical,2213-1582,2213-1582,NA,2213-1582,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,28649489,PMC5470568,NA,NA,TRUE
+liu,2017,1513,10.1186/s13034-017-0146-7,FALSE,Springer,Child and Adolescent Psychiatry and Mental Health,1753-2000,NA,1753-2000,1753-2000,NA,TRUE,28265299,PMC5331746,ut:000395328600001,NA,TRUE
+liu,2017,1516,10.1186/s12864-017-3488-x,FALSE,Springer,BMC Genomics,1471-2164,NA,1471-2164,1471-2164,NA,TRUE,28100167,PMC5242001,ut:000394380200005,NA,TRUE
+liu,2017,1519.5,10.1186/s12906-017-1844-7,FALSE,Springer,BMC Complementary and Alternative Medicine,1472-6882,NA,1472-6882,1472-6882,NA,TRUE,28693538,PMC5504801,ut:000405065800001,NA,TRUE
+liu,2017,1522.6,10.1186/s12891-017-1581-6,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,1471-2474,NA,TRUE,28623897,PMC5474047,ut:000403494900001,NA,TRUE
+liu,2017,1537.5,10.1186/s12944-017-0505-7,FALSE,Springer,Lipids in Health and Disease,1476-511X,NA,1476-511X,1476-511X,NA,TRUE,28606089,PMC5469054,ut:000403043600002,NA,TRUE
+liu,2017,1551,10.1097/MD.0000000000006130,TRUE,Wolters Kluwer,Medicine,0025-7974,0025-7974,NA,0025-7974,NA,TRUE,28248866,PMC5340439,ut:000395795900011,NA,TRUE
+liu,2017,1560,10.1088/1367-2630/aa5f8e,FALSE,IOP Publishing,New Journal of Physics,1367-2630,NA,1367-2630,1367-2630,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,ut:000398666100004,NA,TRUE
+liu,2017,1565,10.1186/s13063-017-1898-3,FALSE,Springer,Trials,1745-6215,NA,1745-6215,1745-6215,NA,TRUE,28372563,PMC5379716,ut:000398119900001,NA,TRUE
+liu,2017,1566,10.1038/srep43512,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,NA,TRUE,28266628,PMC5339898,ut:000395637500001,NA,TRUE
+liu,2017,1566,10.1038/srep45864,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,NA,TRUE,28361922,PMC5374464,ut:000397898100001,NA,TRUE
+liu,2017,1569.1,10.1186/s12889-017-4357-x,FALSE,Springer,BMC Public Health,1471-2458,NA,1471-2458,1471-2458,NA,TRUE,28490328,PMC5426082,ut:000401863200003,NA,TRUE
+liu,2017,1578,NA,TRUE,Springer,JoVE - Journal of Visualized Experiments,1940-087X,NA,NA,1940-087X,NA,FALSE,NA,NA,NA,https://www.jove.com/video/56279/imaging-amyloid-tissues-stained-with-luminescent-conjugated,FALSE
+liu,2017,1591.5,10.1186/s12872-017-0512-7,FALSE,Springer,BMC Cardiovascular Disorders,1471-2261,NA,1471-2261,1471-2261,NA,TRUE,28288580,PMC5348799,ut:000397683100003,NA,TRUE
+liu,2017,1613,10.3390/ijms18050943,FALSE,MDPI,International Journal of Molecular Sciences,1422-0067,NA,1422-0067,1422-0067,NA,TRUE,28468237,PMC5454856,ut:000404113900050,NA,TRUE
+liu,2017,1619.6,10.1186/s12872-017-0557-7,FALSE,Springer,BMC Cardiovascular Disorders,1471-2261,NA,1471-2261,1471-2261,NA,TRUE,28545400,PMC5445354,ut:000402158800002,NA,TRUE
+liu,2017,1642,10.1002/brb3.763,TRUE,Wiley,Brain and Behavior,2162-3279,NA,NA,2162-3279,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,28828222,NA,ut:000407906200019,NA,TRUE
+liu,2017,1694.6,10.3389/fchem.2017.00028,FALSE,Frontiers,Frontiers in Chemistry,2296-2646,NA,2296-2646,2296-2646,NA,TRUE,28487854,PMC5403830,ut:000400374400001,NA,TRUE
+liu,2017,1722.5,10.1534/g3.116.028308,FALSE,Genetics Society of America,G3: Genes|Genomes|Genetics,2160-1836,NA,2160-1836,2160-1836,NA,TRUE,27678519,PMC5144961,ut:000390591400012,NA,TRUE
+liu,2017,1750.8,10.1186/s13049-017-0395-8,FALSE,Springer,"Scandinavian Journal of Trauma, Resuscitation and Emergency Medicine",1757-7241,NA,1757-7241,1757-7241,NA,TRUE,28526053,PMC5438497,ut:000401773100001,NA,TRUE
+liu,2017,1757,10.1364/OE.25.008192,TRUE,Optical Society of America (OSA),Optics Express,1094-4087,NA,1094-4087,1094-4087,NA,TRUE,28380934,NA,ut:000398536000094,NA,FALSE
+liu,2017,1784,10.1177/1687814017695174,TRUE,SAGE Publications,Advances in Mechanical Engineering,1687-8140,1687-8140,1687-8140,1687-8132,NA,TRUE,NA,NA,ut:000400394500001,NA,TRUE
+liu,2017,1823.9,10.3389/fphys.2017.00043,FALSE,Frontiers,Frontiers in Physiology,1664-042X,NA,1664-042X,1664-042X,NA,TRUE,28220076,PMC5292575,ut:000393235000001,NA,TRUE
+liu,2017,1830,10.1016/j.npep.2017.03.005,TRUE,Elsevier,Neuropeptides,0143-4179,0143-4179,NA,0143-4179,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,28434790,NA,ut:000405880200001,NA,FALSE
+liu,2017,1837.4,10.1186/s12991-017-0137-3,FALSE,Springer,Annals of General Psychiatry,1744-859X,NA,1744-859X,1744-859X,NA,TRUE,28250802,PMC5324239,ut:000395706400001,NA,TRUE
+liu,2017,1848.4,10.1534/g3.116.037721,FALSE,Genetics Society of America,G3: Genes|Genomes|Genetics,2160-1836,NA,2160-1836,2160-1836,NA,TRUE,27974436,PMC5295596,ut:000394357100015,NA,TRUE
+liu,2017,1891.7,10.1186/s11556-017-0171-9,FALSE,Springer,European Review of Aging and Physical Activity,1813-7253,1813-7253,1861-6909,1813-7253,NA,TRUE,28203305,PMC5303292,ut:000394341900001,NA,TRUE
+liu,2017,1900,10.1136/bmjopen-2016-014230,FALSE,BMJ,BMJ Open,2044-6055,2044-6055,2044-6055,2044-6055,NA,TRUE,28645953,NA,ut:000406391200048,NA,TRUE
+liu,2017,1934,10.1088/1361-6463/aa57bc,TRUE,IOP Publishing,Journal of Physics D: Applied Physics,0022-3727,0022-3727,1361-6463,0022-3727,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,ut:000398854900001,NA,FALSE
+liu,2017,1939,10.1371/journal.pntd.0005390,FALSE,Public Library of Science (PLoS),PLOS Neglected Tropical Diseases,1935-2735,NA,1935-2735,1935-2727,http://creativecommons.org/licenses/by/4.0/,TRUE,28192437,PMC5325601,ut:000396406600023,NA,TRUE
+liu,2017,1940,10.1371/journal.pcbi.1005608,FALSE,Public Library of Science (PLoS),PLOS Computational Biology,1553-7358,NA,1553-7358,1553-734X,http://creativecommons.org/licenses/by/4.0/,TRUE,28640810,PMC5501685,ut:000404565400053,NA,TRUE
+liu,2017,1974.9,10.1063/1.4977812,TRUE,AIP Publishing,Journal of Applied Physics,0021-8979,0021-8979,1089-7550,0021-8979,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,ut:000400623700006,NA,FALSE
+liu,2017,1993,10.1097/PTS.0000000000000369,TRUE,Wolters Kluwer,Journal of Patient Safety,1549-8417,1549-8417,NA,1549-8417,NA,TRUE,28234728,NA,NA,NA,FALSE
+liu,2017,1994.6,10.1155/2017/5806351,FALSE,Hindawi Publishing Corporation,Evidence-Based Complementary and Alternative Medicine,1741-427X,1741-427X,1741-4288,1741-427X,http://creativecommons.org/licenses/by/4.0/,TRUE,28270851,PMC5320299,ut:000394876600001,NA,TRUE
+liu,2017,2007,10.1371/journal.pgen.1006729,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,1553-7390,http://creativecommons.org/licenses/by/4.0/,TRUE,28414802,PMC5411104,ut:000402549200037,NA,TRUE
+liu,2017,2030.5,10.2147/JPR.S119845,FALSE,Dove Medical Press,Journal of Pain Research,1178-7090,NA,1178-7090,1178-7090,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,NA,NA,ut:000389840700001,NA,TRUE
+liu,2017,2030.5,10.2147/JPR.S138113,FALSE,Dove Medical Press,Journal of Pain Research,1178-7090,NA,1178-7090,1178-7090,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,28761374,PMC5522674,ut:000405597700005,NA,TRUE
+liu,2017,2059.9,10.2147/JPR.S128597,FALSE,Dove Medical Press,Journal of Pain Research,1178-7090,NA,1178-7090,1178-7090,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,28435317,PMC5388344,ut:000398611900001,NA,TRUE
+liu,2017,2078.9,10.2147/JPR.S125667,FALSE,Dove Medical Press,Journal of Pain Research,1178-7090,NA,1178-7090,1178-7090,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,28331360,PMC5356922,ut:000396321300001,NA,TRUE
+liu,2017,2150,10.1080/07292473.2017.1326584,TRUE,Taylor & Francis,War & Society,0729-2473,0729-2473,2042-4345,0729-2473,NA,TRUE,NA,NA,ut:000402098000004,NA,FALSE
+liu,2017,2150,10.1080/08351813.2017.1301293,TRUE,Taylor & Francis,Research on Language and Social Interaction,0835-1813,0835-1813,1532-7973,0835-1813,NA,TRUE,NA,NA,ut:000404581100001,NA,FALSE
+liu,2017,2151.1,10.3389/fcimb.2017.00278,FALSE,Frontiers,Frontiers in Cellular and Infection Microbiology,2235-2988,NA,2235-2988,2235-2988,NA,TRUE,28695112,PMC5483443,ut:000404073500001,NA,TRUE
+liu,2017,2174,10.1044/2016_JSLHR-H-16-0160,TRUE,American Speech Language Hearing Association,Journal of Speech Language and Hearing Research,1092-4388,1092-4388,NA,1092-4388,http://creativecommons.org/licenses/by/4.0/,TRUE,28651255,NA,NA,NA,FALSE
+liu,2017,2174,10.2196/jmir.7101,FALSE,JMIR Publications,Journal of Medical Internet Research,1438-8871,NA,1438-8871,1438-8871,NA,TRUE,28619700,PMC5491899,ut:000408351500002,NA,TRUE
+liu,2017,2215,10.1093/sf/sox043,TRUE,Oxford University Press (OUP),Social Forces,0037-7732,0037-7732,1534-7605,0037-7732,NA,TRUE,NA,NA,NA,NA,FALSE
+liu,2017,2236.7,10.3389/fpsyg.2017.00460,FALSE,Frontiers,Frontiers in Psychology,1664-1078,NA,1664-1078,1664-1078,NA,TRUE,28424641,PMC5372824,ut:000397587600002,NA,TRUE
+liu,2017,2345,10.1016/j.bbi.2016.12.007,TRUE,Elsevier,"Brain, Behavior, and Immunity",0889-1591,0889-1591,NA,0889-1591,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27940259,PMC5325121,ut:000395365900026,NA,FALSE
+liu,2017,2345.1,10.3389/fpsyg.2017.00368,FALSE,Frontiers,Frontiers in Psychology,1664-1078,NA,1664-1078,1664-1078,NA,TRUE,28348542,PMC5346541,ut:000396065900001,NA,TRUE
+liu,2017,2463,10.1073/pnas.1617758114,TRUE,National Academy of Sciences,Proceedings of the National Academy of Sciences,0027-8424,0027-8424,1091-6490,0027-8424,http://www.pnas.org/site/misc/userlicense.xhtml,TRUE,28420793,PMC5422791,ut:000400358000030,NA,FALSE
+liu,2017,2500,10.1002/cphc.201700126,TRUE,Wiley,ChemPhysChem,1439-4235,NA,NA,1439-4235,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28295951,PMC5484993,ut:000403885800004,NA,FALSE
+liu,2017,2530,10.1073/pnas.1616456114,TRUE,National Academy of Sciences,Proceedings of the National Academy of Sciences,0027-8424,0027-8424,1091-6490,0027-8424,http://www.pnas.org/site/misc/userlicense.xhtml,TRUE,28242683,PMC5358360,NA,NA,FALSE
+liu,2017,2541,10.18632/oncotarget.15547,FALSE,Impact Journals,OncoTarget,1949-2553,NA,1949-2553,1949-2553,NA,TRUE,28430630,PMC5444764,ut:000400456200081,NA,FALSE
+liu,2017,2629.1,10.1172/JCI90678,FALSE,American Society for Clinical Investigation,Journal of Clinical Investigation,0021-9738,0021-9738,1558-8238,0021-9738,NA,TRUE,28287401,PMC5373882,ut:000398183300026,NA,FALSE
+liu,2017,2641.1,10.1158/2326-6066.CIR-16-0150,TRUE,American Association for Cancer Research (AACR),Cancer Immunology Research,2326-6066,2326-6066,2326-6074,2326-6066,NA,TRUE,28159748,NA,ut:000396023000006,NA,FALSE
+liu,2017,2691,10.1016/j.amjms.2017.05.013,TRUE,Elsevier,The American Journal of the Medical Sciences,0002-9629,0002-9629,NA,0002-9629,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
+liu,2017,2778,10.1126/sciadv.1700345,FALSE,American Association for the Advancement of Science (AAAS),Science Advances,2375-2548,NA,2375-2548,2375-2548,NA,TRUE,28695197,NA,ut:000406370700067,NA,TRUE
+liu,2017,2960,10.1016/j.sab.2017.03.002,TRUE,Elsevier,Spectrochimica Acta Part B: Atomic Spectroscopy,0584-8547,0584-8547,NA,0584-8547,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000401200700017,NA,FALSE
+liu,2017,3011,10.18632/oncotarget.1798,FALSE,Impact Journals,OncoTarget,1949-2553,NA,1949-2553,1949-2553,NA,TRUE,NA,NA,NA,NA,FALSE
+liu,2017,3246,10.1126/sciadv.1700642,FALSE,American Association for the Advancement of Science (AAAS),Science Advances,2375-2548,NA,2375-2548,2375-2548,NA,TRUE,28776034,PMC5517111,NA,NA,TRUE
+liu,2017,3270.6,10.1242/dmm.029637,FALSE,The Company of Biologists,Disease Models & Mechanisms,1754-8403,1754-8403,1754-8411,1754-8403,http://creativecommons.org/licenses/by/3.0,TRUE,28615189,NA,ut:000406796600009,NA,TRUE
+liu,2017,3700,10.1038/ncomms14214,FALSE,Springer,Nature Communications,2041-1723,NA,2041-1723,2041-1723,NA,TRUE,28139738,PMC5290323,ut:000393027300001,NA,TRUE
+liu,2017,3700,10.1038/ncomms15401,FALSE,Springer,Nature Communications,2041-1723,NA,2041-1723,2041-1723,NA,TRUE,28530227,PMC5458147,ut:000401908900001,NA,TRUE
+liu,2017,375,10.1093/omcr/omx003,FALSE,Oxford University Press (OUP),Oxford Medical Case Reports,2053-8855,NA,2053-8855,2053-8855,NA,TRUE,28473916,PMC5410880,ut:000396869600002,NA,TRUE
+liu,2017,3750,10.1002/jmri.25691,TRUE,Wiley,Journal of Magnetic Resonance Imaging,1053-1807,NA,NA,1053-1807,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28295788,NA,NA,NA,FALSE
+liu,2017,3750,10.1002/mrm.26574,TRUE,Wiley,Magnetic Resonance in Medicine,0740-3194,NA,NA,0740-3194,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28074541,NA,NA,NA,FALSE
+liu,2017,435,10.1080/21663831.2017.1343207,FALSE,Taylor & Francis,Materials Research Letters,2166-3831,NA,2166-3831,2166-3831,NA,TRUE,NA,NA,NA,NA,FALSE
+liu,2017,4440,10.1038/ncomms14949,FALSE,Springer,Nature Communications,2041-1723,NA,2041-1723,2041-1723,NA,TRUE,28440271,PMC5413966,ut:000400065800001,NA,TRUE
+liu,2017,471,10.1016/j.dib.2016.12.046,FALSE,Elsevier,Data in Brief,2352-3409,2352-3409,NA,2352-3409,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,28070549,PMC5219593,NA,NA,TRUE
+liu,2017,652,10.1042/BSR20160514,FALSE,Portland Press,Bioscience Reports,0144-8463,0144-8463,1573-4935,0144-8463,http://creativecommons.org/licenses/by/4.0/,TRUE,27986865,PMC5271673,ut:000395096100021,NA,FALSE
+liu,2017,717,10.3390/app7040383,FALSE,MDPI,Applied Sciences,2076-3417,NA,2076-3417,2076-3417,NA,TRUE,NA,NA,ut:000404447600073,NA,TRUE
+liu,2017,987,10.1016/j.jbef.2017.04.002,TRUE,Elsevier,Journal of Behavioral and Experimental Finance,2214-6350,2214-6350,NA,2214-6350,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000405854600005,NA,FALSE
+liu,2017,987,10.1097/QMH.0000000000000133,TRUE,Wolters Kluwer,Quality Management in Health Care,1063-8628,1063-8628,NA,1063-8628,NA,TRUE,28375953,PMC5381467,ut:000399390400003,NA,FALSE
+lnu,2016,2200,10.1007/s00107-016-1102-6,TRUE,Springer,European Journal of Wood and Wood Products,0018-3768,0018-3768,1436-736X,0018-3768,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392318500002,NA,FALSE
+lnu,2016,2200,10.1007/s00792-016-0882-2,TRUE,Springer,Extremophiles,1431-0651,1431-0651,1433-4909,1431-0651,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000387270500009,NA,FALSE
+lnu,2016,2200,10.1007/s10086-016-1595-y,TRUE,Springer,Journal of Wood Science,1435-0211,1435-0211,1611-4663,1435-0211,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000394991100008,NA,FALSE
+lnu,2016,2200,10.1007/s10615-016-0613-2,TRUE,Springer,Clinical Social Work Journal,0091-1674,0091-1674,1573-3343,0091-1674,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+lnu,2016,2200,10.1007/s10896-016-9856-5,TRUE,Springer,Journal of Family Violence,0885-7482,0885-7482,1573-2851,0885-7482,http://creativecommons.org/licenses/by/4.0,TRUE,28163366,PMC5250674,ut:000393040500004,NA,FALSE
+lnu,2016,2200,10.1007/s10974-016-9458-0,TRUE,Springer,Journal of Muscle Research and Cell Motility,0142-4319,0142-4319,1573-2657,0142-4319,http://creativecommons.org/licenses/by/4.0,TRUE,27864648,NA,ut:000399241700001,NA,FALSE
+lnu,2016,2200,10.1007/s10997-016-9359-z,TRUE,Springer,Journal of Management & Governance,1385-3457,1385-3457,1572-963X,1385-3457,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000408346400006,NA,FALSE
+lnu,2016,2200,10.1007/s11135-016-0390-6,TRUE,Springer,Quality & Quantity,0033-5177,0033-5177,1573-7845,0033-5177,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000407856300005,NA,FALSE
+lnu,2016,2200,10.1007/s11266-016-9815-z,TRUE,Springer,VOLUNTAS: International Journal of Voluntary and Nonprofit Organizations,0957-8765,0957-8765,1573-7888,0957-8765,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000393747800014,NA,FALSE
+lnu,2016,2200,10.1007/s12122-016-9233-4,TRUE,Springer,Journal of Labor Research,0195-3613,0195-3613,1936-4768,0195-3613,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388182800001,NA,FALSE
+ltu,2012,2630,10.1080/02827581.2012.656142,TRUE,Taylor & Francis,Scandinavian Journal of Forest Research,0282-7581,0282-7581,1651-1891,0282-7581,NA,TRUE,NA,NA,ut:000305555600010,NA,FALSE
+ltu,2012,2630,10.1080/17480272.2012.699461,TRUE,Taylor & Francis,Wood Material Science and Engineering,1748-0272,1748-0272,1748-0280,1748-0272,NA,TRUE,NA,NA,NA,NA,FALSE
+ltu,2013,2630,10.1080/03585522.2012.693272,TRUE,Taylor & Francis,Scandinavian Economic History Review,0358-5522,0358-5522,1750-2837,0358-5522,NA,TRUE,NA,NA,NA,NA,FALSE
+ltu,2014,234,10.4161/bioe.36328,TRUE,Taylor & Francis,Bioengineered,2165-5979,2165-5979,2165-5987,2165-5979,NA,TRUE,25424444,PMC4601276,ut:000349212600007,NA,FALSE
+ltu,2014,2429,10.1080/0013791X.2014.952466,TRUE,Taylor & Francis,The Engineering Economist,0013-791X,0013-791X,1547-2701,0013-791X,NA,TRUE,NA,NA,ut:000353499300003,NA,FALSE
+ltu,2014,2429,10.1080/17480930.2014.942519,TRUE,Taylor & Francis,"International Journal of Mining, Reclamation and Environment",1748-0930,1748-0930,1748-0949,1748-0930,NA,TRUE,NA,NA,ut:000343814000006,NA,FALSE
+ltu,2015,2429,10.1080/14783363.2015.1068587,TRUE,Taylor & Francis,Total Quality Management & Business Excellence,1478-3363,1478-3363,1478-3371,1478-3363,NA,TRUE,NA,NA,ut:000362175300012,NA,FALSE
+ltu,2016,2132,10.1080/03719553.2016.1224048,TRUE,Taylor & Francis,Mineral Processing and Extractive Metallurgy,0371-9553,0371-9553,1743-2855,0371-9553,NA,TRUE,NA,NA,NA,NA,FALSE
+ltu,2016,2200,10.1007/s00163-016-0238-z,TRUE,Springer,Research in Engineering Design,0934-9839,0934-9839,1435-6066,0934-9839,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000396359400004,NA,FALSE
+ltu,2016,2200,10.1007/s00500-016-2425-2,TRUE,Springer,Soft Computing,1432-7643,1432-7643,1433-7479,1432-7643,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+ltu,2016,2200,10.1007/s10113-016-1077-1,TRUE,Springer,Regional Environmental Change,1436-3798,1436-3798,1436-378X,1436-3798,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000394991000018,NA,FALSE
+ltu,2016,2200,10.1007/s10115-016-1012-2,TRUE,Springer,Knowledge and Information Systems,0219-1377,0219-1377,0219-3116,0219-3116,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000405223500009,NA,FALSE
+ltu,2016,2200,10.1007/s11071-016-2994-8,TRUE,Springer,Nonlinear Dynamics,0924-090X,0924-090X,1573-269X,0924-090X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000386679400026,NA,FALSE
+ltu,2016,2200,10.1007/s11242-016-0781-0,TRUE,Springer,Transport in Porous Media,0169-3913,0169-3913,1573-1634,0169-3913,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000394167300019,NA,FALSE
+ltu,2016,2200,10.1007/s11249-016-0727-2,TRUE,Springer,Tribology Letters,1023-8883,1023-8883,1573-2711,1023-8883,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000382392200006,NA,FALSE
+ltu,2016,2200,10.1007/s11249-016-0785-5,TRUE,Springer,Tribology Letters,1023-8883,1023-8883,1573-2711,1023-8883,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000397039300005,NA,FALSE
+ltu,2016,2200,10.1007/s11249-016-0790-8,TRUE,Springer,Tribology Letters,1023-8883,1023-8883,1573-2711,1023-8883,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000397039300007,NA,FALSE
+ltu,2016,2200,10.1007/s12119-016-9386-6,TRUE,Springer,Sexuality & Culture,1095-5143,1095-5143,1936-4822,1095-5143,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+ltu,2016,2200,10.1007/s12289-016-1314-7,TRUE,Springer,International Journal of Material Forming,1960-6206,1960-6206,1960-6214,1960-6214,NA,TRUE,NA,NA,NA,NA,FALSE
+ltu,2016,2200,10.1007/s13399-016-0225-7,TRUE,Springer,Biomass Conversion and Biorefinery,2190-6815,2190-6815,2190-6823,2190-6815,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
 ltu,2016,2200,10.1007/s13563-016-0098-z,TRUE,Springer,Mineral Economics,2191-2203,2191-2203,2191-2211,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ltu,2016,2200,10.1007/s40571-016-0120-9,TRUE,Springer,Computational Particle Mechanics,2196-4378,2196-4378,2196-4386,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ltu,2016,2200,10.1007/s40831-016-0094-0,TRUE,Springer,Journal of Sustainable Metallurgy,2199-3823,2199-3823,2199-3831,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ltu,2016,2200,10.1007/s40831-016-0096-y,TRUE,Springer,Journal of Sustainable Metallurgy,2199-3823,2199-3823,2199-3831,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-ltu,2017,1074,10.3390/f8040107,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/1999-4907/8/4/107,TRUE
-ltu,2017,1088,10.3390/app7050488,FALSE,MDPI,Applied Sciences,2076-3417,NA,2076-3417,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/2076-3417/7/5/488,TRUE
-ltu,2017,1150,10.1038/srep35049,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,27733756,PMC5062085,NA,https://www.nature.com/articles/srep35049,TRUE
-ltu,2017,1236,10.3390/en10020184,FALSE,MDPI,Energies,1996-1073,1996-1073,1996-1073,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/1996-1073/10/2/184,TRUE
-ltu,2017,1338,10.1155/2017/5784627,FALSE,Hindawi Publishing Corporation,International Journal of Chemical Engineering,1687-806X,1687-806X,1687-8078,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,NA,https://www.hindawi.com/journals/ijce/2017/5784627/,TRUE
-ltu,2017,1339,10.3390/en10030263,FALSE,MDPI,Energies,1996-1073,NA,1996-1073,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/1996-1073/10/3/263/htm,TRUE
-ltu,2017,1344,10.3390/en10030332,FALSE,MDPI,Energies,1996-1073,NA,1996-1073,NA,NA,TRUE,NA,NA,NA,http://www.mdpi.com/1996-1073/10/3/332/htm,TRUE
-ltu,2017,1562,10.3390/ijerph13121248,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,1661-7827,1660-4601,NA,NA,TRUE,27999272,PMC5201389,NA,http://www.mdpi.com/1660-4601/13/12/1248,TRUE
-ltu,2017,1599,10.3390/s17010181,FALSE,MDPI,Sensors,1424-8220,NA,1424-8220,NA,NA,TRUE,28106817,PMC5298754,NA,http://www.mdpi.com/1424-8220/17/1/181/htm,TRUE
-ltu,2017,2243,10.1016/j.apgeochem.2017.02.012,TRUE,Elsevier,Applied Geochemistry,0883-2927,0883-2927,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S0883292716302141,FALSE
-ltu,2017,2260,10.1016/j.chemolab.2017.05.016#sthash.VNp1MNah.dpuf,TRUE,Elsevier,Chemometrics and Intelligent Laboratory Systems,0169-7439,0169-7439,1873-3239,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S0169743917300734,FALSE
-ltu,2017,239,10.4028/www.scientific.net/MSF.891.18#sthash.pqs6shZX.dpuf,TRUE,Trans Tech Publications,Materials Science Forum,1662-9752,0255-5476,1662-9752,NA,NA,TRUE,NA,NA,NA,https://www.scientific.net/MSF.891.18,FALSE
-ltu,2017,2960,10.1016/j.biortech.2017.04.002,TRUE,Elsevier,Bioresource Technology,0960-8524,0960-8524,1873-2976,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,28412146,NA,NA,http://www.sciencedirect.com/science/article/pii/S0960852417304832,FALSE
-ltu,2017,3140,10.1016/j.carbon.2017.02.007,TRUE,Elsevier,Carbon,0008-6223,0008-6223,1873-3891,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S0008622317301252,FALSE
-ltu,2017,560,10.1039/C6RA27065D,FALSE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,NA,NA,TRUE,NA,NA,NA,http://pubs.rsc.org/en/content/articlepdf/2017/ra/c6ra27065d,FALSE
-ltu,2017,560,10.1039/C6RA28574K,FALSE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,NA,NA,TRUE,NA,NA,NA,http://pubs.rsc.org/en/content/articlepdf/2017/ra/c6ra28574k,FALSE
-ltu,2017,588,10.1039/C6RA25410A,FALSE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,NA,NA,TRUE,NA,NA,NA,http://pubs.rsc.org/en/content/articlelanding/2017/ra/c6ra25410a#!divAbstract,FALSE
-ltu,2017,888,10.4236/eng.2017.95024,FALSE,Scientific Research Publishing,Engineering,1947-3931,1947-3931,1947-394X,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,NA,http://file.scirp.org/pdf/ENG_2017052716204530.pdf,FALSE
-ltu,2017,931,NA,FALSE,Scientific Research Publishing,Bioresources,NA,1930-2126,1930-2126,NA,NA,FALSE,NA,NA,NA,http://ojs.cnr.ncsu.edu/index.php/BioRes/article/view/BioRes_12_2_3122_Sadatnezhad_Continuous_Surface_Densification_Wood,FALSE
-ltu,2017,95,NA,FALSE,Scientific Research Publishing,Civil Engineering Journal,2476-3055,NA,NA,NA,NA,FALSE,NA,NA,NA,http://civilejournal.org/index.php/cej/article/view/310,FALSE
-lu,2012,2630,10.1080/13554794.2012.741258,TRUE,Taylor & Francis,Neurocase,1355-4794,1355-4794,1465-3656,NA,NA,TRUE,23425233,PMC3877915,NA,NA,FALSE
-lu,2013,2429,10.1080/02589001.2013.807566,TRUE,Taylor & Francis,Journal of Contemporary African Studies,0258-9001,0258-9001,1469-9397,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2013,2429,10.1080/07329113.2014.867752,TRUE,Taylor & Francis,The Journal of Legal Pluralism and Unofficial Law,0732-9113,0732-9113,2305-9931,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2013,2429,10.1080/09644016.2013.775723,TRUE,Taylor & Francis,Environmental Politics,0964-4016,0964-4016,1743-8934,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2013,2429,10.1080/09644016.2013.835203,TRUE,Taylor & Francis,Environmental Politics,0964-4016,0964-4016,1743-8934,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2013,2429,10.1080/21507740.2013.863243,TRUE,Taylor & Francis,AJOB Neuroscience,2150-7740,2150-7740,2150-7759,NA,NA,TRUE,24587963,PMC3933012,NA,NA,FALSE
-lu,2013,2630,10.1080/14735903.2012.751714,TRUE,Taylor & Francis,International Journal of Agricultural Sustainability,1473-5903,1473-5903,1747-762X,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2014,0,10.4161/19420889.2014.994376,FALSE,Taylor & Francis,Communicative & Integrative Biology,1942-0889,NA,1942-0889,NA,NA,TRUE,26479712,PMC4594589,NA,NA,TRUE
-lu,2014,2132,10.1080/02691728.2011.604445,TRUE,Taylor & Francis,Social Epistemology,0269-1728,0269-1728,1464-5297,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2014,2429,10.1080/10904018.2014.880928,TRUE,Taylor & Francis,International Journal of Listening,1090-4018,1090-4018,1932-586X,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2014,2429,10.1080/21513732.2013.822930,FALSE,Taylor & Francis,"International Journal of Biodiversity Science, Ecosystem Services & Management",2151-3732,2151-3732,2151-3740,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2014,446,10.1080/21650020.2014.939297,FALSE,Taylor & Francis,"Urban, Planning and Transport Research",2165-0020,NA,2165-0020,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-lu,2014,702,10.4161/21623945.2014.960694,TRUE,Taylor & Francis,Adipocyte,2162-3945,2162-3945,2162-397X,NA,NA,TRUE,26167409,PMC4496978,NA,NA,FALSE
-lu,2015,1115,10.1080/23335432.2015.1014848,FALSE,Taylor & Francis,International Biomechanics,2333-5432,NA,2333-5432,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2015,2074,10.1080/00140139.2015.1019575,TRUE,Taylor & Francis,Ergonomics,0014-0139,0014-0139,1366-5847,NA,NA,TRUE,25761380,PMC4566900,NA,NA,FALSE
-lu,2015,2074,10.3109/00365513.2015.1099724,TRUE,Taylor & Francis,Scandinavian Journal of Clinical and Laboratory Investigation,0036-5513,0036-5513,1502-7686,NA,NA,TRUE,26647957,PMC4720044,NA,NA,FALSE
-lu,2015,2132,10.1080/13504509.2015.1128492,TRUE,Taylor & Francis,International Journal of Sustainable Development & World Ecology,1350-4509,1350-4509,1745-2627,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2015,2132,10.1080/1573062X.2015.1111913,TRUE,Taylor & Francis,Urban Water Journal,1573-062X,1573-062X,1744-9006,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2015,2132,10.3109/00365513.2015.1025427,TRUE,Taylor & Francis,Scandinavian Journal of Clinical and Laboratory Investigation,0036-5513,0036-5513,1502-7686,NA,NA,TRUE,25919022,PMC4487590,NA,NA,FALSE
-lu,2015,2132,10.3109/0284186X.2015.1075663,TRUE,Taylor & Francis,Acta Oncologica,0284-186X,0284-186X,1651-226X,NA,NA,TRUE,26362587,PMC4819809,NA,NA,FALSE
-lu,2015,2132,10.3109/17435390.2015.1048324,TRUE,Taylor & Francis,Nanotoxicology,1743-5390,1743-5390,1743-5404,NA,NA,TRUE,26186033,PMC4819849,NA,NA,FALSE
-lu,2015,2429,10.1080/02698595.2014.953343,TRUE,Taylor & Francis,International Studies in the Philosophy of Science,0269-8595,0269-8595,1469-9281,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2015,248,10.1080/00207543.2012.761363,TRUE,Taylor & Francis,International Journal of Production Research,0020-7543,0020-7543,1366-588X,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2015,3040,10.1517/17460441.2015.1032936,TRUE,Taylor & Francis,Expert Opinion on Drug Discovery,1746-0441,1746-0441,1746-045X,NA,NA,TRUE,25835573,PMC4487606,NA,NA,FALSE
-lu,2015,734,10.1080/19382014.2015.1118195,TRUE,Taylor & Francis,Islets,1938-2014,1938-2014,1938-2022,NA,NA,TRUE,26742564,PMC4878264,NA,NA,FALSE
-lu,2015,755,10.1159/000377710,FALSE,Karger,Cerebrovascular Diseases Extra,1664-5456,NA,1664-5456,NA,NA,TRUE,26120319,PMC4478329,NA,NA,TRUE
-lu,2016,0,10.1080/17453674.2016.1195663,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,NA,NA,TRUE,27339330,PMC4967283,NA,NA,TRUE
-lu,2016,0,10.1080/17453674.2016.1205173,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,NA,NA,TRUE,27391663,PMC5016912,NA,NA,TRUE
-lu,2016,0,10.1080/17453674.2016.1210940,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,NA,NA,TRUE,27436058,PMC5016915,NA,NA,TRUE
-lu,2016,0,10.3109/17453674.2016.1152855,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,NA,NA,TRUE,26905618,PMC4900094,NA,NA,TRUE
-lu,2016,0,10.3109/17453674.2016.1161451,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,NA,NA,TRUE,26982799,PMC4900082,NA,NA,TRUE
-lu,2016,0,10.3109/17453674.2016.1170548,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,NA,NA,TRUE,27212102,PMC4900081,NA,NA,TRUE
-lu,2016,2132,10.1080/02678373.2016.1175524,TRUE,Taylor & Francis,Work & Stress,0267-8373,0267-8373,1464-5335,NA,NA,TRUE,27226677,PMC4867854,NA,NA,FALSE
-lu,2016,2132,10.1080/08039410.2016.1252424,TRUE,Taylor & Francis,Forum for Development Studies,0803-9410,0803-9410,1891-1765,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2132,10.1080/09638288.2016.1236409,TRUE,Taylor & Francis,Disability and Rehabilitation,0963-8288,0963-8288,1464-5165,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2132,10.1080/11038128.2016.1224271,TRUE,Taylor & Francis,Scandinavian Journal of Occupational Therapy,1103-8128,1103-8128,1651-2014,NA,NA,TRUE,27575654,NA,NA,NA,FALSE
-lu,2016,2132,10.1080/13691058.2016.1259503,TRUE,Taylor & Francis,"Culture, Health & Sexuality",1369-1058,1369-1058,1464-5351,NA,NA,TRUE,27894219,NA,NA,NA,FALSE
-lu,2016,2132,10.1080/14693062.2016.1167009,TRUE,Taylor & Francis,Climate Policy,1469-3062,1469-3062,1752-7457,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2132,10.1080/17435390.2016.1189615,TRUE,Taylor & Francis,Nanotoxicology,1743-5390,1743-5390,1743-5404,NA,NA,TRUE,27181920,PMC4975093,NA,NA,FALSE
-lu,2016,2132,10.1080/23254823.2016.1253977,TRUE,Taylor & Francis,European Journal of Cultural and Political Sociology,2325-4823,2325-4823,2325-4815,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2132,10.1080/87565641.2016.1243111,TRUE,Taylor & Francis,Developmental Neuropsychology,8756-5641,8756-5641,1532-6942,NA,NA,TRUE,28059564,NA,NA,NA,FALSE
-lu,2016,2132,10.1179/2047971915Y.0000000021,TRUE,Taylor & Francis,International Journal of Healthcare Management,2047-9700,2047-9700,2047-9719,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2132,10.3109/0284186X.2016.1146826,TRUE,Taylor & Francis,Acta Oncologica,0284-186X,0284-186X,1651-226X,NA,NA,TRUE,27050668,PMC4950423,NA,NA,FALSE
-lu,2016,2132,10.3109/14017431.2016.1154598,TRUE,Taylor & Francis,Scandinavian Cardiovascular Journal,1401-7431,1401-7431,1651-2006,NA,NA,TRUE,26882241,PMC4898163,NA,NA,FALSE
-lu,2016,2200,10.1007/s00018-016-2365-0,TRUE,Springer,Cellular and Molecular Life Sciences,1420-682X,1420-682X,1420-9071,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27652381,PMC5272905,NA,NA,FALSE
-lu,2016,2200,10.1007/s00125-016-4113-2,TRUE,Springer,Diabetologia,0012-186X,0012-186X,1432-0428,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27796421,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s00125-016-4141-y,TRUE,Springer,Diabetologia,0012-186X,0012-186X,1432-0428,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27807598,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s00125-016-4184-0,TRUE,Springer,Diabetologia,0012-186X,0012-186X,1432-0428,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28004149,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s00170-016-9296-7,TRUE,Springer,The International Journal of Advanced Manufacturing Technology,0268-3768,0268-3768,1433-3015,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s00181-016-1123-3,TRUE,Springer,Empirical Economics,0377-7332,0377-7332,1435-8921,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s00198-016-3768-3,TRUE,Springer,Osteoporosis International,0937-941X,0937-941X,1433-2965,NA,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27647528,PMC5206266,NA,NA,FALSE
-lu,2016,2200,10.1007/s00198-016-3771-8,TRUE,Springer,Osteoporosis International,0937-941X,0937-941X,1433-2965,NA,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27822590,PMC5269464,NA,NA,FALSE
-lu,2016,2200,10.1007/s00223-016-0174-y,TRUE,Springer,Calcified Tissue International,0171-967X,0171-967X,1432-0827,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s00253-016-7833-9,TRUE,Springer,Applied Microbiology and Biotechnology,0175-7598,0175-7598,1432-0614,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27678115,PMC5247548,NA,NA,FALSE
-lu,2016,2200,10.1007/s00253-016-8055-x,TRUE,Springer,Applied Microbiology and Biotechnology,0175-7598,0175-7598,1432-0614,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27995311,PMC5219020,NA,NA,FALSE
-lu,2016,2200,10.1007/s00262-016-1909-3,TRUE,Springer,"Cancer Immunology, Immunotherapy",0340-7004,0340-7004,1432-0851,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27714433,PMC5222923,NA,NA,FALSE
-lu,2016,2200,10.1007/s00284-016-1165-y,TRUE,Springer,Current Microbiology,0343-8651,0343-8651,1432-0991,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27896481,PMC5243900,NA,NA,FALSE
-lu,2016,2200,10.1007/s00359-016-1130-z,TRUE,Springer,Journal of Comparative Physiology A,0340-7594,0340-7594,1432-1351,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27837238,PMC5263199,NA,NA,FALSE
-lu,2016,2200,10.1007/s00362-016-0864-6,TRUE,Springer,Statistical Papers,0932-5026,0932-5026,1613-9798,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s00382-016-3408-9,TRUE,Springer,Climate Dynamics,0930-7575,0930-7575,1432-0894,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s00383-016-4001-3,TRUE,Springer,Pediatric Surgery International,0179-0358,0179-0358,1437-9813,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27807610,PMC5225200,NA,NA,FALSE
-lu,2016,2200,10.1007/s00383-016-4013-z,TRUE,Springer,Pediatric Surgery International,0179-0358,0179-0358,1437-9813,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27844168,PMC5263191,NA,NA,FALSE
-lu,2016,2200,10.1007/s00384-016-2639-x,TRUE,Springer,International Journal of Colorectal Disease,0179-1958,0179-1958,1432-1262,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27613729,PMC5219883,NA,NA,FALSE
-lu,2016,2200,10.1007/s00396-016-3927-2,TRUE,Springer,Colloid and Polymer Science,0303-402X,0303-402X,1435-1536,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s00415-016-8287-9,TRUE,Springer,Journal of Neurology,0340-5354,0340-5354,1432-1459,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27646115,PMC5110600,NA,NA,FALSE
-lu,2016,2200,10.1007/s00423-016-1517-x,TRUE,Springer,Langenbeck's Archives of Surgery,1435-2443,1435-2443,1435-2451,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27783154,PMC5346422,NA,NA,FALSE
-lu,2016,2200,10.1007/s00423-016-1535-8,TRUE,Springer,Langenbeck's Archives of Surgery,1435-2443,1435-2443,1435-2451,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27896436,PMC5346413,NA,NA,FALSE
-lu,2016,2200,10.1007/s00453-016-0202-3,TRUE,Springer,Algorithmica,0178-4617,0178-4617,1432-0541,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s00477-016-1375-7,TRUE,Springer,Stochastic Environmental Research and Risk Assessment,1436-3240,1436-3240,1436-3259,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s00592-016-0903-8,TRUE,Springer,Acta Diabetologica,0940-5429,0940-5429,1432-5233,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s10071-016-1015-0,TRUE,Springer,Animal Cognition,1435-9448,1435-9448,1435-9456,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s10071-016-1016-z,TRUE,Springer,Animal Cognition,1435-9448,1435-9448,1435-9456,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s10096-016-2862-y,TRUE,Springer,European Journal of Clinical Microbiology & Infectious Diseases,0934-9723,0934-9723,1435-4373,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s10237-016-0866-2,TRUE,Springer,Biomechanics and Modeling in Mechanobiology,1617-7959,1617-7959,1617-7940,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28004226,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s10344-016-1054-5,TRUE,Springer,European Journal of Wildlife Research,1612-4642,1612-4642,1439-0574,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s10470-016-0800-7,TRUE,Springer,Analog Integrated Circuits and Signal Processing,0925-1030,0925-1030,1573-1979,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s10470-016-0902-2,TRUE,Springer,Analog Integrated Circuits and Signal Processing,0925-1030,0925-1030,1573-1979,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s10584-016-1880-1,TRUE,Springer,Climatic Change,0165-0009,0165-0009,1573-1480,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s10611-016-9675-x,TRUE,Springer,"Crime, Law and Social Change",0925-4994,0925-4994,1573-0751,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s10677-016-9747-0,TRUE,Springer,Ethical Theory and Moral Practice,1386-2820,1386-2820,1572-8447,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s10682-016-9871-2,TRUE,Springer,Evolutionary Ecology,0269-7653,0269-7653,1573-8477,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s10822-016-9942-z,TRUE,Springer,Journal of Computer-Aided Molecular Design,0920-654X,0920-654X,1573-4951,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s10822-016-9948-6,TRUE,Springer,Journal of Computer-Aided Molecular Design,0920-654X,0920-654X,1573-4951,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27573983,PMC5239820,NA,NA,FALSE
-lu,2016,2200,10.1007/s10822-016-9957-5,TRUE,Springer,Journal of Computer-Aided Molecular Design,0920-654X,0920-654X,1573-4951,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27600554,PMC5239813,NA,NA,FALSE
-lu,2016,2200,10.1007/s10823-016-9311-3,TRUE,Springer,Journal of Cross-Cultural Gerontology,0169-3816,0169-3816,1573-0719,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28028743,PMC5310561,NA,NA,FALSE
-lu,2016,2200,10.1007/s10826-016-0602-7,TRUE,Springer,Journal of Child and Family Studies,1062-1024,1062-1024,1573-2843,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28239249,PMC5306151,NA,NA,FALSE
-lu,2016,2200,10.1007/s10851-016-0677-1,TRUE,Springer,Journal of Mathematical Imaging and Vision,0924-9907,0924-9907,1573-7683,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s10862-016-9570-x,TRUE,Springer,Journal of Psychopathology and Behavioral Assessment,0882-2689,0882-2689,1573-3505,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28286372,PMC5323484,NA,NA,FALSE
-lu,2016,2200,10.1007/s10959-016-0725-1,TRUE,Springer,Journal of Theoretical Probability,0894-9840,0894-9840,1572-9230,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s10967-016-5030-z,TRUE,Springer,Journal of Radioanalytical and Nuclear Chemistry,0236-5731,0236-5731,1588-2780,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28111484,PMC5219036,NA,NA,FALSE
-lu,2016,2200,10.1007/s11060-016-2302-y,TRUE,Springer,Journal of Neuro-Oncology,0167-594X,0167-594X,1573-7373,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27757723,PMC5306185,NA,NA,FALSE
-lu,2016,2200,10.1007/s11090-016-9771-9,TRUE,Springer,Plasma Chemistry and Plasma Processing,0272-4324,0272-4324,1572-8986,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s11098-016-0841-x,TRUE,Springer,Philosophical Studies,0031-8116,0031-8116,1573-0883,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s11127-016-0373-0,TRUE,Springer,Public Choice,0048-5829,0048-5829,1573-7101,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s11199-016-0694-y,TRUE,Springer,Sex Roles,0360-0025,0360-0025,1573-2762,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s11207-016-0969-z,TRUE,Springer,Solar Physics,0038-0938,0038-0938,1573-093X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s11224-016-0868-9,TRUE,Springer,Structural Chemistry,1040-0400,1040-0400,1572-9001,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s11239-016-1464-y,TRUE,Springer,Journal of Thrombosis and Thrombolysis,0929-5305,0929-5305,1573-742X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27990607,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s11244-016-0714-8,TRUE,Springer,Topics in Catalysis,1022-5528,1022-5528,1572-9028,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s11251-016-9397-6,TRUE,Springer,Instructional Science,0020-4277,0020-4277,1573-1952,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s11269-016-1546-9,TRUE,Springer,Water Resources Management,0920-4741,0920-4741,1573-1650,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s11356-016-7706-x,TRUE,Springer,Environmental Science and Pollution Research,0944-1344,0944-1344,1614-7499,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s11365-016-0405-8,TRUE,Springer,International Entrepreneurship and Management Journal,1554-7191,1554-7191,1555-1938,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s11406-016-9766-z,TRUE,Springer,Philosophia,0048-3893,0048-3893,1574-9274,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s11434-016-1146-3,TRUE,Springer,Science Bulletin,2095-9273,2095-9273,2095-9281,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27635282,PMC5002044,NA,NA,FALSE
-lu,2016,2200,10.1007/s11517-016-1593-7,TRUE,Springer,Medical & Biological Engineering & Computing,0140-0118,0140-0118,1741-0444,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s11785-016-0596-6,TRUE,Springer,Complex Analysis and Operator Theory,1661-8254,1661-8254,1661-8262,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s11837-016-2112-x,TRUE,Springer,JOM,1047-4838,1047-4838,1543-1851,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s11864-016-0426-0,TRUE,Springer,Current Treatment Options in Oncology,1527-2729,1527-2729,1534-6277,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27476159,PMC4967419,NA,NA,FALSE
-lu,2016,2200,10.1007/s12010-016-2229-y,TRUE,Springer,Applied Biochemistry and Biotechnology,0273-2289,0273-2289,1559-0291,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27631121,PMC5285423,NA,NA,FALSE
-lu,2016,2200,10.1007/s12028-016-0348-5,TRUE,Springer,Neurocritical Care,1541-6933,1541-6933,1556-0961,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s12138-016-0423-5,TRUE,Springer,International Journal of the Classical Tradition,1073-0508,1073-0508,1874-6292,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s12311-016-0839-0,TRUE,Springer,The Cerebellum,1473-4222,1473-4222,1473-4230,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28032320,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s12350-016-0628-7,TRUE,Springer,Journal of Nuclear Cardiology,1071-3581,1071-3581,1532-6551,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s12649-016-9643-9,TRUE,Springer,Waste and Biomass Valorization,1877-2641,1877-2641,1877-265X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s12665-016-6205-1,TRUE,Springer,Environmental Earth Sciences,1866-6280,1866-6280,1866-6299,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s12665-016-6364-0,TRUE,Springer,Environmental Earth Sciences,1866-6280,1866-6280,1866-6299,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s12671-016-0653-2,TRUE,Springer,Mindfulness,1868-8527,1868-8527,1868-8535,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.1007/s13164-016-0318-z,TRUE,Springer,Review of Philosophy and Psychology,1878-5158,1878-5158,1878-5166,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2200,10.3758/s13428-016-0806-1,TRUE,Springer,Behavior Research Methods,1554-3528,NA,1554-3528,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,397,10.3109/02813432.2015.1132884,FALSE,Taylor & Francis,Scandinavian Journal of Primary Health Care,0281-3432,0281-3432,1502-7724,NA,NA,TRUE,26828942,PMC4911028,NA,NA,TRUE
-lu,2016,444,10.1080/21650020.2016.1156020,FALSE,Taylor & Francis,"Urban, Planning and Transport Research",2165-0020,NA,2165-0020,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-lu,2016,521,10.1080/09500340.2016.1257751,TRUE,Taylor & Francis,Journal of Modern Optics,0950-0340,0950-0340,1362-3044,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,734,10.1080/15592294.2016.1178418,TRUE,Taylor & Francis,Epigenetics,1559-2294,1559-2294,1559-2308,NA,NA,TRUE,27148772,PMC4939923,NA,NA,FALSE
-lu,2016,734,10.1080/21623945.2016.1252011,TRUE,Taylor & Francis,Adipocyte,2162-3945,2162-3945,2162-397X,NA,NA,TRUE,27994949,PMC5160390,NA,NA,FALSE
-lu,2016,969,10.1080/23311908.2016.1260237,FALSE,Taylor & Francis,Cogent Psychology,2331-1908,NA,2331-1908,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-mah,2011,2631,10.1111/j.1600-0579.2011.00702.x,TRUE,Wiley,European Journal of Dental Education,1396-5883,NA,1600-0579,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,22251323,PMC3490366,NA,http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1600-0579/homepage/ProductInformation.html,FALSE
-mah,2014,2429,10.1080/13504622.2013.879696,TRUE,Taylor & Francis,Environmental Education Research,1350-4622,1350-4622,1469-5871,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-mah,2014,2429,10.1080/17508487.2014.936890,TRUE,Taylor & Francis,Critical Studies in Education,1750-8487,1750-8487,1750-8495,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-mah,2014,2631,10.1111/clr.12507,TRUE,Wiley,Clinical Oral Implants Research,0905-7161,NA,1600-0501,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25349918,NA,NA,http://onlinelibrary.wiley.com/doi/10.1111/clr.12507/full,FALSE
-mah,2015,1311,10.1371/journal.pone.0140052,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26451727,PMC4599802,NA,http://journals.plos.org/plosone/article?id=10.1371%2Fjournal.pone.0140052,TRUE
-mah,2015,1882,10.1186/s12912-015-0092-8,FALSE,BioMed Central,BMC Nursing,1472-6955,NA,1472-6955,NA,http://www.springer.com/tdm,TRUE,26236155,PMC4521316,NA,http://bmcnurs.biomedcentral.com/articles/10.1186/s12912-015-0092-8,TRUE
-mah,2015,2631,10.1177/1468796815588620,TRUE,SAGE Publications,Ethnicities,1468-7968,1468-7968,1741-2706,NA,NA,TRUE,NA,NA,NA,http://etn.sagepub.com/content/early/2015/05/29/1468796815588620,FALSE
-mah,2016,2132,10.1080/10520295.2016.1255995,TRUE,Taylor & Francis,Biotechnic & Histochemistry,1052-0295,1052-0295,1473-7760,NA,NA,TRUE,28157427,NA,NA,NA,FALSE
-mah,2016,2200,10.1007/s11098-016-0769-1,TRUE,Springer,Philosophical Studies,0031-8116,0031-8116,1573-0883,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-mah,2016,2200,10.1007/s12187-016-9435-6,TRUE,Springer,Child Indicators Research,1874-897X,1874-897X,1874-8988,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-mah,2016,2200,10.1007/s12529-016-9625-0,TRUE,Springer,International Journal of Behavioral Medicine,1070-5503,1070-5503,1532-7558,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28028732,NA,NA,NA,FALSE
-mah,2016,2200,10.1007/s13277-016-5280-y,TRUE,Springer,Tumor Biology,1010-4283,1010-4283,1423-0380,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27476172,PMC5097081,NA,NA,FALSE
-mah,2016,346,10.1177/2158244016633739,FALSE,SAGE Publications,SAGE Open,2158-2440,2158-2440,2158-2440,NA,NA,TRUE,NA,NA,NA,http://sgo.sagepub.com/content/6/1/2158244016633739,TRUE
-mah,2016,468,10.1080/2331186X.2016.1184604,FALSE,Taylor & Francis,Cogent Education,2331-186X,NA,2331-186X,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-mdh,2016,2200,10.1007/s00170-016-9377-7,TRUE,Springer,The International Journal of Advanced Manufacturing Technology,0268-3768,0268-3768,1433-3015,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-mdh,2016,2200,10.1007/s10270-016-0556-7,TRUE,Springer,Software & Systems Modeling,1619-1366,1619-1366,1619-1374,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-mdh,2016,2200,10.1007/s10659-016-9613-2,TRUE,Springer,Journal of Elasticity,0374-3535,0374-3535,1573-2681,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-mdh,2016,2200,10.1007/s10823-016-9296-y,TRUE,Springer,Journal of Cross-Cultural Gerontology,0169-3816,0169-3816,1573-0719,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-mdh,2016,2200,10.1007/s11219-016-9343-5,TRUE,Springer,Software Quality Journal,0963-9314,0963-9314,1573-1367,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-miu,2016,2200,10.1007/s10570-016-1029-4,TRUE,Springer,Cellulose,0969-0239,0969-0239,1572-882X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-miu,2016,2200,10.1007/s10570-016-1068-x,TRUE,Springer,Cellulose,0969-0239,0969-0239,1572-882X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-miu,2016,2200,10.1007/s11575-016-0304-9,TRUE,Springer,Management International Review,0938-8249,0938-8249,1861-8901,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+ltu,2016,2200,10.1007/s40571-016-0120-9,TRUE,Springer,Computational Particle Mechanics,2196-4378,2196-4378,2196-4386,2196-4386,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+ltu,2016,2200,10.1007/s40831-016-0094-0,TRUE,Springer,Journal of Sustainable Metallurgy,2199-3823,2199-3823,2199-3831,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000400824500012,NA,FALSE
+ltu,2016,2200,10.1007/s40831-016-0096-y,TRUE,Springer,Journal of Sustainable Metallurgy,2199-3823,2199-3823,2199-3831,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000400824500014,NA,FALSE
+ltu,2017,1074,10.3390/f8040107,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000404099200013,http://www.mdpi.com/1999-4907/8/4/107,TRUE
+ltu,2017,1088,10.3390/app7050488,FALSE,MDPI,Applied Sciences,2076-3417,NA,2076-3417,2076-3417,NA,TRUE,NA,NA,ut:000404449000055,http://www.mdpi.com/2076-3417/7/5/488,TRUE
+ltu,2017,1150,10.1038/srep35049,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,27733756,PMC5062085,ut:000385536400001,https://www.nature.com/articles/srep35049,TRUE
+ltu,2017,1236,10.3390/en10020184,FALSE,MDPI,Energies,1996-1073,1996-1073,1996-1073,1996-1073,NA,TRUE,NA,NA,ut:000395469200038,http://www.mdpi.com/1996-1073/10/2/184,TRUE
+ltu,2017,1338,10.1155/2017/5784627,FALSE,Hindawi Publishing Corporation,International Journal of Chemical Engineering,1687-806X,1687-806X,1687-8078,1687-806X,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,ut:000397903400001,https://www.hindawi.com/journals/ijce/2017/5784627/,TRUE
+ltu,2017,1339,10.3390/en10030263,FALSE,MDPI,Energies,1996-1073,NA,1996-1073,1996-1073,NA,TRUE,NA,NA,ut:000398736700003,http://www.mdpi.com/1996-1073/10/3/263/htm,TRUE
+ltu,2017,1344,10.3390/en10030332,FALSE,MDPI,Energies,1996-1073,NA,1996-1073,1996-1073,NA,TRUE,NA,NA,ut:000398736700072,http://www.mdpi.com/1996-1073/10/3/332/htm,TRUE
+ltu,2017,1562,10.3390/ijerph13121248,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,1661-7827,1660-4601,1660-4601,NA,TRUE,27999272,PMC5201389,ut:000392280100019,http://www.mdpi.com/1660-4601/13/12/1248,TRUE
+ltu,2017,1599,10.3390/s17010181,FALSE,MDPI,Sensors,1424-8220,NA,1424-8220,1424-8220,NA,TRUE,28106817,PMC5298754,ut:000393021000180,http://www.mdpi.com/1424-8220/17/1/181/htm,TRUE
+ltu,2017,2243,10.1016/j.apgeochem.2017.02.012,TRUE,Elsevier,Applied Geochemistry,0883-2927,0883-2927,NA,0883-2927,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000398867700009,http://www.sciencedirect.com/science/article/pii/S0883292716302141,FALSE
+ltu,2017,2260,10.1016/j.chemolab.2017.05.016#sthash.VNp1MNah.dpuf,TRUE,Elsevier,Chemometrics and Intelligent Laboratory Systems,0169-7439,0169-7439,1873-3239,0169-7439,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S0169743917300734,FALSE
+ltu,2017,239,10.4028/www.scientific.net/MSF.891.18#sthash.pqs6shZX.dpuf,TRUE,Trans Tech Publications,Materials Science Forum,1662-9752,0255-5476,1662-9752,0255-5476,NA,TRUE,NA,NA,NA,https://www.scientific.net/MSF.891.18,FALSE
+ltu,2017,2960,10.1016/j.biortech.2017.04.002,TRUE,Elsevier,Bioresource Technology,0960-8524,0960-8524,1873-2976,0960-8524,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,28412146,NA,ut:000405980700038,http://www.sciencedirect.com/science/article/pii/S0960852417304832,FALSE
+ltu,2017,3140,10.1016/j.carbon.2017.02.007,TRUE,Elsevier,Carbon,0008-6223,0008-6223,1873-3891,0008-6223,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000397549300053,http://www.sciencedirect.com/science/article/pii/S0008622317301252,FALSE
+ltu,2017,560,10.1039/C6RA27065D,FALSE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000393755100024,http://pubs.rsc.org/en/content/articlepdf/2017/ra/c6ra27065d,FALSE
+ltu,2017,560,10.1039/C6RA28574K,FALSE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000393757100006,http://pubs.rsc.org/en/content/articlepdf/2017/ra/c6ra28574k,FALSE
+ltu,2017,588,10.1039/C6RA25410A,FALSE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000393748000028,http://pubs.rsc.org/en/content/articlelanding/2017/ra/c6ra25410a#!divAbstract,FALSE
+ltu,2017,888,10.4236/eng.2017.95024,FALSE,Scientific Research Publishing,Engineering,1947-3931,1947-3931,1947-394X,1947-394X,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,NA,http://file.scirp.org/pdf/ENG_2017052716204530.pdf,FALSE
+ltu,2017,931,NA,FALSE,Scientific Research Publishing,Bioresources,NA,1930-2126,1930-2126,1930-2126,NA,FALSE,NA,NA,NA,http://ojs.cnr.ncsu.edu/index.php/BioRes/article/view/BioRes_12_2_3122_Sadatnezhad_Continuous_Surface_Densification_Wood,FALSE
+ltu,2017,95,NA,FALSE,Scientific Research Publishing,Civil Engineering Journal,2476-3055,NA,NA,2476-3055,NA,FALSE,NA,NA,NA,http://civilejournal.org/index.php/cej/article/view/310,FALSE
+lu,2012,2630,10.1080/13554794.2012.741258,TRUE,Taylor & Francis,Neurocase,1355-4794,1355-4794,1465-3656,1355-4794,NA,TRUE,23425233,PMC3877915,ut:000328103800009,NA,FALSE
+lu,2013,2429,10.1080/02589001.2013.807566,TRUE,Taylor & Francis,Journal of Contemporary African Studies,0258-9001,0258-9001,1469-9397,0258-9001,NA,TRUE,NA,NA,NA,NA,FALSE
+lu,2013,2429,10.1080/07329113.2014.867752,TRUE,Taylor & Francis,The Journal of Legal Pluralism and Unofficial Law,0732-9113,0732-9113,2305-9931,0732-9113,NA,TRUE,NA,NA,NA,NA,FALSE
+lu,2013,2429,10.1080/09644016.2013.775723,TRUE,Taylor & Francis,Environmental Politics,0964-4016,0964-4016,1743-8934,0964-4016,NA,TRUE,NA,NA,ut:000318772600003,NA,FALSE
+lu,2013,2429,10.1080/09644016.2013.835203,TRUE,Taylor & Francis,Environmental Politics,0964-4016,0964-4016,1743-8934,0964-4016,NA,TRUE,NA,NA,ut:000334661300004,NA,FALSE
+lu,2013,2429,10.1080/21507740.2013.863243,TRUE,Taylor & Francis,AJOB Neuroscience,2150-7740,2150-7740,2150-7759,2150-7759,NA,TRUE,24587963,PMC3933012,NA,NA,FALSE
+lu,2013,2630,10.1080/14735903.2012.751714,TRUE,Taylor & Francis,International Journal of Agricultural Sustainability,1473-5903,1473-5903,1747-762X,1473-5903,NA,TRUE,NA,NA,ut:000332060400001,NA,FALSE
+lu,2014,0,10.4161/19420889.2014.994376,FALSE,Taylor & Francis,Communicative & Integrative Biology,1942-0889,NA,1942-0889,1942-0889,NA,TRUE,26479712,PMC4594589,NA,NA,TRUE
+lu,2014,2132,10.1080/02691728.2011.604445,TRUE,Taylor & Francis,Social Epistemology,0269-1728,0269-1728,1464-5297,0269-1728,NA,TRUE,NA,NA,ut:000209097500006,NA,FALSE
+lu,2014,2429,10.1080/10904018.2014.880928,TRUE,Taylor & Francis,International Journal of Listening,1090-4018,1090-4018,1932-586X,1090-4018,NA,TRUE,NA,NA,NA,NA,FALSE
+lu,2014,2429,10.1080/21513732.2013.822930,FALSE,Taylor & Francis,"International Journal of Biodiversity Science, Ecosystem Services & Management",2151-3732,2151-3732,2151-3740,2151-3732,NA,TRUE,NA,NA,NA,NA,FALSE
+lu,2014,446,10.1080/21650020.2014.939297,FALSE,Taylor & Francis,"Urban, Planning and Transport Research",2165-0020,NA,2165-0020,2165-0020,NA,TRUE,NA,NA,NA,NA,TRUE
+lu,2014,702,10.4161/21623945.2014.960694,TRUE,Taylor & Francis,Adipocyte,2162-3945,2162-3945,2162-397X,2162-3945,NA,TRUE,26167409,PMC4496978,ut:000357659300001,NA,FALSE
+lu,2015,1115,10.1080/23335432.2015.1014848,FALSE,Taylor & Francis,International Biomechanics,2333-5432,NA,2333-5432,2333-5432,NA,TRUE,NA,NA,NA,NA,FALSE
+lu,2015,2074,10.1080/00140139.2015.1019575,TRUE,Taylor & Francis,Ergonomics,0014-0139,0014-0139,1366-5847,0014-0139,NA,TRUE,25761380,PMC4566900,ut:000369436300005,NA,FALSE
+lu,2015,2074,10.3109/00365513.2015.1099724,TRUE,Taylor & Francis,Scandinavian Journal of Clinical and Laboratory Investigation,0036-5513,0036-5513,1502-7686,0036-5513,NA,TRUE,26647957,PMC4720044,ut:000366183000011,NA,FALSE
+lu,2015,2132,10.1080/13504509.2015.1128492,TRUE,Taylor & Francis,International Journal of Sustainable Development & World Ecology,1350-4509,1350-4509,1745-2627,1350-4509,NA,TRUE,NA,NA,ut:000382541300003,NA,FALSE
+lu,2015,2132,10.1080/1573062X.2015.1111913,TRUE,Taylor & Francis,Urban Water Journal,1573-062X,1573-062X,1744-9006,1573-062X,NA,TRUE,NA,NA,ut:000392208900006,NA,FALSE
+lu,2015,2132,10.3109/00365513.2015.1025427,TRUE,Taylor & Francis,Scandinavian Journal of Clinical and Laboratory Investigation,0036-5513,0036-5513,1502-7686,0036-5513,NA,TRUE,25919022,PMC4487590,ut:000353654200009,NA,FALSE
+lu,2015,2132,10.3109/0284186X.2015.1075663,TRUE,Taylor & Francis,Acta Oncologica,0284-186X,0284-186X,1651-226X,0284-186X,NA,TRUE,26362587,PMC4819809,ut:000371249500005,NA,FALSE
+lu,2015,2132,10.3109/17435390.2015.1048324,TRUE,Taylor & Francis,Nanotoxicology,1743-5390,1743-5390,1743-5404,1743-5390,NA,TRUE,26186033,PMC4819849,ut:000371822800010,NA,FALSE
+lu,2015,2429,10.1080/02698595.2014.953343,TRUE,Taylor & Francis,International Studies in the Philosophy of Science,0269-8595,0269-8595,1469-9281,0269-8595,NA,TRUE,NA,NA,ut:000346055600005,NA,FALSE
+lu,2015,248,10.1080/00207543.2012.761363,TRUE,Taylor & Francis,International Journal of Production Research,0020-7543,0020-7543,1366-588X,0020-7543,NA,TRUE,NA,NA,ut:000328246000011,NA,FALSE
+lu,2015,3040,10.1517/17460441.2015.1032936,TRUE,Taylor & Francis,Expert Opinion on Drug Discovery,1746-0441,1746-0441,1746-045X,1746-0441,NA,TRUE,25835573,PMC4487606,ut:000353208600002,NA,FALSE
+lu,2015,734,10.1080/19382014.2015.1118195,TRUE,Taylor & Francis,Islets,1938-2014,1938-2014,1938-2022,1938-2022,NA,TRUE,26742564,PMC4878264,ut:000368712100002,NA,FALSE
+lu,2015,755,10.1159/000377710,FALSE,Karger,Cerebrovascular Diseases Extra,1664-5456,NA,1664-5456,1664-5456,NA,TRUE,26120319,PMC4478329,NA,NA,TRUE
+lu,2016,0,10.1080/17453674.2016.1195663,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,1745-3674,NA,TRUE,27339330,PMC4967283,ut:000381540900013,NA,TRUE
+lu,2016,0,10.1080/17453674.2016.1205173,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,1745-3674,NA,TRUE,27391663,PMC5016912,ut:000387526300014,NA,TRUE
+lu,2016,0,10.1080/17453674.2016.1210940,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,1745-3674,NA,TRUE,27436058,PMC5016915,ut:000387526300017,NA,TRUE
+lu,2016,0,10.3109/17453674.2016.1152855,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,1745-3674,NA,TRUE,26905618,PMC4900094,ut:000377098700016,NA,TRUE
+lu,2016,0,10.3109/17453674.2016.1161451,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,1745-3674,NA,TRUE,26982799,PMC4900082,ut:000377098700007,NA,TRUE
+lu,2016,0,10.3109/17453674.2016.1170548,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,1745-3674,NA,TRUE,27212102,PMC4900081,ut:000377098700012,NA,TRUE
+lu,2016,2132,10.1080/02678373.2016.1175524,TRUE,Taylor & Francis,Work & Stress,0267-8373,0267-8373,1464-5335,0267-8373,NA,TRUE,27226677,PMC4867854,ut:000375478000001,NA,FALSE
+lu,2016,2132,10.1080/08039410.2016.1252424,TRUE,Taylor & Francis,Forum for Development Studies,0803-9410,0803-9410,1891-1765,0803-9410,NA,TRUE,NA,NA,ut:000396607200002,NA,FALSE
+lu,2016,2132,10.1080/09638288.2016.1236409,TRUE,Taylor & Francis,Disability and Rehabilitation,0963-8288,0963-8288,1464-5165,0963-8288,NA,TRUE,NA,NA,NA,NA,FALSE
+lu,2016,2132,10.1080/11038128.2016.1224271,TRUE,Taylor & Francis,Scandinavian Journal of Occupational Therapy,1103-8128,1103-8128,1651-2014,1103-8128,NA,TRUE,27575654,NA,ut:000392839900006,NA,FALSE
+lu,2016,2132,10.1080/13691058.2016.1259503,TRUE,Taylor & Francis,"Culture, Health & Sexuality",1369-1058,1369-1058,1464-5351,1369-1058,NA,TRUE,27894219,NA,ut:000402817200004,NA,FALSE
+lu,2016,2132,10.1080/14693062.2016.1167009,TRUE,Taylor & Francis,Climate Policy,1469-3062,1469-3062,1752-7457,1469-3062,NA,TRUE,NA,NA,ut:000403099400005,NA,FALSE
+lu,2016,2132,10.1080/17435390.2016.1189615,TRUE,Taylor & Francis,Nanotoxicology,1743-5390,1743-5390,1743-5404,1743-5390,NA,TRUE,27181920,PMC4975093,ut:000382337100015,NA,FALSE
+lu,2016,2132,10.1080/23254823.2016.1253977,TRUE,Taylor & Francis,European Journal of Cultural and Political Sociology,2325-4823,2325-4823,2325-4815,2325-4815,NA,TRUE,NA,NA,NA,NA,FALSE
+lu,2016,2132,10.1080/87565641.2016.1243111,TRUE,Taylor & Francis,Developmental Neuropsychology,8756-5641,8756-5641,1532-6942,1532-6942,NA,TRUE,28059564,NA,ut:000395349600004,NA,FALSE
+lu,2016,2132,10.1179/2047971915Y.0000000021,TRUE,Taylor & Francis,International Journal of Healthcare Management,2047-9700,2047-9700,2047-9719,2047-9700,NA,TRUE,NA,NA,NA,NA,FALSE
+lu,2016,2132,10.3109/0284186X.2016.1146826,TRUE,Taylor & Francis,Acta Oncologica,0284-186X,0284-186X,1651-226X,0284-186X,NA,TRUE,27050668,PMC4950423,ut:000381102800006,NA,FALSE
+lu,2016,2132,10.3109/14017431.2016.1154598,TRUE,Taylor & Francis,Scandinavian Cardiovascular Journal,1401-7431,1401-7431,1651-2006,1401-7431,NA,TRUE,26882241,PMC4898163,ut:000377282900009,NA,FALSE
+lu,2016,2200,10.1007/s00018-016-2365-0,TRUE,Springer,Cellular and Molecular Life Sciences,1420-682X,1420-682X,1420-9071,1420-682X,http://creativecommons.org/licenses/by/4.0,TRUE,27652381,PMC5272905,ut:000393694900011,NA,FALSE
+lu,2016,2200,10.1007/s00125-016-4113-2,TRUE,Springer,Diabetologia,0012-186X,0012-186X,1432-0428,0012-186X,http://creativecommons.org/licenses/by/4.0,TRUE,27796421,NA,ut:000389634000015,NA,FALSE
+lu,2016,2200,10.1007/s00125-016-4141-y,TRUE,Springer,Diabetologia,0012-186X,0012-186X,1432-0428,0012-186X,http://creativecommons.org/licenses/by/4.0,TRUE,27807598,NA,ut:000391359800013,NA,FALSE
+lu,2016,2200,10.1007/s00125-016-4184-0,TRUE,Springer,Diabetologia,0012-186X,0012-186X,1432-0428,0012-186X,http://creativecommons.org/licenses/by/4.0,TRUE,28004149,NA,ut:000394462100010,NA,FALSE
+lu,2016,2200,10.1007/s00170-016-9296-7,TRUE,Springer,The International Journal of Advanced Manufacturing Technology,0268-3768,0268-3768,1433-3015,0268-3768,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000398922700047,NA,FALSE
+lu,2016,2200,10.1007/s00181-016-1123-3,TRUE,Springer,Empirical Economics,0377-7332,0377-7332,1435-8921,0377-7332,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000407847400001,NA,FALSE
+lu,2016,2200,10.1007/s00198-016-3768-3,TRUE,Springer,Osteoporosis International,0937-941X,0937-941X,1433-2965,0937-941X,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27647528,PMC5206266,ut:000391390100014,NA,FALSE
+lu,2016,2200,10.1007/s00198-016-3771-8,TRUE,Springer,Osteoporosis International,0937-941X,0937-941X,1433-2965,0937-941X,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27822590,PMC5269464,ut:000393646200026,NA,FALSE
+lu,2016,2200,10.1007/s00223-016-0174-y,TRUE,Springer,Calcified Tissue International,0171-967X,0171-967X,1432-0827,0171-967X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000385162500001,NA,FALSE
+lu,2016,2200,10.1007/s00253-016-7833-9,TRUE,Springer,Applied Microbiology and Biotechnology,0175-7598,0175-7598,1432-0614,0175-7598,http://creativecommons.org/licenses/by/4.0,TRUE,27678115,PMC5247548,ut:000392502600018,NA,FALSE
+lu,2016,2200,10.1007/s00253-016-8055-x,TRUE,Springer,Applied Microbiology and Biotechnology,0175-7598,0175-7598,1432-0614,0175-7598,http://creativecommons.org/licenses/by/4.0,TRUE,27995311,PMC5219020,ut:000392060500004,NA,FALSE
+lu,2016,2200,10.1007/s00262-016-1909-3,TRUE,Springer,"Cancer Immunology, Immunotherapy",0340-7004,0340-7004,1432-0851,0340-7004,http://creativecommons.org/licenses/by/4.0,TRUE,27714433,PMC5222923,ut:000393598500001,NA,FALSE
+lu,2016,2200,10.1007/s00284-016-1165-y,TRUE,Springer,Current Microbiology,0343-8651,0343-8651,1432-0991,0343-8651,http://creativecommons.org/licenses/by/4.0,TRUE,27896481,PMC5243900,ut:000392302100002,NA,FALSE
+lu,2016,2200,10.1007/s00359-016-1130-z,TRUE,Springer,Journal of Comparative Physiology A,0340-7594,0340-7594,1432-1351,0340-7594,http://creativecommons.org/licenses/by/4.0,TRUE,27837238,PMC5263199,ut:000393670200002,NA,FALSE
+lu,2016,2200,10.1007/s00362-016-0864-6,TRUE,Springer,Statistical Papers,0932-5026,0932-5026,1613-9798,0932-5026,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+lu,2016,2200,10.1007/s00382-016-3408-9,TRUE,Springer,Climate Dynamics,0930-7575,0930-7575,1432-0894,0930-7575,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000408718200012,NA,FALSE
+lu,2016,2200,10.1007/s00383-016-4001-3,TRUE,Springer,Pediatric Surgery International,0179-0358,0179-0358,1437-9813,0179-0358,http://creativecommons.org/licenses/by/4.0,TRUE,27807610,PMC5225200,ut:000392292900012,NA,FALSE
+lu,2016,2200,10.1007/s00383-016-4013-z,TRUE,Springer,Pediatric Surgery International,0179-0358,0179-0358,1437-9813,0179-0358,http://creativecommons.org/licenses/by/4.0,TRUE,27844168,PMC5263191,ut:000393962600011,NA,FALSE
+lu,2016,2200,10.1007/s00384-016-2639-x,TRUE,Springer,International Journal of Colorectal Disease,0179-1958,0179-1958,1432-1262,0179-1958,http://creativecommons.org/licenses/by/4.0,TRUE,27613729,PMC5219883,ut:000392129400002,NA,FALSE
+lu,2016,2200,10.1007/s00396-016-3927-2,TRUE,Springer,Colloid and Polymer Science,0303-402X,0303-402X,1435-1536,0303-402X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000386339600001,NA,FALSE
+lu,2016,2200,10.1007/s00415-016-8287-9,TRUE,Springer,Journal of Neurology,0340-5354,0340-5354,1432-1459,0340-5354,http://creativecommons.org/licenses/by/4.0,TRUE,27646115,PMC5110600,ut:000388625500015,NA,FALSE
+lu,2016,2200,10.1007/s00423-016-1517-x,TRUE,Springer,Langenbeck's Archives of Surgery,1435-2443,1435-2443,1435-2451,1435-2443,http://creativecommons.org/licenses/by/4.0,TRUE,27783154,PMC5346422,ut:000397297900011,NA,FALSE
+lu,2016,2200,10.1007/s00423-016-1535-8,TRUE,Springer,Langenbeck's Archives of Surgery,1435-2443,1435-2443,1435-2451,1435-2443,http://creativecommons.org/licenses/by/4.0,TRUE,27896436,PMC5346413,ut:000397297900017,NA,FALSE
+lu,2016,2200,10.1007/s00453-016-0202-3,TRUE,Springer,Algorithmica,0178-4617,0178-4617,1432-0541,0178-4617,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000406779100007,NA,FALSE
+lu,2016,2200,10.1007/s00477-016-1375-7,TRUE,Springer,Stochastic Environmental Research and Risk Assessment,1436-3240,1436-3240,1436-3259,1436-3240,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+lu,2016,2200,10.1007/s00592-016-0903-8,TRUE,Springer,Acta Diabetologica,0940-5429,0940-5429,1432-5233,0940-5429,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392277200014,NA,FALSE
+lu,2016,2200,10.1007/s10071-016-1015-0,TRUE,Springer,Animal Cognition,1435-9448,1435-9448,1435-9456,1435-9448,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000385153000003,NA,FALSE
+lu,2016,2200,10.1007/s10071-016-1016-z,TRUE,Springer,Animal Cognition,1435-9448,1435-9448,1435-9456,1435-9448,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000385153000020,NA,FALSE
+lu,2016,2200,10.1007/s10096-016-2862-y,TRUE,Springer,European Journal of Clinical Microbiology & Infectious Diseases,0934-9723,0934-9723,1435-4373,0934-9723,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000399694500005,NA,FALSE
+lu,2016,2200,10.1007/s10237-016-0866-2,TRUE,Springer,Biomechanics and Modeling in Mechanobiology,1617-7959,1617-7959,1617-7940,1617-7940,http://creativecommons.org/licenses/by/4.0,TRUE,28004226,NA,ut:000400977300018,NA,FALSE
+lu,2016,2200,10.1007/s10344-016-1054-5,TRUE,Springer,European Journal of Wildlife Research,1612-4642,1612-4642,1439-0574,1439-0574,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388963000013,NA,FALSE
+lu,2016,2200,10.1007/s10470-016-0800-7,TRUE,Springer,Analog Integrated Circuits and Signal Processing,0925-1030,0925-1030,1573-1979,0925-1030,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000387770900002,NA,FALSE
+lu,2016,2200,10.1007/s10470-016-0902-2,TRUE,Springer,Analog Integrated Circuits and Signal Processing,0925-1030,0925-1030,1573-1979,0925-1030,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392502300007,NA,FALSE
+lu,2016,2200,10.1007/s10584-016-1880-1,TRUE,Springer,Climatic Change,0165-0009,0165-0009,1573-1480,0165-0009,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000393744800004,NA,FALSE
+lu,2016,2200,10.1007/s10611-016-9675-x,TRUE,Springer,"Crime, Law and Social Change",0925-4994,0925-4994,1573-0751,0925-4994,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+lu,2016,2200,10.1007/s10677-016-9747-0,TRUE,Springer,Ethical Theory and Moral Practice,1386-2820,1386-2820,1572-8447,1386-2820,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000397986300009,NA,FALSE
+lu,2016,2200,10.1007/s10682-016-9871-2,TRUE,Springer,Evolutionary Ecology,0269-7653,0269-7653,1573-8477,0269-7653,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000394017000004,NA,FALSE
+lu,2016,2200,10.1007/s10822-016-9942-z,TRUE,Springer,Journal of Computer-Aided Molecular Design,0920-654X,0920-654X,1573-4951,0920-654X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000387088900005,NA,FALSE
+lu,2016,2200,10.1007/s10822-016-9948-6,TRUE,Springer,Journal of Computer-Aided Molecular Design,0920-654X,0920-654X,1573-4951,0920-654X,http://creativecommons.org/licenses/by/4.0,TRUE,27573983,PMC5239820,ut:000392326500010,NA,FALSE
+lu,2016,2200,10.1007/s10822-016-9957-5,TRUE,Springer,Journal of Computer-Aided Molecular Design,0920-654X,0920-654X,1573-4951,0920-654X,http://creativecommons.org/licenses/by/4.0,TRUE,27600554,PMC5239813,ut:000392326500008,NA,FALSE
+lu,2016,2200,10.1007/s10823-016-9311-3,TRUE,Springer,Journal of Cross-Cultural Gerontology,0169-3816,0169-3816,1573-0719,0169-3816,http://creativecommons.org/licenses/by/4.0,TRUE,28028743,PMC5310561,ut:000408866300002,NA,FALSE
+lu,2016,2200,10.1007/s10826-016-0602-7,TRUE,Springer,Journal of Child and Family Studies,1062-1024,1062-1024,1573-2843,1062-1024,http://creativecommons.org/licenses/by/4.0,TRUE,28239249,PMC5306151,ut:000394439700005,NA,FALSE
+lu,2016,2200,10.1007/s10851-016-0677-1,TRUE,Springer,Journal of Mathematical Imaging and Vision,0924-9907,0924-9907,1573-7683,0924-9907,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000394150100005,NA,FALSE
+lu,2016,2200,10.1007/s10862-016-9570-x,TRUE,Springer,Journal of Psychopathology and Behavioral Assessment,0882-2689,0882-2689,1573-3505,0882-2689,http://creativecommons.org/licenses/by/4.0,TRUE,28286372,PMC5323484,ut:000395082800011,NA,FALSE
+lu,2016,2200,10.1007/s10959-016-0725-1,TRUE,Springer,Journal of Theoretical Probability,0894-9840,0894-9840,1572-9230,0894-9840,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+lu,2016,2200,10.1007/s10967-016-5030-z,TRUE,Springer,Journal of Radioanalytical and Nuclear Chemistry,0236-5731,0236-5731,1588-2780,0236-5731,http://creativecommons.org/licenses/by/4.0,TRUE,28111484,PMC5219036,ut:000392075200038,NA,FALSE
+lu,2016,2200,10.1007/s11060-016-2302-y,TRUE,Springer,Journal of Neuro-Oncology,0167-594X,0167-594X,1573-7373,0167-594X,http://creativecommons.org/licenses/by/4.0,TRUE,27757723,PMC5306185,ut:000394342500005,NA,FALSE
+lu,2016,2200,10.1007/s11090-016-9771-9,TRUE,Springer,Plasma Chemistry and Plasma Processing,0272-4324,0272-4324,1572-8986,0272-4324,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000395207100006,NA,FALSE
+lu,2016,2200,10.1007/s11098-016-0841-x,TRUE,Springer,Philosophical Studies,0031-8116,0031-8116,1573-0883,0031-8116,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+lu,2016,2200,10.1007/s11127-016-0373-0,TRUE,Springer,Public Choice,0048-5829,0048-5829,1573-7101,0048-5829,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388837000002,NA,FALSE
+lu,2016,2200,10.1007/s11199-016-0694-y,TRUE,Springer,Sex Roles,0360-0025,0360-0025,1573-2762,0360-0025,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000403548700007,NA,FALSE
+lu,2016,2200,10.1007/s11207-016-0969-z,TRUE,Springer,Solar Physics,0038-0938,0038-0938,1573-093X,0038-0938,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388842600028,NA,FALSE
+lu,2016,2200,10.1007/s11224-016-0868-9,TRUE,Springer,Structural Chemistry,1040-0400,1040-0400,1572-9001,1040-0400,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000394341700031,NA,FALSE
+lu,2016,2200,10.1007/s11239-016-1464-y,TRUE,Springer,Journal of Thrombosis and Thrombolysis,0929-5305,0929-5305,1573-742X,0929-5305,http://creativecommons.org/licenses/by/4.0,TRUE,27990607,NA,ut:000399021200006,NA,FALSE
+lu,2016,2200,10.1007/s11244-016-0714-8,TRUE,Springer,Topics in Catalysis,1022-5528,1022-5528,1572-9028,1022-5528,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000403020800013,NA,FALSE
+lu,2016,2200,10.1007/s11251-016-9397-6,TRUE,Springer,Instructional Science,0020-4277,0020-4277,1573-1952,0020-4277,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000397984900007,NA,FALSE
+lu,2016,2200,10.1007/s11269-016-1546-9,TRUE,Springer,Water Resources Management,0920-4741,0920-4741,1573-1650,0920-4741,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000393777100033,NA,FALSE
+lu,2016,2200,10.1007/s11356-016-7706-x,TRUE,Springer,Environmental Science and Pollution Research,0944-1344,0944-1344,1614-7499,0944-1344,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000389301700046,NA,FALSE
+lu,2016,2200,10.1007/s11365-016-0405-8,TRUE,Springer,International Entrepreneurship and Management Journal,1554-7191,1554-7191,1555-1938,1554-7191,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000394301700011,NA,FALSE
+lu,2016,2200,10.1007/s11406-016-9766-z,TRUE,Springer,Philosophia,0048-3893,0048-3893,1574-9274,0048-3893,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000400403700014,NA,FALSE
+lu,2016,2200,10.1007/s11434-016-1146-3,TRUE,Springer,Science Bulletin,2095-9273,2095-9273,2095-9281,2095-9273,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27635282,PMC5002044,ut:000382391600005,NA,FALSE
+lu,2016,2200,10.1007/s11517-016-1593-7,TRUE,Springer,Medical & Biological Engineering & Computing,0140-0118,0140-0118,1741-0444,0140-0118,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000407310300016,NA,FALSE
+lu,2016,2200,10.1007/s11785-016-0596-6,TRUE,Springer,Complex Analysis and Operator Theory,1661-8254,1661-8254,1661-8262,1661-8254,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000398768500003,NA,FALSE
+lu,2016,2200,10.1007/s11837-016-2112-x,TRUE,Springer,JOM,1047-4838,1047-4838,1543-1851,1047-4838,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388818100012,NA,FALSE
+lu,2016,2200,10.1007/s11864-016-0426-0,TRUE,Springer,Current Treatment Options in Oncology,1527-2729,1527-2729,1534-6277,1534-6277,http://creativecommons.org/licenses/by/4.0,TRUE,27476159,PMC4967419,ut:000381076500006,NA,FALSE
+lu,2016,2200,10.1007/s12010-016-2229-y,TRUE,Springer,Applied Biochemistry and Biotechnology,0273-2289,0273-2289,1559-0291,0273-2289,http://creativecommons.org/licenses/by/4.0,TRUE,27631121,PMC5285423,ut:000394219200005,NA,FALSE
+lu,2016,2200,10.1007/s12028-016-0348-5,TRUE,Springer,Neurocritical Care,1541-6933,1541-6933,1556-0961,1541-6933,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000402101100019,NA,FALSE
+lu,2016,2200,10.1007/s12138-016-0423-5,TRUE,Springer,International Journal of the Classical Tradition,1073-0508,1073-0508,1874-6292,1073-0508,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000407359600004,NA,FALSE
+lu,2016,2200,10.1007/s12311-016-0839-0,TRUE,Springer,The Cerebellum,1473-4222,1473-4222,1473-4230,1473-4222,http://creativecommons.org/licenses/by/4.0,TRUE,28032320,NA,ut:000401509000004,NA,FALSE
+lu,2016,2200,10.1007/s12350-016-0628-7,TRUE,Springer,Journal of Nuclear Cardiology,1071-3581,1071-3581,1532-6551,1071-3581,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+lu,2016,2200,10.1007/s12649-016-9643-9,TRUE,Springer,Waste and Biomass Valorization,1877-2641,1877-2641,1877-265X,1877-2641,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000398594100028,NA,FALSE
+lu,2016,2200,10.1007/s12665-016-6205-1,TRUE,Springer,Environmental Earth Sciences,1866-6280,1866-6280,1866-6299,1866-6280,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388600900001,NA,FALSE
+lu,2016,2200,10.1007/s12665-016-6364-0,TRUE,Springer,Environmental Earth Sciences,1866-6280,1866-6280,1866-6299,1866-6280,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392286300036,NA,FALSE
+lu,2016,2200,10.1007/s12671-016-0653-2,TRUE,Springer,Mindfulness,1868-8527,1868-8527,1868-8535,1868-8527,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000400330000020,NA,FALSE
+lu,2016,2200,10.1007/s13164-016-0318-z,TRUE,Springer,Review of Philosophy and Psychology,1878-5158,1878-5158,1878-5166,1878-5158,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+lu,2016,2200,10.3758/s13428-016-0806-1,TRUE,Springer,Behavior Research Methods,1554-3528,NA,1554-3528,1554-351X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000407202200011,NA,FALSE
+lu,2016,397,10.3109/02813432.2015.1132884,FALSE,Taylor & Francis,Scandinavian Journal of Primary Health Care,0281-3432,0281-3432,1502-7724,0281-3432,NA,TRUE,26828942,PMC4911028,ut:000372023200013,NA,TRUE
+lu,2016,444,10.1080/21650020.2016.1156020,FALSE,Taylor & Francis,"Urban, Planning and Transport Research",2165-0020,NA,2165-0020,2165-0020,NA,TRUE,NA,NA,NA,NA,TRUE
+lu,2016,521,10.1080/09500340.2016.1257751,TRUE,Taylor & Francis,Journal of Modern Optics,0950-0340,0950-0340,1362-3044,0950-0340,NA,TRUE,NA,NA,NA,NA,FALSE
+lu,2016,734,10.1080/15592294.2016.1178418,TRUE,Taylor & Francis,Epigenetics,1559-2294,1559-2294,1559-2308,1559-2294,NA,TRUE,27148772,PMC4939923,ut:000380906200002,NA,FALSE
+lu,2016,734,10.1080/21623945.2016.1252011,TRUE,Taylor & Francis,Adipocyte,2162-3945,2162-3945,2162-397X,2162-3945,NA,TRUE,27994949,PMC5160390,ut:000390393500003,NA,FALSE
+lu,2016,969,10.1080/23311908.2016.1260237,FALSE,Taylor & Francis,Cogent Psychology,2331-1908,NA,2331-1908,2331-1908,NA,TRUE,NA,NA,ut:000390692400001,NA,TRUE
+mah,2011,2631,10.1111/j.1600-0579.2011.00702.x,TRUE,Wiley,European Journal of Dental Education,1396-5883,NA,1600-0579,1396-5883,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,22251323,PMC3490366,ut:000299202600036,http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1600-0579/homepage/ProductInformation.html,FALSE
+mah,2014,2429,10.1080/13504622.2013.879696,TRUE,Taylor & Francis,Environmental Education Research,1350-4622,1350-4622,1469-5871,1350-4622,NA,TRUE,NA,NA,ut:000348307100002,NA,FALSE
+mah,2014,2429,10.1080/17508487.2014.936890,TRUE,Taylor & Francis,Critical Studies in Education,1750-8487,1750-8487,1750-8495,1750-8487,NA,TRUE,NA,NA,ut:000342135600008,NA,FALSE
+mah,2014,2631,10.1111/clr.12507,TRUE,Wiley,Clinical Oral Implants Research,0905-7161,NA,1600-0501,0905-7161,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25349918,NA,ut:000368340200004,http://onlinelibrary.wiley.com/doi/10.1111/clr.12507/full,FALSE
+mah,2015,1311,10.1371/journal.pone.0140052,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26451727,PMC4599802,ut:000362511200031,http://journals.plos.org/plosone/article?id=10.1371%2Fjournal.pone.0140052,TRUE
+mah,2015,1882,10.1186/s12912-015-0092-8,FALSE,BioMed Central,BMC Nursing,1472-6955,NA,1472-6955,1472-6955,http://www.springer.com/tdm,TRUE,26236155,PMC4521316,ut:000210484900039,http://bmcnurs.biomedcentral.com/articles/10.1186/s12912-015-0092-8,TRUE
+mah,2015,2631,10.1177/1468796815588620,TRUE,SAGE Publications,Ethnicities,1468-7968,1468-7968,1741-2706,1468-7968,NA,TRUE,NA,NA,NA,http://etn.sagepub.com/content/early/2015/05/29/1468796815588620,FALSE
+mah,2016,2132,10.1080/10520295.2016.1255995,TRUE,Taylor & Francis,Biotechnic & Histochemistry,1052-0295,1052-0295,1473-7760,1052-0295,NA,TRUE,28157427,NA,ut:000395756300006,NA,FALSE
+mah,2016,2200,10.1007/s11098-016-0769-1,TRUE,Springer,Philosophical Studies,0031-8116,0031-8116,1573-0883,0031-8116,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000400234300008,NA,FALSE
+mah,2016,2200,10.1007/s12187-016-9435-6,TRUE,Springer,Child Indicators Research,1874-897X,1874-897X,1874-8988,1874-897X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+mah,2016,2200,10.1007/s12529-016-9625-0,TRUE,Springer,International Journal of Behavioral Medicine,1070-5503,1070-5503,1532-7558,1070-5503,http://creativecommons.org/licenses/by/4.0,TRUE,28028732,NA,NA,NA,FALSE
+mah,2016,2200,10.1007/s13277-016-5280-y,TRUE,Springer,Tumor Biology,1010-4283,1010-4283,1423-0380,1010-4283,http://creativecommons.org/licenses/by/4.0,TRUE,27476172,PMC5097081,ut:000387538700076,NA,FALSE
+mah,2016,346,10.1177/2158244016633739,FALSE,SAGE Publications,SAGE Open,2158-2440,2158-2440,2158-2440,2158-2440,NA,TRUE,NA,NA,NA,http://sgo.sagepub.com/content/6/1/2158244016633739,TRUE
+mah,2016,468,10.1080/2331186X.2016.1184604,FALSE,Taylor & Francis,Cogent Education,2331-186X,NA,2331-186X,2331-186X,NA,TRUE,NA,NA,ut:000385834300001,NA,TRUE
+mdh,2016,2200,10.1007/s00170-016-9377-7,TRUE,Springer,The International Journal of Advanced Manufacturing Technology,0268-3768,0268-3768,1433-3015,0268-3768,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000401505000030,NA,FALSE
+mdh,2016,2200,10.1007/s10270-016-0556-7,TRUE,Springer,Software & Systems Modeling,1619-1366,1619-1366,1619-1374,1619-1366,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+mdh,2016,2200,10.1007/s10659-016-9613-2,TRUE,Springer,Journal of Elasticity,0374-3535,0374-3535,1573-2681,0374-3535,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000396525700006,NA,FALSE
+mdh,2016,2200,10.1007/s10823-016-9296-y,TRUE,Springer,Journal of Cross-Cultural Gerontology,0169-3816,0169-3816,1573-0719,0169-3816,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000408865400003,NA,FALSE
+mdh,2016,2200,10.1007/s11219-016-9343-5,TRUE,Springer,Software Quality Journal,0963-9314,0963-9314,1573-1367,0963-9314,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+miu,2016,2200,10.1007/s10570-016-1029-4,TRUE,Springer,Cellulose,0969-0239,0969-0239,1572-882X,0969-0239,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000382634300026,NA,FALSE
+miu,2016,2200,10.1007/s10570-016-1068-x,TRUE,Springer,Cellulose,0969-0239,0969-0239,1572-882X,0969-0239,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388961200019,NA,FALSE
+miu,2016,2200,10.1007/s11575-016-0304-9,TRUE,Springer,Management International Review,0938-8249,0938-8249,1861-8901,0938-8249,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388727900003,NA,FALSE
 miu,2016,2200,10.1007/s41233-016-0003-0,TRUE,Springer,Quality and User Experience,2366-0139,2366-0139,2366-0147,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-nrm,2016,2200,10.1007/s11230-016-9668-2,TRUE,Springer,Systematic Parasitology,0165-5752,0165-5752,1573-5192,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-nrm,2016,2200,10.1007/s13225-016-0372-y,TRUE,Springer,Fungal Diversity,1560-2745,1560-2745,1878-9129,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-oru,2016,2200,10.1007/s00405-016-4239-3,TRUE,Springer,European Archives of Oto-Rhino-Laryngology,0937-4477,0937-4477,1434-4726,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27538736,PMC5222931,NA,NA,FALSE
-oru,2016,2200,10.1007/s00787-016-0899-1,TRUE,Springer,European Child & Adolescent Psychiatry,1018-8827,1018-8827,1435-165X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27683227,NA,NA,NA,FALSE
-oru,2016,2200,10.1007/s10096-016-2777-7,TRUE,Springer,European Journal of Clinical Microbiology & Infectious Diseases,0934-9723,0934-9723,1435-4373,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27680718,PMC5203848,NA,NA,FALSE
-oru,2016,2200,10.1007/s10519-016-9827-x,TRUE,Springer,Behavior Genetics,0001-8244,0001-8244,1573-3297,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27888366,PMC5306271,NA,NA,FALSE
-oru,2016,2200,10.1007/s10691-016-9332-x,TRUE,Springer,Feminist Legal Studies,0966-3622,0966-3622,1572-8455,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-oru,2016,2200,10.1007/s10803-016-2976-1,TRUE,Springer,Journal of Autism and Developmental Disorders,0162-3257,0162-3257,1573-3432,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27921201,PMC5352790,NA,NA,FALSE
-oru,2016,2200,10.1007/s10826-016-0623-2,TRUE,Springer,Journal of Child and Family Studies,1062-1024,1062-1024,1573-2843,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28337053,PMC5344949,NA,NA,FALSE
-sh,2016,2200,10.1007/s10342-016-0994-3,TRUE,Springer,European Journal of Forest Research,1612-4669,1612-4669,1612-4677,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,1008.83,10.1371/journal.pone.0111786,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25369054,PMC4219778,NA,NA,TRUE
-slu,2014,1070.25,10.1371/journal.pone.0111455,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25347069,PMC4210224,NA,NA,TRUE
-slu,2014,1070.25,10.1371/journal.pone.0111509,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25356591,PMC4214728,NA,NA,TRUE
-slu,2014,1074.33,10.1371/journal.pone.0111663,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25391132,PMC4229113,NA,NA,TRUE
-slu,2014,1074.33,10.1371/journal.pone.0114118,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25436772,PMC4250227,NA,NA,TRUE
-slu,2014,1085.66,10.1371/journal.pone.0117318,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25668783,PMC4323107,NA,NA,TRUE
-slu,2014,1105,10.4172/2155-9546.1000208,FALSE,OMICS Publishing Group,Journal of Aquaculture Research & Development,2155-9546,NA,2155-9546,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,1179.33,10.3390/ijerph110606586,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,NA,NA,TRUE,25003175,PMC4078597,NA,NA,TRUE
-slu,2014,1179.33,10.3390/ijerph110707094,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,NA,NA,TRUE,25026080,PMC4113863,NA,NA,TRUE
-slu,2014,1190,10.1186/1756-3305-6-251,FALSE,BioMed Central,Parasites & Vectors,1756-3305,1756-3305,NA,NA,NA,TRUE,23985077,PMC3765860,NA,NA,TRUE
-slu,2014,1201,10.1186/1751-0147-56-20,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,NA,NA,TRUE,24712831,PMC3998380,NA,NA,TRUE
-slu,2014,1210,10.1186/2046-0481-67-12,FALSE,BioMed Central,Irish Veterinary Journal,2046-0481,2046-0481,NA,NA,NA,TRUE,24917926,PMC4051667,NA,NA,TRUE
-slu,2014,1224,10.1002/ece3.1084,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25360251,PMC4201424,NA,NA,TRUE
-slu,2014,1224,10.1002/ece3.1145,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25247059,PMC4161175,NA,NA,TRUE
-slu,2014,1224,10.1002/ece3.1345,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25691962,PMC4314267,NA,NA,TRUE
-slu,2014,1254.54,10.1002/fsn3.192,FALSE,Wiley,Food Science & Nutrition,2048-7177,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25650294,PMC4304564,NA,NA,TRUE
-slu,2014,1280,10.3389/fphys.2014.00504,FALSE,Frontiers,Frontiers in Physiology,1664-042X,NA,1664-042X,NA,NA,TRUE,25566097,PMC4273620,NA,NA,TRUE
-slu,2014,1311.38,10.5194/hess-18-5255-2014,FALSE,Copernicus Publications,Hydrology and Earth System Sciences,1607-7938,NA,1607-7938,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,NA,TRUE
-slu,2014,1314.83,10.1016/j.ufug.2014.09.007,TRUE,Elsevier,Urban Forestry & Urban Greening,1618-8667,1618-8667,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,1314.83,10.1016/j.vaccine.2014.09.066,TRUE,Elsevier,Vaccine,0264-410X,0264-410X,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25312275,NA,NA,NA,FALSE
-slu,2014,1314.84,10.3390/ijerph110403870,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,NA,NA,TRUE,24717360,PMC4025038,NA,NA,TRUE
-slu,2014,1320,10.1186/s12917-014-0208-5,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,NA,1746-6148,NA,http://www.springer.com/tdm,TRUE,25208481,PMC4172778,NA,NA,TRUE
-slu,2014,1321,10.1186/s13028-014-0055-1,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,25193181,PMC4172964,NA,NA,TRUE
-slu,2014,1321,10.1186/s13028-014-0074-y,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,25344341,PMC4220060,NA,NA,TRUE
-slu,2014,1326,10.4172/2157-7579.1000163,FALSE,OMICS Publishing Group,Journal of Veterinary Science & Technology,2157-7579,NA,2157-7579,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,1334,10.1186/1746-6148-10-110,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,1746-6148,NA,NA,NA,TRUE,24885733,PMC4018535,NA,NA,TRUE
-slu,2014,1334,10.1186/1751-0147-56-34,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,NA,NA,TRUE,24884886,PMC4067625,NA,NA,TRUE
-slu,2014,1341,10.1186/1751-0147-55-20,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,NA,NA,TRUE,23497680,PMC3602148,NA,NA,TRUE
-slu,2014,1350,10.1186/1751-0147-56-23,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,NA,NA,TRUE,24735953,PMC3998218,NA,NA,TRUE
+nrm,2016,2200,10.1007/s11230-016-9668-2,TRUE,Springer,Systematic Parasitology,0165-5752,0165-5752,1573-5192,0165-5752,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000386359600004,NA,FALSE
+nrm,2016,2200,10.1007/s13225-016-0372-y,TRUE,Springer,Fungal Diversity,1560-2745,1560-2745,1878-9129,1560-2745,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392666900004,NA,FALSE
+oru,2016,2200,10.1007/s00405-016-4239-3,TRUE,Springer,European Archives of Oto-Rhino-Laryngology,0937-4477,0937-4477,1434-4726,0937-4477,http://creativecommons.org/licenses/by/4.0,TRUE,27538736,PMC5222931,ut:000393599900039,NA,FALSE
+oru,2016,2200,10.1007/s00787-016-0899-1,TRUE,Springer,European Child & Adolescent Psychiatry,1018-8827,1018-8827,1435-165X,1018-8827,http://creativecommons.org/licenses/by/4.0,TRUE,27683227,NA,ut:000398820500009,NA,FALSE
+oru,2016,2200,10.1007/s10096-016-2777-7,TRUE,Springer,European Journal of Clinical Microbiology & Infectious Diseases,0934-9723,0934-9723,1435-4373,0934-9723,http://creativecommons.org/licenses/by/4.0,TRUE,27680718,PMC5203848,ut:000391388800014,NA,FALSE
+oru,2016,2200,10.1007/s10519-016-9827-x,TRUE,Springer,Behavior Genetics,0001-8244,0001-8244,1573-3297,0001-8244,http://creativecommons.org/licenses/by/4.0,TRUE,27888366,PMC5306271,ut:000394344000003,NA,FALSE
+oru,2016,2200,10.1007/s10691-016-9332-x,TRUE,Springer,Feminist Legal Studies,0966-3622,0966-3622,1572-8455,0966-3622,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000391457600002,NA,FALSE
+oru,2016,2200,10.1007/s10803-016-2976-1,TRUE,Springer,Journal of Autism and Developmental Disorders,0162-3257,0162-3257,1573-3432,0162-3257,http://creativecommons.org/licenses/by/4.0,TRUE,27921201,PMC5352790,ut:000396815400006,NA,FALSE
+oru,2016,2200,10.1007/s10826-016-0623-2,TRUE,Springer,Journal of Child and Family Studies,1062-1024,1062-1024,1573-2843,1062-1024,http://creativecommons.org/licenses/by/4.0,TRUE,28337053,PMC5344949,ut:000396304200003,NA,FALSE
+sh,2016,2200,10.1007/s10342-016-0994-3,TRUE,Springer,European Journal of Forest Research,1612-4669,1612-4669,1612-4677,1612-4669,NA,TRUE,NA,NA,ut:000388105400006,NA,FALSE
+slu,2014,1008.83,10.1371/journal.pone.0111786,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25369054,PMC4219778,ut:000344402000100,NA,TRUE
+slu,2014,1070.25,10.1371/journal.pone.0111455,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25347069,PMC4210224,ut:000347994900077,NA,TRUE
+slu,2014,1070.25,10.1371/journal.pone.0111509,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25356591,PMC4214728,ut:000346765000066,NA,TRUE
+slu,2014,1074.33,10.1371/journal.pone.0111663,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25391132,PMC4229113,ut:000349144400028,NA,TRUE
+slu,2014,1074.33,10.1371/journal.pone.0114118,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25436772,PMC4250227,ut:000347114900119,NA,TRUE
+slu,2014,1085.66,10.1371/journal.pone.0117318,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25668783,PMC4323107,ut:000349493000018,NA,TRUE
+slu,2014,1105,10.4172/2155-9546.1000208,FALSE,OMICS Publishing Group,Journal of Aquaculture Research & Development,2155-9546,NA,2155-9546,2155-9546,NA,TRUE,NA,NA,NA,NA,FALSE
+slu,2014,1179.33,10.3390/ijerph110606586,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,1660-4601,NA,TRUE,25003175,PMC4078597,ut:000338662600065,NA,TRUE
+slu,2014,1179.33,10.3390/ijerph110707094,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,1660-4601,NA,TRUE,25026080,PMC4113863,ut:000339989500031,NA,TRUE
+slu,2014,1190,10.1186/1756-3305-6-251,FALSE,BioMed Central,Parasites & Vectors,1756-3305,1756-3305,NA,1756-3305,NA,TRUE,23985077,PMC3765860,ut:000323786900001,NA,TRUE
+slu,2014,1201,10.1186/1751-0147-56-20,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,0044-605X,NA,TRUE,24712831,PMC3998380,ut:000334941600001,NA,TRUE
+slu,2014,1210,10.1186/2046-0481-67-12,FALSE,BioMed Central,Irish Veterinary Journal,2046-0481,2046-0481,NA,2046-0481,NA,TRUE,24917926,PMC4051667,ut:000338784900001,NA,TRUE
+slu,2014,1224,10.1002/ece3.1084,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25360251,PMC4201424,ut:000337522200006,NA,TRUE
+slu,2014,1224,10.1002/ece3.1145,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25247059,PMC4161175,ut:000340575000004,NA,TRUE
+slu,2014,1224,10.1002/ece3.1345,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25691962,PMC4314267,ut:000348853300010,NA,TRUE
+slu,2014,1254.54,10.1002/fsn3.192,FALSE,Wiley,Food Science & Nutrition,2048-7177,NA,NA,2048-7177,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25650294,PMC4304564,ut:000360115600009,NA,TRUE
+slu,2014,1280,10.3389/fphys.2014.00504,FALSE,Frontiers,Frontiers in Physiology,1664-042X,NA,1664-042X,1664-042X,NA,TRUE,25566097,PMC4273620,ut:000348211000001,NA,TRUE
+slu,2014,1311.38,10.5194/hess-18-5255-2014,FALSE,Copernicus Publications,Hydrology and Earth System Sciences,1607-7938,NA,1607-7938,1027-5606,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000347313600020,NA,TRUE
+slu,2014,1314.83,10.1016/j.ufug.2014.09.007,TRUE,Elsevier,Urban Forestry & Urban Greening,1618-8667,1618-8667,NA,1610-8167,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000346547000033,NA,FALSE
+slu,2014,1314.83,10.1016/j.vaccine.2014.09.066,TRUE,Elsevier,Vaccine,0264-410X,0264-410X,NA,0264-410X,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25312275,NA,ut:000345820800006,NA,FALSE
+slu,2014,1314.84,10.3390/ijerph110403870,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,1660-4601,NA,TRUE,24717360,PMC4025038,ut:000335762700061,NA,TRUE
+slu,2014,1320,10.1186/s12917-014-0208-5,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,NA,1746-6148,1746-6148,http://www.springer.com/tdm,TRUE,25208481,PMC4172778,ut:000342165900001,NA,TRUE
+slu,2014,1321,10.1186/s13028-014-0055-1,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,25193181,PMC4172964,ut:000342022800001,NA,TRUE
+slu,2014,1321,10.1186/s13028-014-0074-y,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,25344341,PMC4220060,ut:000346090400001,NA,TRUE
+slu,2014,1326,10.4172/2157-7579.1000163,FALSE,OMICS Publishing Group,Journal of Veterinary Science & Technology,2157-7579,NA,2157-7579,2157-7579,NA,TRUE,NA,NA,NA,NA,FALSE
+slu,2014,1334,10.1186/1746-6148-10-110,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,1746-6148,NA,1746-6148,NA,TRUE,24885733,PMC4018535,ut:000335999900001,NA,TRUE
+slu,2014,1334,10.1186/1751-0147-56-34,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,0044-605X,NA,TRUE,24884886,PMC4067625,ut:000338452700001,NA,TRUE
+slu,2014,1341,10.1186/1751-0147-55-20,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,0044-605X,NA,TRUE,23497680,PMC3602148,ut:000317049700001,NA,TRUE
+slu,2014,1350,10.1186/1751-0147-56-23,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,0044-605X,NA,TRUE,24735953,PMC3998218,ut:000334942800001,NA,TRUE
 slu,2014,1351,10.1186/1751-0147-55-50m,FALSE,BioMed Central,NA,NA,NA,NA,NA,NA,FALSE,NA,NA,NA,NA,NA
-slu,2014,1361,10.1186/1751-0147-55-33,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,NA,NA,TRUE,23594682,PMC3640916,NA,NA,TRUE
-slu,2014,1385.87,10.1186/1471-2164-15-315,FALSE,BioMed Central,BMC Genomics,1471-2164,1471-2164,NA,NA,NA,TRUE,24773703,PMC4234511,NA,NA,TRUE
-slu,2014,1385.87,10.1186/1471-2180-14-90,FALSE,BioMed Central,BMC Microbiology,1471-2180,1471-2180,NA,NA,NA,TRUE,24725382,PMC3991884,NA,NA,TRUE
-slu,2014,1409,10.1186/1471-2164-14-893,FALSE,BioMed Central,BMC Genomics,1471-2164,1471-2164,NA,NA,NA,TRUE,24341908,PMC3878592,NA,NA,TRUE
-slu,2014,1412.91,10.1186/s12870-014-0254-y,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,NA,http://www.springer.com/tdm,TRUE,25270759,PMC4192290,NA,NA,TRUE
-slu,2014,1415,10.1186/1751-0147-55-83,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,NA,NA,TRUE,24256697,PMC4176978,NA,NA,TRUE
-slu,2014,1432.48,10.1186/1471-2229-14-31,FALSE,BioMed Central,BMC Plant Biology,1471-2229,1471-2229,NA,NA,NA,TRUE,24438179,PMC3945485,NA,NA,TRUE
-slu,2014,1433,10.1186/s12917-014-0273-9,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,NA,1746-6148,NA,http://www.springer.com/tdm,TRUE,25430894,PMC4247870,NA,NA,TRUE
-slu,2014,1436,10.1186/1751-0147-56-7,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,NA,NA,TRUE,24461167,PMC3922756,NA,NA,TRUE
-slu,2014,1452,10.1186/1751-0147-56-25,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,NA,NA,TRUE,24758285,PMC4020358,NA,NA,TRUE
-slu,2014,1466,10.1186/s13028-014-0041-7,FALSE,Public Library of Science (PLoS),Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,25011553,PMC4226984,NA,NA,TRUE
-slu,2014,1475.92,10.1186/1756-3305-7-13,FALSE,BioMed Central,Parasites & Vectors,1756-3305,1756-3305,NA,NA,NA,TRUE,24401545,PMC3892011,NA,NA,TRUE
-slu,2014,1478,10.1186/1751-0147-56-37,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,NA,NA,TRUE,24910081,PMC4061533,NA,NA,TRUE
-slu,2014,1480,10.1111/eva.12229,FALSE,Wiley,Evolutionary Applications,1752-4571,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25553072,PMC4231600,NA,NA,TRUE
-slu,2014,1492.12,10.3390/molecules190914195,FALSE,MDPI,Molecules,1420-3049,NA,1420-3049,NA,NA,TRUE,25207719,NA,NA,NA,TRUE
-slu,2014,1496.92,10.1186/s12866-014-0308-1,FALSE,BioMed Central,BMC Microbiology,1471-2180,NA,1471-2180,NA,http://www.springer.com/tdm,TRUE,25492044,PMC4272539,NA,NA,TRUE
-slu,2014,1497.23,10.1186/s12870-014-0329-9,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,NA,http://www.springer.com/tdm,TRUE,25476999,PMC4274702,NA,NA,TRUE
-slu,2014,1511,10.1186/s13028-014-0082-y,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,25510194,PMC4271328,NA,NA,TRUE
-slu,2014,1511.57,10.1186/s12870-014-0298-z,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,NA,http://www.springer.com/tdm,TRUE,25365911,PMC4232680,NA,NA,TRUE
-slu,2014,1544,10.1186/s13028-014-0070-2,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,25366065,PMC4222379,NA,NA,TRUE
-slu,2014,1571,10.1186/s13028-014-0073-z,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,25359553,PMC4219133,NA,NA,TRUE
-slu,2014,1600,10.3389/fevo.2014.00065,FALSE,Frontiers,Frontiers in Ecology and Evolution,2296-701X,NA,2296-701X,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2014,1608,10.1186/s13028-014-0069-8,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,25288196,PMC4192735,NA,NA,TRUE
-slu,2014,1630.04,10.1111/1365-2664.12289,TRUE,Wiley,Journal of Applied Ecology,0021-8901,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25552747,PMC4277688,NA,NA,FALSE
-slu,2014,1633,10.1186/1471-2229-14-104,FALSE,BioMed Central,BMC Plant Biology,1471-2229,1471-2229,NA,NA,NA,TRUE,24758347,PMC4108048,NA,NA,TRUE
-slu,2014,1637.47,10.1111/1365-2664.12219,TRUE,Wiley,Journal of Applied Ecology,0021-8901,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25653457,PMC4299503,NA,NA,FALSE
-slu,2014,1766.98,10.1186/s12870-014-0220-8,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,NA,http://www.springer.com/tdm,TRUE,25143005,PMC4160553,NA,NA,TRUE
-slu,2014,1790.54,10.1371/journal.pgen.1004842,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25503602,PMC4263395,NA,NA,TRUE
-slu,2014,1796,10.1186/s12917-014-0228-1,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,NA,1746-6148,NA,http://www.springer.com/tdm,TRUE,25293656,PMC4195903,NA,NA,TRUE
-slu,2014,1814,10.1186/s13028-014-0091-x,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,NA,NA,TRUE,25582919,PMC4300160,NA,NA,TRUE
-slu,2014,1826.15,10.1016/j.chemosphere.2014.07.009,TRUE,Elsevier,Chemosphere,0045-6535,0045-6535,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25103085,NA,NA,NA,FALSE
-slu,2014,1840.13,10.1016/j.forpol.2013.12.007,TRUE,Elsevier,Forest Policy and Economics,1389-9341,1389-9341,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,1843.22,10.1105/tpc.114.130120,TRUE,American Society of Plant Biologists (ASPB),The Plant Cell,1040-4651,1040-4651,1532-298X,NA,NA,TRUE,25217506,NA,NA,NA,FALSE
-slu,2014,1843.22,10.​1105/​tpc.​114.​130120,TRUE,American Society of Plant Biologists,NA,NA,NA,NA,NA,NA,FALSE,NA,NA,NA,NA,NA
-slu,2014,1851.17,10.1016/j.scitotenv.2014.05.123,TRUE,Elsevier,Science of The Total Environment,0048-9697,0048-9697,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,24946033,NA,NA,NA,FALSE
-slu,2014,1851.18,10.1016/j.theriogenology.2014.02.014,TRUE,Elsevier,Theriogenology,0093-691X,0093-691X,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,24661434,NA,NA,NA,FALSE
-slu,2014,1854.9,10.1186/s13028-014-0061-3,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,25297979,PMC4194406,NA,NA,TRUE
-slu,2014,1901.53,10.1186/1756-3305-7-410,FALSE,BioMed Central,Parasites & Vectors,1756-3305,1756-3305,NA,NA,NA,TRUE,25175357,PMC4156605,NA,NA,TRUE
-slu,2014,1905.58,10.1111/1462-2920.12596,TRUE,Wiley,Environmental Microbiology,1462-2912,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25142400,NA,NA,NA,FALSE
-slu,2014,2137,10.1080/1081602X.2014.927783,TRUE,Taylor & Francis,The History of the Family,1081-602X,1081-602X,1873-5398,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,2171,10.1017/S0950268814002891,TRUE,Cambridge University Press (CUP),Epidemiology and Infection,0950-2688,0950-2688,1469-4409,NA,NA,TRUE,25373497,PMC4456771,NA,NA,FALSE
-slu,2014,2173,10.1111/rda.12346,TRUE,Wiley,Reproduction in Domestic Animals,0936-6768,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,24930481,PMC4286828,NA,NA,FALSE
-slu,2014,2183.29,10.1111/conl.12087,FALSE,Wiley,Conservation Letters,1755-263X,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,TRUE
-slu,2014,2183.29,10.1111/gcb.12527,TRUE,Wiley,Global Change Biology,1354-1013,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,24535943,PMC4257505,NA,NA,FALSE
-slu,2014,2187.66,10.1111/tbed.12234,TRUE,Wiley,Transboundary and Emerging Diseases,1865-1674,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,24828615,PMC4283756,NA,NA,FALSE
-slu,2014,2191.38,10.1016/j.jip.2014.11.003,TRUE,Elsevier,Journal of Invertebrate Pathology,0022-2011,0022-2011,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25446037,NA,NA,NA,FALSE
-slu,2014,2191.38,10.1016/j.ymben.2014.07.001,TRUE,Elsevier,Metabolic Engineering,1096-7176,1096-7176,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25038447,NA,NA,NA,FALSE
-slu,2014,2191.77,10.1002/sia.5661,TRUE,Wiley,Surface and Interface Analysis,0142-2421,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,2191.77,10.1111/rda.12393,TRUE,Wiley,Reproduction in Domestic Animals,0936-6768,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25244510,PMC4260169,NA,NA,FALSE
-slu,2014,2200,10.1007/s00294-014-0436-z,TRUE,Springer,Current Genetics,0172-8083,0172-8083,1432-0983,NA,NA,TRUE,25011705,PMC4201751,NA,NA,FALSE
-slu,2014,2200,10.1007/s00300-014-1499-5,TRUE,Springer,Polar Biology,0722-4060,0722-4060,1432-2056,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,2200,10.1007/s00382-014-2124-6,TRUE,Springer,Climate Dynamics,0930-7575,0930-7575,1432-0894,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,2200,10.1007/s00425-014-2184-1,TRUE,Springer,Planta,0032-0935,0032-0935,1432-2048,NA,NA,TRUE,25298156,PMC4302238,NA,NA,FALSE
-slu,2014,2200,10.1007/s00442-014-3080-x,TRUE,Springer,Oecologia,0029-8549,0029-8549,1432-1939,NA,NA,TRUE,25234375,PMC4226841,NA,NA,FALSE
-slu,2014,2200,10.1007/s10340-014-0616-0,TRUE,Springer,Journal of Pest Science,1612-4758,1612-4758,1612-4766,NA,NA,TRUE,26005402,PMC4435630,NA,NA,FALSE
-slu,2014,2200,10.1007/s10661-014-4054-5,TRUE,Springer,Environmental Monitoring and Assessment,0167-6369,0167-6369,1573-2959,NA,NA,TRUE,25260924,PMC4210647,NA,NA,FALSE
-slu,2014,2200,10.1007/s10681-014-1215-0,TRUE,Springer,Euphytica,0014-2336,0014-2336,1573-5060,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,2200,10.1007/s10806-014-9512-0,TRUE,Springer,Journal of Agricultural and Environmental Ethics,1187-7863,1187-7863,1573-322X,NA,NA,TRUE,NA,NA,NA,NA,FALSE
+slu,2014,1361,10.1186/1751-0147-55-33,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,0044-605X,NA,TRUE,23594682,PMC3640916,ut:000318478800003,NA,TRUE
+slu,2014,1385.87,10.1186/1471-2164-15-315,FALSE,BioMed Central,BMC Genomics,1471-2164,1471-2164,NA,1471-2164,NA,TRUE,24773703,PMC4234511,ut:000335409900001,NA,TRUE
+slu,2014,1385.87,10.1186/1471-2180-14-90,FALSE,BioMed Central,BMC Microbiology,1471-2180,1471-2180,NA,1471-2180,NA,TRUE,24725382,PMC3991884,ut:000335414700001,NA,TRUE
+slu,2014,1409,10.1186/1471-2164-14-893,FALSE,BioMed Central,BMC Genomics,1471-2164,1471-2164,NA,1471-2164,NA,TRUE,24341908,PMC3878592,ut:000329365900001,NA,TRUE
+slu,2014,1412.91,10.1186/s12870-014-0254-y,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,1471-2229,http://www.springer.com/tdm,TRUE,25270759,PMC4192290,ut:000342782300001,NA,TRUE
+slu,2014,1415,10.1186/1751-0147-55-83,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,0044-605X,NA,TRUE,24256697,PMC4176978,ut:000328953800001,NA,TRUE
+slu,2014,1432.48,10.1186/1471-2229-14-31,FALSE,BioMed Central,BMC Plant Biology,1471-2229,1471-2229,NA,1471-2229,NA,TRUE,24438179,PMC3945485,ut:000334471800001,NA,TRUE
+slu,2014,1433,10.1186/s12917-014-0273-9,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,NA,1746-6148,1746-6148,http://www.springer.com/tdm,TRUE,25430894,PMC4247870,ut:000347014200001,NA,TRUE
+slu,2014,1436,10.1186/1751-0147-56-7,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,0044-605X,NA,TRUE,24461167,PMC3922756,ut:000334367700001,NA,TRUE
+slu,2014,1452,10.1186/1751-0147-56-25,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,0044-605X,NA,TRUE,24758285,PMC4020358,ut:000335987500001,NA,TRUE
+slu,2014,1466,10.1186/s13028-014-0041-7,FALSE,Public Library of Science (PLoS),Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,25011553,PMC4226984,ut:000340951600001,NA,TRUE
+slu,2014,1475.92,10.1186/1756-3305-7-13,FALSE,BioMed Central,Parasites & Vectors,1756-3305,1756-3305,NA,1756-3305,NA,TRUE,24401545,PMC3892011,ut:000334634400001,NA,TRUE
+slu,2014,1478,10.1186/1751-0147-56-37,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,0044-605X,NA,TRUE,24910081,PMC4061533,ut:000338453400001,NA,TRUE
+slu,2014,1480,10.1111/eva.12229,FALSE,Wiley,Evolutionary Applications,1752-4571,NA,NA,1752-4571,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25553072,PMC4231600,ut:000344595700013,NA,TRUE
+slu,2014,1492.12,10.3390/molecules190914195,FALSE,MDPI,Molecules,1420-3049,NA,1420-3049,1420-3049,NA,TRUE,25207719,NA,ut:000343093100078,NA,TRUE
+slu,2014,1496.92,10.1186/s12866-014-0308-1,FALSE,BioMed Central,BMC Microbiology,1471-2180,NA,1471-2180,1471-2180,http://www.springer.com/tdm,TRUE,25492044,PMC4272539,ut:000347355900001,NA,TRUE
+slu,2014,1497.23,10.1186/s12870-014-0329-9,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,1471-2229,http://www.springer.com/tdm,TRUE,25476999,PMC4274702,ut:000346933900001,NA,TRUE
+slu,2014,1511,10.1186/s13028-014-0082-y,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,25510194,PMC4271328,ut:000346537100001,NA,TRUE
+slu,2014,1511.57,10.1186/s12870-014-0298-z,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,1471-2229,http://www.springer.com/tdm,TRUE,25365911,PMC4232680,ut:000346928600001,NA,TRUE
+slu,2014,1544,10.1186/s13028-014-0070-2,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,25366065,PMC4222379,ut:000344888700001,NA,TRUE
+slu,2014,1571,10.1186/s13028-014-0073-z,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,25359553,PMC4219133,ut:000346090000001,NA,TRUE
+slu,2014,1600,10.3389/fevo.2014.00065,FALSE,Frontiers,Frontiers in Ecology and Evolution,2296-701X,NA,2296-701X,2296-701X,NA,TRUE,NA,NA,NA,NA,TRUE
+slu,2014,1608,10.1186/s13028-014-0069-8,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,25288196,PMC4192735,ut:000342776800001,NA,TRUE
+slu,2014,1630.04,10.1111/1365-2664.12289,TRUE,Wiley,Journal of Applied Ecology,0021-8901,NA,NA,0021-8901,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25552747,PMC4277688,ut:000345706100022,NA,FALSE
+slu,2014,1633,10.1186/1471-2229-14-104,FALSE,BioMed Central,BMC Plant Biology,1471-2229,1471-2229,NA,1471-2229,NA,TRUE,24758347,PMC4108048,ut:000335992000001,NA,TRUE
+slu,2014,1637.47,10.1111/1365-2664.12219,TRUE,Wiley,Journal of Applied Ecology,0021-8901,NA,NA,0021-8901,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25653457,PMC4299503,ut:000335962200021,NA,FALSE
+slu,2014,1766.98,10.1186/s12870-014-0220-8,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,1471-2229,http://www.springer.com/tdm,TRUE,25143005,PMC4160553,ut:000341527400001,NA,TRUE
+slu,2014,1790.54,10.1371/journal.pgen.1004842,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,1553-7390,http://creativecommons.org/licenses/by/4.0/,TRUE,25503602,PMC4263395,ut:000346649900043,NA,TRUE
+slu,2014,1796,10.1186/s12917-014-0228-1,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,NA,1746-6148,1746-6148,http://www.springer.com/tdm,TRUE,25293656,PMC4195903,ut:000346805200001,NA,TRUE
+slu,2014,1814,10.1186/s13028-014-0091-x,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,0044-605X,NA,TRUE,25582919,PMC4300160,ut:000347992600001,NA,TRUE
+slu,2014,1826.15,10.1016/j.chemosphere.2014.07.009,TRUE,Elsevier,Chemosphere,0045-6535,0045-6535,NA,0045-6535,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25103085,NA,ut:000348003200033,NA,FALSE
+slu,2014,1840.13,10.1016/j.forpol.2013.12.007,TRUE,Elsevier,Forest Policy and Economics,1389-9341,1389-9341,NA,1389-9341,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000333854600005,NA,FALSE
+slu,2014,1843.22,10.1105/tpc.114.130120,TRUE,American Society of Plant Biologists (ASPB),The Plant Cell,1040-4651,1040-4651,1532-298X,1040-4651,NA,TRUE,25217506,NA,ut:000345919700009,NA,FALSE
+slu,2014,1843.22,10.1105/tpc.114.130120,TRUE,American Society of Plant Biologists,NA,NA,NA,NA,NA,NA,FALSE,NA,NA,ut:000345919700009,NA,NA
+slu,2014,1851.17,10.1016/j.scitotenv.2014.05.123,TRUE,Elsevier,Science of The Total Environment,0048-9697,0048-9697,NA,0048-9697,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,24946033,NA,ut:000340312000023,NA,FALSE
+slu,2014,1851.18,10.1016/j.theriogenology.2014.02.014,TRUE,Elsevier,Theriogenology,0093-691X,0093-691X,NA,0093-691X,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,24661434,NA,ut:000337006100006,NA,FALSE
+slu,2014,1854.9,10.1186/s13028-014-0061-3,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,25297979,PMC4194406,ut:000342776500001,NA,TRUE
+slu,2014,1901.53,10.1186/1756-3305-7-410,FALSE,BioMed Central,Parasites & Vectors,1756-3305,1756-3305,NA,1756-3305,NA,TRUE,25175357,PMC4156605,ut:000341205100001,NA,TRUE
+slu,2014,1905.58,10.1111/1462-2920.12596,TRUE,Wiley,Environmental Microbiology,1462-2912,NA,NA,1462-2912,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25142400,NA,ut:000350546200016,NA,FALSE
+slu,2014,2137,10.1080/1081602X.2014.927783,TRUE,Taylor & Francis,The History of the Family,1081-602X,1081-602X,1873-5398,1081-602X,NA,TRUE,NA,NA,ut:000341642500009,NA,FALSE
+slu,2014,2171,10.1017/S0950268814002891,TRUE,Cambridge University Press (CUP),Epidemiology and Infection,0950-2688,0950-2688,1469-4409,0950-2688,NA,TRUE,25373497,PMC4456771,ut:000355760600015,NA,FALSE
+slu,2014,2173,10.1111/rda.12346,TRUE,Wiley,Reproduction in Domestic Animals,0936-6768,NA,NA,0936-6768,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,24930481,PMC4286828,ut:000339561900023,NA,FALSE
+slu,2014,2183.29,10.1111/conl.12087,FALSE,Wiley,Conservation Letters,1755-263X,NA,NA,1755-263X,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000350544200006,NA,TRUE
+slu,2014,2183.29,10.1111/gcb.12527,TRUE,Wiley,Global Change Biology,1354-1013,NA,NA,1354-1013,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,24535943,PMC4257505,ut:000340287300007,NA,FALSE
+slu,2014,2187.66,10.1111/tbed.12234,TRUE,Wiley,Transboundary and Emerging Diseases,1865-1674,NA,NA,1865-1674,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,24828615,PMC4283756,ut:000339094700001,NA,FALSE
+slu,2014,2191.38,10.1016/j.jip.2014.11.003,TRUE,Elsevier,Journal of Invertebrate Pathology,0022-2011,0022-2011,NA,0022-2011,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25446037,NA,ut:000348250600013,NA,FALSE
+slu,2014,2191.38,10.1016/j.ymben.2014.07.001,TRUE,Elsevier,Metabolic Engineering,1096-7176,1096-7176,NA,1096-7176,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25038447,NA,ut:000341312200011,NA,FALSE
+slu,2014,2191.77,10.1002/sia.5661,TRUE,Wiley,Surface and Interface Analysis,0142-2421,NA,NA,0142-2421,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000345696200056,NA,FALSE
+slu,2014,2191.77,10.1111/rda.12393,TRUE,Wiley,Reproduction in Domestic Animals,0936-6768,NA,NA,0936-6768,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25244510,PMC4260169,ut:000345305900007,NA,FALSE
+slu,2014,2200,10.1007/s00294-014-0436-z,TRUE,Springer,Current Genetics,0172-8083,0172-8083,1432-0983,0172-8083,NA,TRUE,25011705,PMC4201751,ut:000344061200008,NA,FALSE
+slu,2014,2200,10.1007/s00300-014-1499-5,TRUE,Springer,Polar Biology,0722-4060,0722-4060,1432-2056,0722-4060,NA,TRUE,NA,NA,ut:000338278300010,NA,FALSE
+slu,2014,2200,10.1007/s00382-014-2124-6,TRUE,Springer,Climate Dynamics,0930-7575,0930-7575,1432-0894,0930-7575,NA,TRUE,NA,NA,ut:000336983900004,NA,FALSE
+slu,2014,2200,10.1007/s00425-014-2184-1,TRUE,Springer,Planta,0032-0935,0032-0935,1432-2048,0032-0935,NA,TRUE,25298156,PMC4302238,ut:000348309800005,NA,FALSE
+slu,2014,2200,10.1007/s00442-014-3080-x,TRUE,Springer,Oecologia,0029-8549,0029-8549,1432-1939,0029-8549,NA,TRUE,25234375,PMC4226841,ut:000345146700007,NA,FALSE
+slu,2014,2200,10.1007/s10340-014-0616-0,TRUE,Springer,Journal of Pest Science,1612-4758,1612-4758,1612-4766,1612-4758,NA,TRUE,26005402,PMC4435630,ut:000354621500009,NA,FALSE
+slu,2014,2200,10.1007/s10661-014-4054-5,TRUE,Springer,Environmental Monitoring and Assessment,0167-6369,0167-6369,1573-2959,0167-6369,NA,TRUE,25260924,PMC4210647,ut:000344349200063,NA,FALSE
+slu,2014,2200,10.1007/s10681-014-1215-0,TRUE,Springer,Euphytica,0014-2336,0014-2336,1573-5060,0014-2336,NA,TRUE,NA,NA,ut:000346775500004,NA,FALSE
+slu,2014,2200,10.1007/s10806-014-9512-0,TRUE,Springer,Journal of Agricultural and Environmental Ethics,1187-7863,1187-7863,1573-322X,1187-7863,NA,TRUE,NA,NA,ut:000345641600007,NA,FALSE
 slu,2014,2200,10.1007/s10818-014-9183-yc,TRUE,Springer,NA,NA,NA,NA,NA,NA,FALSE,NA,NA,NA,NA,NA
-slu,2014,2200,10.1007/s11104-014-2091-z,TRUE,Springer,Plant and Soil,0032-079X,0032-079X,1573-5036,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,2200,10.1007/s11250-013-0534-9,TRUE,Springer,Tropical Animal Health and Production,0049-4747,0049-4747,1573-7438,NA,NA,TRUE,24414248,PMC3936117,NA,NA,FALSE
-slu,2014,2200,10.1007/s11829-014-9303-6,TRUE,Springer,Arthropod-Plant Interactions,1872-8855,1872-8855,1872-8847,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,2200,10.1007/s13592-014-0320-3,TRUE,Springer,Apidologie,0044-8435,0044-8435,1297-9678,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,2200,10.1007/s13593-014-0235-4,TRUE,Springer,Agronomy for Sustainable Development,1774-0746,1774-0746,1773-0155,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,223.93,10.3390/plants3040513,FALSE,MDPI,Plants,2223-7747,NA,2223-7747,NA,NA,TRUE,27135517,PMC4844284,NA,NA,TRUE
-slu,2014,223.94,10.3390/agronomy4040470,FALSE,MDPI,Agronomy,2073-4395,NA,2073-4395,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2014,2284.58,10.1111/ppa.12306,TRUE,Wiley,Plant Pathology,0032-0862,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,2322.65,10.3168/jds.2014-7929,TRUE,Elsevier,Journal of Dairy Science,0022-0302,0022-0302,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,24996274,NA,NA,NA,FALSE
-slu,2014,2378.34,10.1111/jzs.12063,TRUE,Wiley,Journal of Zoological Systematics and Evolutionary Research,0947-5745,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,2383,10.1080/21513732.2014.968805,TRUE,Taylor & Francis,"International Journal of Biodiversity Science, Ecosystem Services & Management",2151-3732,2151-3732,2151-3740,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,2387.39,10.1111/evj.12385,TRUE,Wiley,Equine Veterinary Journal,0425-1644,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25399722,PMC4964936,NA,NA,FALSE
-slu,2014,2394.06,10.1016/j.funeco.2014.12.003,TRUE,Elsevier,Fungal Ecology,1754-5048,1754-5048,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,2400,10.1038/hdy.2014.125,TRUE,Nature Publishing Group,Heredity,0018-067X,0018-067X,1365-2540,NA,NA,TRUE,25649501,PMC4434249,NA,NA,FALSE
-slu,2014,2412.58,10.1111/ejss.12228,TRUE,Wiley,European Journal of Soil Science,1351-0754,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,2428.97,10.1016/j.foreco.2014.01.020,TRUE,Elsevier,Forest Ecology and Management,0378-1127,0378-1127,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,2436.88,10.1089/fpd.2014.1863,TRUE,Mary Ann Liebert,Foodborne Pathogens and Disease,1535-3141,1535-3141,1556-7125,NA,NA,TRUE,25562377,NA,NA,NA,FALSE
-slu,2014,253.87,10.1371/journal.pone.0096086,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,24811199,PMC4014485,NA,NA,TRUE
-slu,2014,2538.74,10.1002/2013GB004770,TRUE,Wiley,Global Biogeochemical Cycles,0886-6236,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,2538.74,10.1002/2013WR015197,TRUE,Wiley,Water Resources Research,0043-1397,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25641996,PMC4302979,NA,NA,FALSE
-slu,2014,2618,10.1007/s12571-014-0331-y,TRUE,Springer,Food Security,1876-4517,1876-4517,1876-4525,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,2730,10.1093/icesjms/fsu230,TRUE,Oxford University Press (OUP),ICES Journal of Marine Science,1054-3139,1054-3139,1095-9289,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,410.89,10.3390/f5030535,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2014,410.89,10.3390/f5040557,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2014,575,10.3389/fpls.2014.00286,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,NA,NA,TRUE,24999347,PMC4064663,NA,NA,TRUE
-slu,2014,591.69,10.3390/f5092106,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2014,592.89,10.3390/d6030500,FALSE,MDPI,Diversity,1424-2818,NA,1424-2818,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2014,592.89,10.3390/f5081931,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2014,597.14,10.3390/f5122967,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2014,598.41,10.3390/f6010047,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2014,646,10.15226/2374-815X/1/4/00121,FALSE,Symbiosis,"Journal of Gastroenterology, Pancreatology & Liver Disorders",2374-815X,NA,2374-815X,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,657.44,10.3390/f5082037,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2014,696,10.5194/hessd-11-3787-2014,FALSE,Copernicus Publications,Hydrology and Earth System Sciences Discussions,1812-2116,NA,1812-2116,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,NA,TRUE
-slu,2014,729.39,10.1186/1756-0500-6-464,FALSE,BioMed Central,BMC Research Notes,1756-0500,1756-0500,NA,NA,NA,TRUE,24229396,PMC3835548,NA,NA,TRUE
-slu,2014,730.59,10.1021/ic4023486,TRUE,American Chemical Society (ACS),Inorganic Chemistry,0020-1669,0020-1669,1520-510X,NA,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,24392745,PMC3905692,NA,NA,FALSE
-slu,2014,739.6,10.3390/rs6032084,FALSE,MDPI,Remote Sensing,2072-4292,NA,2072-4292,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2014,783,10.5194/hess-18-3623-2014,FALSE,Copernicus Publications,Hydrology and Earth System Sciences,1607-7938,NA,1607-7938,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,NA,TRUE
-slu,2014,789.65,10.5751/ES-06750-190315,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,NA,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2014,803.51,10.1016/j.foodpol.2014.10.012,TRUE,Elsevier,Food Policy,0306-9192,0306-9192,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2014,852,10.5751/ES-06665-190407,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,NA,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2014,960,10.3389/fpls.2014.00077,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,NA,NA,TRUE,24639681,PMC3945484,NA,NA,TRUE
-slu,2014,960,10.3389/fpls.2014.00373,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,NA,NA,TRUE,25126092,PMC4115670,NA,NA,TRUE
-slu,2014,978.03,10.1371/journal.pone.0099998,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,24926792,PMC4057421,NA,NA,TRUE
-slu,2014,982.48,10.1371/journal.pone.0088187,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,24505423,PMC3913773,NA,NA,TRUE
-slu,2014,982.48,10.1371/journal.pone.0088758,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,24586385,PMC3930587,NA,NA,TRUE
-slu,2014,982.48,10.1371/journal.pone.0089311,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,24586680,PMC3930735,NA,NA,TRUE
-slu,2014,982.48,10.1371/journal.pone.0089643,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,24586930,PMC3933640,NA,NA,TRUE
-slu,2014,983.49,10.3390/rs6054323,FALSE,MDPI,Remote Sensing,2072-4292,NA,2072-4292,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2014,984.45,10.1371/journal.pone.0093957,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,24747938,PMC3991569,NA,NA,TRUE
-slu,2014,984.45,10.1371/journal.pone.0094750,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,24722396,PMC3983253,NA,NA,TRUE
-slu,2014,984.45,10.1371/journal.pone.0095078,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,24999627,PMC4085034,NA,NA,TRUE
-slu,2014,986.3,10.1371/journal.pone.0104651,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25119988,PMC4138018,NA,NA,TRUE
-slu,2014,991,10.1371/journal.pone.0100392,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,24945377,PMC4063758,NA,NA,TRUE
-slu,2014,991.66,10.1371/journal.pone.0101049,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25036209,PMC4103950,NA,NA,TRUE
-slu,2014,995.9,10.1371/journal.pone.0091881,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,https://creativecommons.org/publicdomain/zero/1.0/,TRUE,24618720,PMC3950282,NA,NA,TRUE
-slu,2014,995.9,10.1371/journal.pone.0092107,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,24637949,PMC3956879,NA,NA,TRUE
-slu,2014,995.9,10.1371/journal.pone.0092278,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,24699501,PMC3974706,NA,NA,TRUE
-slu,2014,995.9,10.1371/journal.pone.0092453,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,24637926,PMC3956935,NA,NA,TRUE
-slu,2014,995.9,10.1371/journal.pone.0092897,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,24651625,PMC3961408,NA,NA,TRUE
-slu,2015,1034.45,10.3390/rs70404233,FALSE,MDPI,Remote Sensing,2072-4292,NA,2072-4292,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,1108.28,10.1371/journal.pone.0118455,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25714432,PMC4340961,NA,NA,TRUE
-slu,2015,1110,10.5194/bg-13-399-2016,FALSE,Copernicus Publications,Biogeosciences,1726-4189,NA,1726-4189,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,1130,10.14814/phy2.12355,FALSE,Wiley,Physiological Reports,2051-817X,NA,2051-817X,NA,NA,TRUE,25847917,PMC4425961,NA,NA,TRUE
-slu,2015,1160.76,10.3390/su7067512,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,1160.76,10.3390/su7078598,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,1190.01,10.1371/journal.pone.0118896,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25756871,PMC4355491,NA,NA,TRUE
-slu,2015,1190.01,10.1371/journal.pone.0119957,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25853570,PMC4390345,NA,NA,TRUE
-slu,2015,1190.01,10.1371/journal.pone.0120570,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25806949,PMC4373782,NA,NA,TRUE
-slu,2015,1190.01,10.1371/journal.pone.0121237,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25811859,PMC4374699,NA,NA,TRUE
-slu,2015,1190.01,10.1371/journal.pone.0122241,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25826373,PMC4380355,NA,NA,TRUE
-slu,2015,1197.39,10.3390/ijerph120201928,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,NA,NA,TRUE,25671775,PMC4344702,NA,NA,TRUE
-slu,2015,1200,10.1002/iid3.95,FALSE,Wiley,"Immunity, Inflammation and Disease",2050-4527,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27042303,PMC4768062,NA,NA,TRUE
-slu,2015,1204.09,10.1371/journal.pone.0122194,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25822750,PMC4379071,NA,NA,TRUE
-slu,2015,1204.09,10.1371/journal.pone.0122492,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25815509,PMC4376685,NA,NA,TRUE
-slu,2015,1204.09,10.1371/journal.pone.0122875,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25923329,PMC4414519,NA,NA,TRUE
-slu,2015,1204.09,10.1371/journal.pone.0123173,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25970163,PMC4430432,NA,NA,TRUE
-slu,2015,1207.33,10.3390/v7072789,FALSE,MDPI,Viruses,1999-4915,NA,1999-4915,NA,NA,TRUE,26154017,PMC4517118,NA,NA,TRUE
-slu,2015,1211.75,10.1371/journal.pone.0129614,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26046538,PMC4457531,NA,NA,TRUE
-slu,2015,1211.75,10.1371/journal.pone.0129815,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26053171,PMC4459979,NA,NA,TRUE
-slu,2015,1222,10.1111/jvim.13584,FALSE,Wiley,Journal of Veterinary Internal Medicine,0891-6640,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26179258,PMC4858030,NA,NA,FALSE
-slu,2015,1224,10.1002/ece3.1866,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26865966,PMC4739569,NA,NA,TRUE
-slu,2015,1224,10.1002/ece3.1923,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26839685,PMC4725332,NA,NA,TRUE
-slu,2015,1231,10.1021/acs.est.5b03146,TRUE,American Chemical Society (ACS),Environmental Science & Technology,0013-936X,0013-936X,1520-5851,NA,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,26450629,NA,NA,NA,FALSE
-slu,2015,1234.89,10.1371/journal.pone.0136928,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26313444,PMC4552548,NA,NA,TRUE
-slu,2015,1234.89,10.1371/journal.pone.0137871,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26366881,PMC4569288,NA,NA,TRUE
-slu,2015,1236.45,10.1371/journal.pone.0131182,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26151363,PMC4495060,NA,NA,TRUE
-slu,2015,1253.08,10.1371/journal.pone.0142257,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26554587,PMC4640599,NA,NA,TRUE
-slu,2015,1255.88,10.1371/journal.pone.0125139,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25933113,PMC4416813,NA,NA,TRUE
-slu,2015,1255.88,10.1371/journal.pone.0126021,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,25933435,PMC4416768,NA,NA,TRUE
-slu,2015,1260.75,10.3389/fmicb.2015.01033,FALSE,Frontiers,Frontiers in Microbiology,1664-302X,NA,1664-302X,NA,NA,TRUE,26441951,PMC4585013,NA,NA,TRUE
-slu,2015,1279.07,10.3389/fpls.2015.00368,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,NA,NA,TRUE,26074934,PMC4448002,NA,NA,TRUE
-slu,2015,1282.61,10.3389/fpls.2015.00634,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,NA,NA,TRUE,26322071,PMC4532917,NA,NA,TRUE
-slu,2015,1303.49,10.3389/fpls.2015.00718,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,NA,NA,TRUE,26442032,PMC4585127,NA,NA,TRUE
-slu,2015,1322.24,10.1073/pnas.1423440112,TRUE,National Academy of Sciences,Proceedings of the National Academy of Sciences,0027-8424,0027-8424,1091-6490,NA,http://www.pnas.org/site/misc/userlicense.xhtml,TRUE,25713384,PMC4364234,NA,NA,FALSE
-slu,2015,1325.65,10.3389/fmicb.2015.00387,FALSE,Frontiers,Frontiers in Microbiology,1664-302X,NA,1664-302X,NA,NA,TRUE,26052312,PMC4439574,NA,NA,TRUE
-slu,2015,1325.65,10.3389/fpls.2015.00270,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,NA,NA,TRUE,25954295,PMC4406003,NA,NA,TRUE
-slu,2015,1328.85,10.1016/j.ufug.2015.06.002,TRUE,Elsevier,Urban Forestry & Urban Greening,1618-8667,1618-8667,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,1345.94,10.3389/fevo.2015.00151,FALSE,Frontiers,Frontiers in Ecology and Evolution,2296-701X,NA,2296-701X,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,1362.44,10.1186/1756-3305-7-419,FALSE,BioMed Central,Parasites & Vectors,1756-3305,1756-3305,NA,NA,NA,TRUE,25189316,PMC4261757,NA,NA,TRUE
-slu,2015,1375,10.1111/conl.12171,FALSE,Wiley,Conservation Letters,1755-263X,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,1375,10.1111/conl.12200,FALSE,Wiley,Conservation Letters,1755-263X,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,1379.26,10.3390/ijms16048997,FALSE,MDPI,International Journal of Molecular Sciences,1422-0067,NA,1422-0067,NA,NA,TRUE,25913379,PMC4425120,NA,NA,TRUE
-slu,2015,1380,10.5194/bgd-12-15763-2015,FALSE,Copernicus Publications,Biogeosciences Discussions,1810-6285,NA,1810-6285,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,1392.91,10.3390/ijerph120707274,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,NA,NA,TRUE,26132480,PMC4515656,NA,NA,TRUE
-slu,2015,1408.28,10.1186/s13071-015-0635-6,FALSE,BioMed Central,Parasites & Vectors,1756-3305,1756-3305,NA,NA,NA,TRUE,25604581,PMC4307889,NA,NA,TRUE
-slu,2015,1423,10.1186/s12917-015-0389-6,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,NA,1746-6148,NA,NA,TRUE,25890239,PMC4377052,NA,NA,TRUE
-slu,2015,1437.29,10.3390/ijerph120707974,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,NA,NA,TRUE,26184268,PMC4515704,NA,NA,TRUE
-slu,2015,1467.37,10.3390/ijerph121114068,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,NA,NA,TRUE,26540066,PMC4661633,NA,NA,TRUE
-slu,2015,1523.02,10.3390/molecules20045729,FALSE,MDPI,Molecules,1420-3049,NA,1420-3049,NA,NA,TRUE,25834986,NA,NA,NA,TRUE
-slu,2015,1530,10.1002/ece3.1527,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26257881,PMC4523364,NA,NA,TRUE
-slu,2015,1534.33,10.1186/s13028-014-0079-6,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,25512143,PMC4271407,NA,NA,TRUE
-slu,2015,1552,10.1186/s12889-015-1811-5,FALSE,BioMed Central,BMC Public Health,1471-2458,NA,1471-2458,NA,http://www.springer.com/tdm,TRUE,25952633,PMC4427931,NA,NA,TRUE
-slu,2015,1559.93,10.1186/s40462-015-0036-7,FALSE,BioMed Central,Movement Ecology,2051-3933,NA,2051-3933,NA,NA,TRUE,25941571,PMC4418104,NA,NA,TRUE
-slu,2015,1569.08,10.1016/j.ijpddr.2015.07.003,FALSE,Elsevier,International Journal for Parasitology: Drugs and Drug Resistance,2211-3207,2211-3207,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26448903,PMC4572398,NA,NA,TRUE
-slu,2015,1591,10.1186/s12917-015-0487-5,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,NA,1746-6148,NA,NA,TRUE,26209243,PMC4514937,NA,NA,TRUE
-slu,2015,1615.5,10.1186/s12870-015-0676-1,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,NA,NA,TRUE,26654722,PMC4676809,NA,NA,TRUE
+slu,2014,2200,10.1007/s11104-014-2091-z,TRUE,Springer,Plant and Soil,0032-079X,0032-079X,1573-5036,0032-079X,NA,TRUE,NA,NA,ut:000339345400005,NA,FALSE
+slu,2014,2200,10.1007/s11250-013-0534-9,TRUE,Springer,Tropical Animal Health and Production,0049-4747,0049-4747,1573-7438,0049-4747,NA,TRUE,24414248,PMC3936117,ut:000332985100012,NA,FALSE
+slu,2014,2200,10.1007/s11829-014-9303-6,TRUE,Springer,Arthropod-Plant Interactions,1872-8855,1872-8855,1872-8847,1872-8847,NA,TRUE,NA,NA,ut:000335920900001,NA,FALSE
+slu,2014,2200,10.1007/s13592-014-0320-3,TRUE,Springer,Apidologie,0044-8435,0044-8435,1297-9678,0044-8435,NA,TRUE,NA,NA,ut:000354134900001,NA,FALSE
+slu,2014,2200,10.1007/s13593-014-0235-4,TRUE,Springer,Agronomy for Sustainable Development,1774-0746,1774-0746,1773-0155,1773-0155,NA,TRUE,NA,NA,ut:000348065500021,NA,FALSE
+slu,2014,223.93,10.3390/plants3040513,FALSE,MDPI,Plants,2223-7747,NA,2223-7747,2223-7747,NA,TRUE,27135517,PMC4844284,NA,NA,TRUE
+slu,2014,223.94,10.3390/agronomy4040470,FALSE,MDPI,Agronomy,2073-4395,NA,2073-4395,2073-4395,NA,TRUE,NA,NA,NA,NA,TRUE
+slu,2014,2284.58,10.1111/ppa.12306,TRUE,Wiley,Plant Pathology,0032-0862,NA,NA,0032-0862,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000354275700012,NA,FALSE
+slu,2014,2322.65,10.3168/jds.2014-7929,TRUE,Elsevier,Journal of Dairy Science,0022-0302,0022-0302,NA,0022-0302,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,24996274,NA,ut:000340580400044,NA,FALSE
+slu,2014,2378.34,10.1111/jzs.12063,TRUE,Wiley,Journal of Zoological Systematics and Evolutionary Research,0947-5745,NA,NA,0947-5745,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000342841700003,NA,FALSE
+slu,2014,2383,10.1080/21513732.2014.968805,TRUE,Taylor & Francis,"International Journal of Biodiversity Science, Ecosystem Services & Management",2151-3732,2151-3732,2151-3740,2151-3732,NA,TRUE,NA,NA,NA,NA,FALSE
+slu,2014,2387.39,10.1111/evj.12385,TRUE,Wiley,Equine Veterinary Journal,0425-1644,NA,NA,0425-1644,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25399722,PMC4964936,ut:000366514900015,NA,FALSE
+slu,2014,2394.06,10.1016/j.funeco.2014.12.003,TRUE,Elsevier,Fungal Ecology,1754-5048,1754-5048,NA,1878-0083,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000350936300015,NA,FALSE
+slu,2014,2400,10.1038/hdy.2014.125,TRUE,Nature Publishing Group,Heredity,0018-067X,0018-067X,1365-2540,0018-067X,NA,TRUE,25649501,PMC4434249,ut:000354386700006,NA,FALSE
+slu,2014,2412.58,10.1111/ejss.12228,TRUE,Wiley,European Journal of Soil Science,1351-0754,NA,NA,1351-0754,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000357341900002,NA,FALSE
+slu,2014,2428.97,10.1016/j.foreco.2014.01.020,TRUE,Elsevier,Forest Ecology and Management,0378-1127,0378-1127,NA,0378-1127,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000334082900019,NA,FALSE
+slu,2014,2436.88,10.1089/fpd.2014.1863,TRUE,Mary Ann Liebert,Foodborne Pathogens and Disease,1535-3141,1535-3141,1556-7125,1535-3141,NA,TRUE,25562377,NA,ut:000352302500002,NA,FALSE
+slu,2014,253.87,10.1371/journal.pone.0096086,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,24811199,PMC4014485,ut:000338213300019,NA,TRUE
+slu,2014,2538.74,10.1002/2013GB004770,TRUE,Wiley,Global Biogeochemical Cycles,0886-6236,NA,NA,0886-6236,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000335809500009,NA,FALSE
+slu,2014,2538.74,10.1002/2013WR015197,TRUE,Wiley,Water Resources Research,0043-1397,NA,NA,0043-1397,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25641996,PMC4302979,ut:000336026000033,NA,FALSE
+slu,2014,2618,10.1007/s12571-014-0331-y,TRUE,Springer,Food Security,1876-4517,1876-4517,1876-4525,1876-4517,NA,TRUE,NA,NA,ut:000334525500005,NA,FALSE
+slu,2014,2730,10.1093/icesjms/fsu230,TRUE,Oxford University Press (OUP),ICES Journal of Marine Science,1054-3139,1054-3139,1095-9289,1054-3139,NA,TRUE,NA,NA,ut:000356233800027,NA,FALSE
+slu,2014,410.89,10.3390/f5030535,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000333403600010,NA,TRUE
+slu,2014,410.89,10.3390/f5040557,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000336905000001,NA,TRUE
+slu,2014,575,10.3389/fpls.2014.00286,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,1664-462X,NA,TRUE,24999347,PMC4064663,ut:000339440700001,NA,TRUE
+slu,2014,591.69,10.3390/f5092106,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000343110700003,NA,TRUE
+slu,2014,592.89,10.3390/d6030500,FALSE,MDPI,Diversity,1424-2818,NA,1424-2818,1424-2818,NA,TRUE,NA,NA,NA,NA,TRUE
+slu,2014,592.89,10.3390/f5081931,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000341099200007,NA,TRUE
+slu,2014,597.14,10.3390/f5122967,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000346798100002,NA,TRUE
+slu,2014,598.41,10.3390/f6010047,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000348403700003,NA,TRUE
+slu,2014,646,10.15226/2374-815X/1/4/00121,FALSE,Symbiosis,"Journal of Gastroenterology, Pancreatology & Liver Disorders",2374-815X,NA,2374-815X,2374-815X,NA,TRUE,NA,NA,NA,NA,FALSE
+slu,2014,657.44,10.3390/f5082037,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000341099200013,NA,TRUE
+slu,2014,696,10.5194/hessd-11-3787-2014,FALSE,Copernicus Publications,Hydrology and Earth System Sciences Discussions,1812-2116,NA,1812-2116,1812-2116,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,NA,TRUE
+slu,2014,729.39,10.1186/1756-0500-6-464,FALSE,BioMed Central,BMC Research Notes,1756-0500,1756-0500,NA,1756-0500,NA,TRUE,24229396,PMC3835548,NA,NA,TRUE
+slu,2014,730.59,10.1021/ic4023486,TRUE,American Chemical Society (ACS),Inorganic Chemistry,0020-1669,0020-1669,1520-510X,0020-1669,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,24392745,PMC3905692,ut:000330204000042,NA,FALSE
+slu,2014,739.6,10.3390/rs6032084,FALSE,MDPI,Remote Sensing,2072-4292,NA,2072-4292,2072-4292,NA,TRUE,NA,NA,ut:000334797000017,NA,TRUE
+slu,2014,783,10.5194/hess-18-3623-2014,FALSE,Copernicus Publications,Hydrology and Earth System Sciences,1607-7938,NA,1607-7938,1027-5606,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000343118500018,NA,TRUE
+slu,2014,789.65,10.5751/ES-06750-190315,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,NA,1708-3087,NA,TRUE,NA,NA,ut:000343247200036,NA,TRUE
+slu,2014,803.51,10.1016/j.foodpol.2014.10.012,TRUE,Elsevier,Food Policy,0306-9192,0306-9192,NA,0306-9192,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000348748600004,NA,FALSE
+slu,2014,852,10.5751/ES-06665-190407,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,NA,1708-3087,NA,TRUE,NA,NA,ut:000347440700004,NA,TRUE
+slu,2014,960,10.3389/fpls.2014.00077,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,1664-462X,NA,TRUE,24639681,PMC3945484,ut:000332335400001,NA,TRUE
+slu,2014,960,10.3389/fpls.2014.00373,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,1664-462X,NA,TRUE,25126092,PMC4115670,ut:000342042800001,NA,TRUE
+slu,2014,978.03,10.1371/journal.pone.0099998,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,24926792,PMC4057421,ut:000338278100105,NA,TRUE
+slu,2014,982.48,10.1371/journal.pone.0088187,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,24505423,PMC3913773,ut:000336971300069,NA,TRUE
+slu,2014,982.48,10.1371/journal.pone.0088758,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,24586385,PMC3930587,ut:000331714700029,NA,TRUE
+slu,2014,982.48,10.1371/journal.pone.0089311,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,24586680,PMC3930735,ut:000331714700099,NA,TRUE
+slu,2014,982.48,10.1371/journal.pone.0089643,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,24586930,PMC3933640,ut:000331880700067,NA,TRUE
+slu,2014,983.49,10.3390/rs6054323,FALSE,MDPI,Remote Sensing,2072-4292,NA,2072-4292,2072-4292,NA,TRUE,NA,NA,ut:000337160700038,NA,TRUE
+slu,2014,984.45,10.1371/journal.pone.0093957,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,24747938,PMC3991569,ut:000335226500017,NA,TRUE
+slu,2014,984.45,10.1371/journal.pone.0094750,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,24722396,PMC3983253,ut:000336909100129,NA,TRUE
+slu,2014,984.45,10.1371/journal.pone.0095078,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,24999627,PMC4085034,ut:000338637300001,NA,TRUE
+slu,2014,986.3,10.1371/journal.pone.0104651,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25119988,PMC4138018,ut:000340900600074,NA,TRUE
+slu,2014,991,10.1371/journal.pone.0100392,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,24945377,PMC4063758,ut:000340721500069,NA,TRUE
+slu,2014,991.66,10.1371/journal.pone.0101049,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25036209,PMC4103950,ut:000339615200012,NA,TRUE
+slu,2014,995.9,10.1371/journal.pone.0091881,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,https://creativecommons.org/publicdomain/zero/1.0/,TRUE,24618720,PMC3950282,ut:000332842400139,NA,TRUE
+slu,2014,995.9,10.1371/journal.pone.0092107,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,24637949,PMC3956879,ut:000333254100112,NA,TRUE
+slu,2014,995.9,10.1371/journal.pone.0092278,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,24699501,PMC3974706,ut:000334105000021,NA,TRUE
+slu,2014,995.9,10.1371/journal.pone.0092453,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,24637926,PMC3956935,ut:000333254100149,NA,TRUE
+slu,2014,995.9,10.1371/journal.pone.0092897,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,24651625,PMC3961408,ut:000333352800162,NA,TRUE
+slu,2015,1034.45,10.3390/rs70404233,FALSE,MDPI,Remote Sensing,2072-4292,NA,2072-4292,2072-4292,NA,TRUE,NA,NA,ut:000354789300038,NA,TRUE
+slu,2015,1108.28,10.1371/journal.pone.0118455,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25714432,PMC4340961,ut:000350168700074,NA,TRUE
+slu,2015,1110,10.5194/bg-13-399-2016,FALSE,Copernicus Publications,Biogeosciences,1726-4189,NA,1726-4189,1726-4170,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000369524500004,NA,TRUE
+slu,2015,1130,10.14814/phy2.12355,FALSE,Wiley,Physiological Reports,2051-817X,NA,2051-817X,2051-817X,NA,TRUE,25847917,PMC4425961,ut:000214746200015,NA,TRUE
+slu,2015,1160.76,10.3390/su7067512,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,2071-1050,NA,TRUE,NA,NA,ut:000357593000056,NA,TRUE
+slu,2015,1160.76,10.3390/su7078598,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,2071-1050,NA,TRUE,NA,NA,ut:000360354500027,NA,TRUE
+slu,2015,1190.01,10.1371/journal.pone.0118896,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25756871,PMC4355491,ut:000351275700030,NA,TRUE
+slu,2015,1190.01,10.1371/journal.pone.0119957,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25853570,PMC4390345,ut:000352478400007,NA,TRUE
+slu,2015,1190.01,10.1371/journal.pone.0120570,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25806949,PMC4373782,ut:000351880000085,NA,TRUE
+slu,2015,1190.01,10.1371/journal.pone.0121237,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25811859,PMC4374699,ut:000356353700087,NA,TRUE
+slu,2015,1190.01,10.1371/journal.pone.0122241,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25826373,PMC4380355,ut:000352084800062,NA,TRUE
+slu,2015,1197.39,10.3390/ijerph120201928,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,1660-4601,NA,TRUE,25671775,PMC4344702,ut:000350209800049,NA,TRUE
+slu,2015,1200,10.1002/iid3.95,FALSE,Wiley,"Immunity, Inflammation and Disease",2050-4527,NA,NA,2050-4527,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27042303,PMC4768062,ut:000381569000007,NA,TRUE
+slu,2015,1204.09,10.1371/journal.pone.0122194,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25822750,PMC4379071,ut:000352134700158,NA,TRUE
+slu,2015,1204.09,10.1371/journal.pone.0122492,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25815509,PMC4376685,ut:000352133600184,NA,TRUE
+slu,2015,1204.09,10.1371/journal.pone.0122875,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25923329,PMC4414519,ut:000353711600025,NA,TRUE
+slu,2015,1204.09,10.1371/journal.pone.0123173,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25970163,PMC4430432,ut:000354544200009,NA,TRUE
+slu,2015,1207.33,10.3390/v7072789,FALSE,MDPI,Viruses,1999-4915,NA,1999-4915,1999-4915,NA,TRUE,26154017,PMC4517118,ut:000360353200014,NA,TRUE
+slu,2015,1211.75,10.1371/journal.pone.0129614,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26046538,PMC4457531,ut:000355652200164,NA,TRUE
+slu,2015,1211.75,10.1371/journal.pone.0129815,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26053171,PMC4459979,ut:000355955300164,NA,TRUE
+slu,2015,1222,10.1111/jvim.13584,FALSE,Wiley,Journal of Veterinary Internal Medicine,0891-6640,NA,NA,0891-6640,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26179258,PMC4858030,ut:000360916700011,NA,FALSE
+slu,2015,1224,10.1002/ece3.1866,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26865966,PMC4739569,ut:000369974900013,NA,TRUE
+slu,2015,1224,10.1002/ece3.1923,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26839685,PMC4725332,ut:000371069800023,NA,TRUE
+slu,2015,1231,10.1021/acs.est.5b03146,TRUE,American Chemical Society (ACS),Environmental Science & Technology,0013-936X,0013-936X,1520-5851,0013-936X,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,26450629,NA,ut:000364355300009,NA,FALSE
+slu,2015,1234.89,10.1371/journal.pone.0136928,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26313444,PMC4552548,ut:000360144000108,NA,TRUE
+slu,2015,1234.89,10.1371/journal.pone.0137871,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26366881,PMC4569288,ut:000361601100162,NA,TRUE
+slu,2015,1236.45,10.1371/journal.pone.0131182,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26151363,PMC4495060,ut:000358158900019,NA,TRUE
+slu,2015,1253.08,10.1371/journal.pone.0142257,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26554587,PMC4640599,ut:000364430700075,NA,TRUE
+slu,2015,1255.88,10.1371/journal.pone.0125139,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25933113,PMC4416813,ut:000353887100081,NA,TRUE
+slu,2015,1255.88,10.1371/journal.pone.0126021,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25933435,PMC4416768,ut:000353887100147,NA,TRUE
+slu,2015,1260.75,10.3389/fmicb.2015.01033,FALSE,Frontiers,Frontiers in Microbiology,1664-302X,NA,1664-302X,1664-302X,NA,TRUE,26441951,PMC4585013,ut:000363344400001,NA,TRUE
+slu,2015,1279.07,10.3389/fpls.2015.00368,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,1664-462X,NA,TRUE,26074934,PMC4448002,ut:000357011300001,NA,TRUE
+slu,2015,1282.61,10.3389/fpls.2015.00634,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,1664-462X,NA,TRUE,26322071,PMC4532917,ut:000359913200001,NA,TRUE
+slu,2015,1303.49,10.3389/fpls.2015.00718,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,1664-462X,NA,TRUE,26442032,PMC4585127,NA,NA,TRUE
+slu,2015,1322.24,10.1073/pnas.1423440112,TRUE,National Academy of Sciences,Proceedings of the National Academy of Sciences,0027-8424,0027-8424,1091-6490,0027-8424,http://www.pnas.org/site/misc/userlicense.xhtml,TRUE,25713384,PMC4364234,ut:000350646500061,NA,FALSE
+slu,2015,1325.65,10.3389/fmicb.2015.00387,FALSE,Frontiers,Frontiers in Microbiology,1664-302X,NA,1664-302X,1664-302X,NA,TRUE,26052312,PMC4439574,ut:000356266100001,NA,TRUE
+slu,2015,1325.65,10.3389/fpls.2015.00270,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,1664-462X,NA,TRUE,25954295,PMC4406003,ut:000356890400001,NA,TRUE
+slu,2015,1328.85,10.1016/j.ufug.2015.06.002,TRUE,Elsevier,Urban Forestry & Urban Greening,1618-8667,1618-8667,NA,1610-8167,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000363069400018,NA,FALSE
+slu,2015,1345.94,10.3389/fevo.2015.00151,FALSE,Frontiers,Frontiers in Ecology and Evolution,2296-701X,NA,2296-701X,2296-701X,NA,TRUE,NA,NA,NA,NA,TRUE
+slu,2015,1362.44,10.1186/1756-3305-7-419,FALSE,BioMed Central,Parasites & Vectors,1756-3305,1756-3305,NA,1756-3305,NA,TRUE,25189316,PMC4261757,ut:000342706900001,NA,TRUE
+slu,2015,1375,10.1111/conl.12171,FALSE,Wiley,Conservation Letters,1755-263X,NA,NA,1755-263X,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000363728900006,NA,TRUE
+slu,2015,1375,10.1111/conl.12200,FALSE,Wiley,Conservation Letters,1755-263X,NA,NA,1755-263X,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000374778600001,NA,TRUE
+slu,2015,1379.26,10.3390/ijms16048997,FALSE,MDPI,International Journal of Molecular Sciences,1422-0067,NA,1422-0067,1422-0067,NA,TRUE,25913379,PMC4425120,ut:000354040400142,NA,TRUE
+slu,2015,1380,10.5194/bgd-12-15763-2015,FALSE,Copernicus Publications,Biogeosciences Discussions,1810-6285,NA,1810-6285,1810-6285,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,NA,TRUE
+slu,2015,1392.91,10.3390/ijerph120707274,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,1660-4601,NA,TRUE,26132480,PMC4515656,ut:000359342300013,NA,TRUE
+slu,2015,1408.28,10.1186/s13071-015-0635-6,FALSE,BioMed Central,Parasites & Vectors,1756-3305,1756-3305,NA,1756-3305,NA,TRUE,25604581,PMC4307889,ut:000349417300001,NA,TRUE
+slu,2015,1423,10.1186/s12917-015-0389-6,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,NA,1746-6148,1746-6148,NA,TRUE,25890239,PMC4377052,ut:000351730200001,NA,TRUE
+slu,2015,1437.29,10.3390/ijerph120707974,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,1660-4601,NA,TRUE,26184268,PMC4515704,ut:000359342300061,NA,TRUE
+slu,2015,1467.37,10.3390/ijerph121114068,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,1660-4601,NA,TRUE,26540066,PMC4661633,ut:000365645500028,NA,TRUE
+slu,2015,1523.02,10.3390/molecules20045729,FALSE,MDPI,Molecules,1420-3049,NA,1420-3049,1420-3049,NA,TRUE,25834986,NA,ut:000354480700029,NA,TRUE
+slu,2015,1530,10.1002/ece3.1527,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26257881,PMC4523364,ut:000357962200017,NA,TRUE
+slu,2015,1534.33,10.1186/s13028-014-0079-6,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,25512143,PMC4271407,ut:000347724400001,NA,TRUE
+slu,2015,1552,10.1186/s12889-015-1811-5,FALSE,BioMed Central,BMC Public Health,1471-2458,NA,1471-2458,1471-2458,http://www.springer.com/tdm,TRUE,25952633,PMC4427931,ut:000354362200001,NA,TRUE
+slu,2015,1559.93,10.1186/s40462-015-0036-7,FALSE,BioMed Central,Movement Ecology,2051-3933,NA,2051-3933,2051-3933,NA,TRUE,25941571,PMC4418104,NA,NA,TRUE
+slu,2015,1569.08,10.1016/j.ijpddr.2015.07.003,FALSE,Elsevier,International Journal for Parasitology: Drugs and Drug Resistance,2211-3207,2211-3207,NA,2211-3207,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26448903,PMC4572398,ut:000367100600012,NA,TRUE
+slu,2015,1591,10.1186/s12917-015-0487-5,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,NA,1746-6148,1746-6148,NA,TRUE,26209243,PMC4514937,ut:000358405700004,NA,TRUE
+slu,2015,1615.5,10.1186/s12870-015-0676-1,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,1471-2229,NA,TRUE,26654722,PMC4676809,ut:000366271900001,NA,TRUE
 slu,2015,1646.26,0.1186/s12864-015-1829-1,FALSE,BioMed Central,NA,NA,NA,NA,NA,NA,FALSE,NA,NA,NA,NA,NA
-slu,2015,1646.26,10.1186/s12864-015-1829-1,FALSE,BioMed Central,BMC Genomics,1471-2164,NA,1471-2164,NA,NA,TRUE,26293353,PMC4546216,NA,NA,TRUE
-slu,2015,1646.26,10.1186/s12917-015-0447-0,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,NA,1746-6148,NA,NA,TRUE,26054940,PMC4459679,NA,NA,TRUE
-slu,2015,1653.61,10.1186/s12870-015-0630-2,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,NA,NA,TRUE,26458893,PMC4604075,NA,NA,TRUE
-slu,2015,1655.9,10.3168/jds.2014-9118,TRUE,American Dairy Science Association,Journal of Dairy Science,0022-0302,0022-0302,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25771050,NA,NA,NA,FALSE
-slu,2015,1656,10.1186/s12870-015-0579-1,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,NA,NA,TRUE,26253704,PMC4528408,NA,NA,TRUE
-slu,2015,1674.63,10.1186/s12864-015-1538-9,FALSE,BioMed Central,BMC Genomics,1471-2164,NA,1471-2164,NA,NA,TRUE,25896169,PMC4404599,NA,NA,TRUE
-slu,2015,1680,10.1186/s13028-015-0122-2,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,26109477,PMC4489116,NA,NA,TRUE
-slu,2015,1703.62,10.3389/fevo.2015.00121,FALSE,Frontiers,Frontiers in Ecology and Evolution,2296-701X,NA,2296-701X,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,1712.11,10.1186/s13028-015-0103-5,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,NA,NA,TRUE,25887040,PMC4359795,NA,NA,TRUE
-slu,2015,1714,10.1186/s12917-015-0352-6,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,1746-6148,NA,NA,NA,TRUE,25886633,PMC4349773,NA,NA,TRUE
-slu,2015,1716.95,10.1186/s12859-015-0657-2,FALSE,BioMed Central,BMC Bioinformatics,1471-2105,NA,1471-2105,NA,http://www.springer.com/tdm,TRUE,26224486,PMC4520095,NA,NA,TRUE
-slu,2015,1727.38,10.1186/s13028-015-0107-1,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,25884463,PMC4389305,NA,NA,TRUE
-slu,2015,1728.84,10.1186/s12862-015-0461-7,FALSE,BioMed Central,BMC Evolutionary Biology,1471-2148,NA,1471-2148,NA,NA,TRUE,26376815,PMC4574262,NA,NA,TRUE
-slu,2015,1730,10.1186/s40066-015-0029-1,FALSE,BioMed Central,Agriculture & Food Security,2048-7010,NA,2048-7010,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,1764,10.1186/s13028-015-0124-0,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,26104188,PMC4491221,NA,NA,TRUE
-slu,2015,1794.58,10.3389/fpls.2015.01186,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,NA,NA,TRUE,26779220,PMC4702147,NA,NA,TRUE
-slu,2015,1800,10.3920/CEP140024,TRUE,Wageningen Academic Publishers,Comparative Exercise Physiology,1755-2540,1755-2540,1755-2559,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,1800,10.3920/CEP150005,TRUE,Wageningen Academic Publishers,Comparative Exercise Physiology,1755-2540,1755-2540,1755-2559,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,1808.39,10.1186/s13002-015-0036-0,FALSE,BioMed Central,Journal of Ethnobiology and Ethnomedicine,1746-4269,NA,1746-4269,NA,NA,TRUE,26077671,PMC4474580,NA,NA,TRUE
-slu,2015,1858.23,10.1186/s12866-015-0537-y,FALSE,BioMed Central,BMC Microbiology,1471-2180,NA,1471-2180,NA,NA,TRUE,26458507,PMC4603578,NA,NA,TRUE
-slu,2015,1860.56,10.1111/jav.00623,TRUE,Wiley,Journal of Avian Biology,0908-8857,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,1978,10.1186/s13028-015-0101-7,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,NA,NA,TRUE,25884361,PMC4340676,NA,NA,TRUE
-slu,2015,1995.02,10.1186/s12915-015-0188-3,FALSE,BioMed Central,BMC Biology,1741-7007,NA,1741-7007,NA,NA,TRUE,26377197,PMC4571119,NA,NA,TRUE
-slu,2015,1995.05,10.1016/j.anireprosci.2014.12.011,TRUE,Elsevier,Animal Reproduction Science,0378-4320,0378-4320,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25576030,NA,NA,NA,FALSE
-slu,2015,2019.58,10.1371/journal.pgen.1005295,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26086217,PMC4472357,NA,NA,TRUE
-slu,2015,2045.78,10.1371/journal.pgen.1005648,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26599497,PMC4657900,NA,NA,TRUE
-slu,2015,2048.46,10.1186/s13059-015-0785-z,FALSE,BioMed Central,Genome Biology,1474-760X,NA,1474-760X,NA,NA,TRUE,26438066,PMC4595211,NA,NA,TRUE
-slu,2015,2064.46,10.1105/tpc.114.132043,TRUE,American Society of Plant Biologists (ASPB),The Plant Cell Online,1040-4651,1040-4651,1532-298X,NA,NA,TRUE,25681156,NA,NA,NA,FALSE
-slu,2015,2064.46,10.1105/tpc.114.134494,TRUE,American Society of Plant Biologists (ASPB),The Plant Cell,1040-4651,1040-4651,1532-298X,NA,NA,TRUE,25736060,NA,NA,NA,FALSE
-slu,2015,2064.46,10.​1105/​tpc.​114.​132043,TRUE,American Society of Plant Biologists,NA,NA,NA,NA,NA,NA,FALSE,NA,NA,NA,NA,NA
-slu,2015,2064.46,10.​1105/​tpc.​114.​134494,TRUE,American Society of Plant Biologists,NA,NA,NA,NA,NA,NA,FALSE,NA,NA,NA,NA,NA
-slu,2015,2112,10.1186/s12917-015-0328-6,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,1746-6148,NA,NA,NA,TRUE,25636335,PMC4318355,NA,NA,TRUE
-slu,2015,2125,10.1371/journal.pgen.1005541,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26397943,PMC4580642,NA,NA,TRUE
-slu,2015,2130.83,10.1186/s13068-015-0328-6,FALSE,BioMed Central,Biotechnology for Biofuels,1754-6834,NA,1754-6834,NA,NA,TRUE,26396592,PMC4578335,NA,NA,TRUE
-slu,2015,2200,10.1007/s00267-015-0613-y,TRUE,Springer,Environmental Management,0364-152X,0364-152X,1432-1009,NA,NA,TRUE,26395184,PMC4712240,NA,NA,FALSE
-slu,2015,2200,10.1007/s00442-015-3326-2,TRUE,Springer,Oecologia,0029-8549,0029-8549,1432-1939,NA,NA,TRUE,25943193,PMC4553151,NA,NA,FALSE
-slu,2015,2200,10.1007/s00442-015-3345-z,TRUE,Springer,Oecologia,0029-8549,0029-8549,1432-1939,NA,NA,TRUE,26001605,PMC4568007,NA,NA,FALSE
-slu,2015,2200,10.1007/s10344-015-0968-7,TRUE,Springer,European Journal of Wildlife Research,1612-4642,1612-4642,1439-0574,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2200,10.1007/s10530-015-0915-2,TRUE,Springer,Biological Invasions,1387-3547,1387-3547,1573-1464,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2200,10.1007/s10661-015-4385-x,TRUE,Springer,Environmental Monitoring and Assessment,0167-6369,0167-6369,1573-2959,NA,http://creativecommons.org/licenses/by/4.0,TRUE,25787168,PMC4365174,NA,NA,FALSE
-slu,2015,2200,10.1007/s10705-015-9712-7,TRUE,Springer,Nutrient Cycling in Agroecosystems,1385-1314,1385-1314,1573-0867,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2200,10.1007/s10750-015-2605-6,TRUE,Springer,Hydrobiologia,0018-8158,0018-8158,1573-5117,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2200,10.1007/s10818-015-9209-0,TRUE,Springer,Journal of Bioeconomics,1387-6996,1387-6996,1573-6989,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2200,10.1007/s10980-015-0210-8,TRUE,Springer,Landscape Ecology,0921-2973,0921-2973,1572-9761,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2200,10.1007/s10980-015-0246-9,TRUE,Springer,Landscape Ecology,0921-2973,0921-2973,1572-9761,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2200,10.1007/s11104-015-2456-y,TRUE,Springer,Plant and Soil,0032-079X,0032-079X,1573-5036,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2200,10.1007/s11250-015-0911-7,TRUE,Springer,Tropical Animal Health and Production,0049-4747,0049-4747,1573-7438,NA,NA,TRUE,26374208,PMC4710656,NA,NA,FALSE
-slu,2015,2200,10.1007/s11306-015-0814-7,TRUE,Springer,Metabolomics,1573-3882,1573-3882,1573-3890,NA,NA,TRUE,26491421,PMC4605972,NA,NA,FALSE
-slu,2015,2200,10.1007/s13165-014-0094-y,TRUE,Springer,Organic Agriculture,1879-4238,1879-4238,1879-4246,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2200,10.1007/s13165-015-0125-3,TRUE,Springer,Organic Agriculture,1879-4238,1879-4238,1879-4246,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2200,10.1007/s13280-015-0706-0,TRUE,Springer,Ambio,0044-7447,0044-7447,1654-7209,NA,NA,TRUE,26508343,PMC4623861,NA,NA,FALSE
-slu,2015,2214.75,10.1016/j.ecocom.2015.04.001,TRUE,Elsevier,Ecological Complexity,1476-945X,1476-945X,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2214.75,10.1016/j.marpolbul.2015.02.010,TRUE,Elsevier,Marine Pollution Bulletin,0025-326X,0025-326X,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25726066,NA,NA,NA,FALSE
-slu,2015,2214.75,10.1016/j.marpolbul.2015.04.033,TRUE,Elsevier,Marine Pollution Bulletin,0025-326X,0025-326X,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26066862,NA,NA,NA,FALSE
-slu,2015,2214.75,10.1016/j.wasman.2015.02.009,TRUE,Elsevier,Waste Management,0956-053X,0956-053X,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25728090,NA,NA,NA,FALSE
-slu,2015,2231.35,10.1016/j.fcr.2015.11.006,TRUE,Elsevier,Field Crops Research,0378-4290,0378-4290,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2241,10.1016/j.plantsci.2015.08.021,TRUE,Elsevier,Plant Science,0168-9452,0168-9452,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26566822,NA,NA,NA,FALSE
-slu,2015,2241.55,10.1016/j.jveb.2015.05.004,TRUE,Elsevier,Journal of Veterinary Behavior: Clinical Applications and Research,1558-7878,1558-7878,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2255.33,10.1186/s13028-015-0135-x,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,26289447,PMC4545324,NA,NA,TRUE
-slu,2015,2303.34,10.1016/j.jchromb.2015.07.009,TRUE,Elsevier,Journal of Chromatography B,1570-0232,1570-0232,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26218771,NA,NA,NA,FALSE
-slu,2015,2315.41,10.1080/02827581.2015.1028435,TRUE,Taylor & Francis,Scandinavian Journal of Forest Research,0282-7581,0282-7581,1651-1891,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2331.26,10.1186/s40793-015-0092-z,FALSE,BioMed Central,Standards in Genomic Sciences,1944-3277,NA,1944-3277,NA,NA,TRUE,26566424,PMC4642661,NA,NA,TRUE
-slu,2015,2337,10.1017/S1751731115000750,TRUE,Cambridge University Press (CUP),animal,1751-7311,1751-7311,1751-732X,NA,NA,TRUE,25959256,PMC4762244,NA,NA,FALSE
-slu,2015,2369.93,10.1186/s12885-015-1073-8,FALSE,BioMed Central,BMC Cancer,1471-2407,NA,1471-2407,NA,http://www.springer.com/tdm,TRUE,25881026,PMC4336758,NA,NA,TRUE
-slu,2015,2622.5,10.1111/1751-7915.12330,FALSE,Wiley,Microbial Biotechnology,1751-7915,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26686366,PMC4767286,NA,NA,TRUE
-slu,2015,2647,10.1080/02827581.2015.1046482,TRUE,Taylor & Francis,Scandinavian Journal of Forest Research,0282-7581,0282-7581,1651-1891,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,265.42,10.5539/jas.v7n11p28,FALSE,Canadian Center of Science and Education,Journal of Agricultural Science,1916-9760,1916-9752,1916-9760,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2654.21,10.1111/age.12334,TRUE,Wiley,Animal Genetics,0268-9146,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26417640,PMC5054924,NA,NA,FALSE
-slu,2015,2654.21,10.1111/wre.12183,TRUE,Wiley,Weed Research,0043-1737,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2668,10.2527/jas.2014-8598,TRUE,American Society of Animal Science (ASAS),Journal of Animal Science,1525-3163,NA,1525-3163,NA,NA,TRUE,26020760,NA,NA,NA,FALSE
-slu,2015,2675.75,10.1111/evj.12446,TRUE,Wiley,Equine Veterinary Journal,0425-1644,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25808700,PMC5032979,NA,NA,FALSE
-slu,2015,2677.62,10.1016/j.vetimm.2015.10.002,TRUE,Elsevier,Veterinary Immunology and Immunopathology,0165-2427,0165-2427,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26547884,NA,NA,NA,FALSE
-slu,2015,2686.72,10.1111/ppl.12397,TRUE,Wiley,Physiologia Plantarum,0031-9317,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2689,10.1016/j.watres.2015.08.024,TRUE,Elsevier,Water Research,0043-1354,0043-1354,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26342182,NA,NA,NA,FALSE
-slu,2015,2690,10.1016/j.tplants.2015.08.007,TRUE,Elsevier,Trends in Plant Science,1360-1385,1360-1385,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26447042,NA,NA,NA,FALSE
-slu,2015,2692.78,10.1111/1744-7917.12233,TRUE,Wiley,Insect Science,1672-9609,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25959579,NA,NA,NA,FALSE
-slu,2015,2726,10.1136/vr.102960,TRUE,BMJ,Veterinary Record,0042-4900,0042-4900,2042-7670,NA,NA,TRUE,26089352,PMC4518756,NA,NA,FALSE
-slu,2015,2744.2,10.1111/efp.12236,TRUE,Wiley,Forest Pathology,1437-4781,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2747.67,10.1111/anti.12170,TRUE,Wiley,Antipode,0066-4812,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2747.67,10.1111/een.12247,TRUE,Wiley,Ecological Entomology,0307-6946,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2747.67,10.1111/nph.13536,TRUE,Wiley,New Phytologist,0028-646X,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26115363,PMC5034847,NA,NA,FALSE
-slu,2015,2790.85,10.1111/imb.12176,TRUE,Wiley,Insect Molecular Biology,0962-1075,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26033210,NA,NA,NA,FALSE
-slu,2015,2833.55,10.1111/jvs.12387,TRUE,Wiley,Journal of Vegetation Science,1100-9233,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,2945.38,10.1016/j.agee.2015.12.021,TRUE,Elsevier,"Agriculture, Ecosystems & Environment",0167-8809,0167-8809,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,3134.5,10.1002/2015JG003190,TRUE,Wiley,Journal of Geophysical Research: Biogeosciences,2169-8953,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,3283.78,10.1111/gcb.12872,TRUE,Wiley,Global Change Biology,1354-1013,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25611952,NA,NA,NA,FALSE
-slu,2015,3305.81,10.3168/jds.2015-9755,TRUE,American Dairy Science Association,Journal of Dairy Science,0022-0302,0022-0302,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26547638,NA,NA,NA,FALSE
-slu,2015,3365,10.1242/jeb.116798,TRUE,Company of Biologists,Journal of Experimental Biology,0022-0949,0022-0949,1477-9145,NA,NA,TRUE,26056246,PMC4528704,NA,NA,FALSE
-slu,2015,428.93,10.3390/insects6010183,FALSE,MDPI,Insects,2075-4450,NA,2075-4450,NA,NA,TRUE,26463074,PMC4553537,NA,NA,TRUE
-slu,2015,566,10.1155/2015/610391,FALSE,Hindawi Publishing Corporation,International Journal of Biodiversity,2314-4149,2314-4149,2314-4157,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,575,10.3389/fpls.2015.00130,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,NA,NA,TRUE,25806038,PMC4353180,NA,NA,TRUE
-slu,2015,612.5,10.3389/fgene.2015.00044,FALSE,Frontiers,Frontiers in Genetics,1664-8021,NA,1664-8021,NA,NA,TRUE,25741364,PMC4330917,NA,NA,TRUE
-slu,2015,669.4,10.1016/j.gecco.2015.10.009,FALSE,Elsevier,Global Ecology and Conservation,2351-9894,2351-9894,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,748.37,10.3390/su7021142,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,750,10.5194/bg-13-1119-2016,FALSE,Copernicus Publications,Biogeosciences,1726-4189,NA,1726-4189,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,768,10.3389/fevo.2015.00131,FALSE,Frontiers,Frontiers in Ecology and Evolution,2296-701X,NA,2296-701X,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,770,10.3389/fevo.2015.00056,FALSE,Frontiers,Frontiers in Ecology and Evolution,2296-701X,NA,2296-701X,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,784.56,10.3389/fpls.2015.00970,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,NA,NA,TRUE,26579190,PMC4630563,NA,NA,TRUE
-slu,2015,803,10.1186/s40064-015-1285-z,FALSE,BioMed Central,SpringerPlus,2193-1801,NA,2193-1801,NA,NA,TRUE,26380165,PMC4565800,NA,NA,FALSE
-slu,2015,814,10.3389/fpls.2015.00279,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,NA,NA,TRUE,25983736,PMC4416443,NA,NA,TRUE
-slu,2015,826.95,10.3390/f6124384,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,862.04,10.3390/f6041145,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,870,10.5194/bg-12-3241-2015,FALSE,Copernicus Publications,Biogeosciences,1726-4189,NA,1726-4189,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,870,10.5194/bg-13-1-2016,FALSE,Copernicus Publications,Biogeosciences,1726-4189,NA,1726-4189,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,889,10.1111/jvim.13815,FALSE,Wiley,Journal of Veterinary Internal Medicine,0891-6640,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26683136,PMC4913634,NA,NA,FALSE
-slu,2015,889,10.1111/jvim.13829,FALSE,Wiley,Journal of Veterinary Internal Medicine,0891-6640,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26812988,PMC4913606,NA,NA,FALSE
-slu,2015,917.11,10.3390/f6114001,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,922.32,10.3390/f6103594,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,946.74,10.3390/f6082785,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,946.74,10.3390/f6092982,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2015,960,10.3389/fgene.2015.00049,FALSE,Frontiers,Frontiers in Genetics,1664-8021,NA,1664-8021,NA,NA,TRUE,25750652,PMC4335173,NA,NA,TRUE
-slu,2015,981.79,10.1016/j.foodpol.2015.10.008,TRUE,Elsevier,Food Policy,0306-9192,0306-9192,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2015,981.79,10.1016/j.foodpol.2015.11.002,TRUE,Elsevier,Food Policy,0306-9192,0306-9192,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,1062.79,10.3390/su8090865,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1082.35,10.1016/j.atmosenv.2016.08.033,TRUE,Elsevier,Atmospheric Environment,1352-2310,1352-2310,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,1104,10.3390/su8040340,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1164.5,10.1186/s12863-015-0261-5,FALSE,BioMed Central,BMC Genetics,1471-2156,NA,1471-2156,NA,NA,TRUE,26286720,PMC4541747,NA,NA,TRUE
-slu,2016,1165,10.1038/srep21895,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,26900083,PMC4761999,NA,NA,TRUE
-slu,2016,1165,10.1038/srep21930,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,26908158,PMC4764941,NA,NA,TRUE
-slu,2016,1165,10.1038/srep22806,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,26960555,PMC4785398,NA,NA,TRUE
-slu,2016,1165,10.1038/srep23198,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,26979573,PMC4793264,NA,NA,TRUE
-slu,2016,1165,10.1038/srep23518,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,27006164,PMC4804390,NA,NA,TRUE
-slu,2016,1165,10.1038/srep28498,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,27346604,PMC4921962,NA,NA,TRUE
-slu,2016,1165,10.1038/srep31314,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,27499001,PMC4976314,NA,NA,TRUE
-slu,2016,1165,10.1038/srep37930,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,27901056,PMC5128813,NA,NA,TRUE
-slu,2016,1165,10.1038/srep39208,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,27966627,PMC5155301,NA,NA,TRUE
-slu,2016,1178.36,10.1186/s12711-016-0219-8,FALSE,BioMed Central,Genetics Selection Evolution,1297-9686,NA,1297-9686,NA,NA,TRUE,27286957,PMC4901500,NA,NA,TRUE
-slu,2016,1203,10.1002/ecs2.1257,FALSE,Wiley,Ecosphere,2150-8925,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1203,10.1002/ecs2.1583,FALSE,Wiley,Ecosphere,2150-8925,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1222,10.1111/jvim.13830,FALSE,Wiley,Journal of Veterinary Internal Medicine,0891-6640,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26822126,PMC4913616,NA,NA,FALSE
-slu,2016,1224,10.1002/ece3.2032,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27217946,PMC4863019,NA,NA,TRUE
-slu,2016,1224,10.1002/ece3.2279,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27547341,PMC4983578,NA,NA,TRUE
-slu,2016,1224,10.1002/ece3.2597,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28070296,PMC5216661,NA,NA,TRUE
-slu,2016,1224,10.1002/ece3.2601,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28070299,PMC5216679,NA,NA,TRUE
-slu,2016,1228.64,10.1371/journal.pone.0166510,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27846312,PMC5113013,NA,NA,TRUE
-slu,2016,123.57,10.5897/JEN2016.0159,FALSE,Academic Journals,Journal of Entomology and Nematology,2006-9855,NA,2006-9855,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,1234.34,10.1371/journal.pone.0147004,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26799558,PMC4723141,NA,NA,TRUE
-slu,2016,1234.34,10.1371/journal.pone.0147791,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26840533,PMC4739691,NA,NA,TRUE
-slu,2016,1237.47,10.1371/journal.pone.0148960,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26866480,PMC4750853,NA,NA,TRUE
-slu,2016,1262.25,10.1186/s13028-016-0191-x,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,26829925,PMC4736141,NA,NA,TRUE
-slu,2016,1279.91,10.3389/fimmu.2016.00247,FALSE,Frontiers,Frontiers in Immunology,1664-3224,NA,1664-3224,NA,NA,TRUE,27446077,PMC4917549,NA,NA,TRUE
-slu,2016,1299.8,10.1186/s13071-016-1897-3,FALSE,BioMed Central,Parasites & Vectors,1756-3305,NA,1756-3305,NA,NA,TRUE,27899131,PMC5129611,NA,NA,TRUE
-slu,2016,1311,10.1371/journal.pone.0156151,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27223472,PMC4880347,NA,NA,TRUE
-slu,2016,1311.36,10.1371/journal.pone.0155541,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27171471,PMC4865114,NA,NA,TRUE
-slu,2016,1311.36,10.1371/journal.pone.0157136,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27270445,PMC4896472,NA,NA,TRUE
-slu,2016,1313.01,10.1371/journal.pone.0152966,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27070818,PMC4829256,NA,NA,TRUE
-slu,2016,1313.01,10.1371/journal.pone.0155137,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27223473,PMC4880312,NA,NA,TRUE
-slu,2016,1315.75,10.1155/2016/3841803,FALSE,Hindawi Publishing Corporation,Oxidative Medicine and Cellular Longevity,1942-0900,1942-0900,1942-0994,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27429708,PMC4939354,NA,NA,TRUE
-slu,2016,1337.72,10.1371/journal.pone.0165742,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27828995,PMC5102373,NA,NA,TRUE
-slu,2016,1338,10.1371/journal.pone.0161346,FALSE,BioMed Central,PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27584666,PMC5008833,NA,NA,TRUE
-slu,2016,1338.67,10.1371/journal.pone.0162086,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27580120,PMC5007034,NA,NA,TRUE
-slu,2016,1338.81,10.1016/j.jfe.2016.04.002,TRUE,Elsevier,Journal of Forest Economics,1104-6899,1104-6899,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,1338.81,10.1016/j.ufug.2015.04.003,TRUE,Elsevier,Urban Forestry & Urban Greening,1618-8667,1618-8667,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,1338.81,10.1016/j.ufug.2016.04.012,TRUE,Elsevier,Urban Forestry & Urban Greening,1618-8667,1618-8667,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,1342.46,10.1371/journal.pone.0162751,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27682810,PMC5040392,NA,NA,TRUE
-slu,2016,1342.79,10.1371/journal.pone.0157972,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27333328,PMC4917106,NA,NA,TRUE
-slu,2016,1342.79,10.1371/journal.pone.0157977,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27322387,PMC4913902,NA,NA,TRUE
-slu,2016,1347.89,10.1371/journal.pone.0160334,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27479078,PMC4968819,NA,NA,TRUE
-slu,2016,1350,10.5194/hess-20-2811-2016,FALSE,Copernicus Publications,Hydrology and Earth System Sciences,1607-7938,NA,1607-7938,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1350.21,10.1186/s12917-016-0924-0,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,NA,1746-6148,NA,NA,TRUE,28056957,PMC5217653,NA,NA,TRUE
-slu,2016,1352.94,10.1016/j.ufug.2016.08.012,TRUE,Elsevier,Urban Forestry & Urban Greening,1618-8667,1618-8667,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,1352.94,10.1016/j.ufug.2016.12.006,TRUE,Elsevier,Urban Forestry & Urban Greening,1618-8667,1618-8667,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,1360.61,10.1371/journal.pone.0166520,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27851830,PMC5113046,NA,NA,TRUE
-slu,2016,1360.61,10.1371/journal.pone.0166863,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27907010,PMC5131951,NA,NA,TRUE
-slu,2016,1366,10.1371/journal.pone.0148896,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26859145,PMC4747562,NA,NA,TRUE
-slu,2016,1376,10.1371/journal.pone.0151904,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27028005,PMC4814071,NA,NA,TRUE
-slu,2016,1376.06,10.1371/journal.pone.0150870,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26986618,PMC4795764,NA,NA,TRUE
-slu,2016,1376.06,10.1371/journal.pone.0151481,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26982708,PMC4794121,NA,NA,TRUE
-slu,2016,1376.06,10.1371/journal.pone.0151969,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27002525,PMC4803345,NA,NA,TRUE
-slu,2016,1377,10.1002/ece3.2076,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27096081,PMC4829048,NA,NA,TRUE
-slu,2016,1378,10.1371/journal.pone.0149594,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26938257,PMC4777320,NA,NA,TRUE
-slu,2016,1408.19,10.1186/s40793-016-0199-x,FALSE,BioMed Central,Standards in Genomic Sciences,1944-3277,NA,1944-3277,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1408.19,10.1186/s41065-016-0014-0,FALSE,BioMed Central,Hereditas,1601-5223,NA,1601-5223,NA,NA,TRUE,28096772,PMC5226105,NA,NA,TRUE
-slu,2016,1409.5,10.1371/journal.pone.0167964,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27936149,PMC5148084,NA,NA,TRUE
-slu,2016,1409.5,10.1371/journal.pone.0168776,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28002449,PMC5176316,NA,NA,TRUE
-slu,2016,1416.62,10.3389/fpubh.2016.00098,FALSE,Frontiers,Frontiers in Public Health,2296-2565,NA,2296-2565,NA,NA,TRUE,27242990,PMC4871859,NA,NA,TRUE
-slu,2016,1428.09,10.1186/s13742-016-0132-7,FALSE,Oxford University Press (OUP),GigaScience,2047-217X,NA,2047-217X,NA,NA,TRUE,27267963,PMC4897895,NA,NA,TRUE
-slu,2016,1435.1,10.1186/s12864-016-2458-z,FALSE,BioMed Central,BMC Genomics,1471-2164,NA,1471-2164,NA,NA,TRUE,26887814,PMC4758094,NA,NA,TRUE
-slu,2016,1435.69,10.1186/s12870-016-0952-8,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,NA,NA,TRUE,28061815,PMC5219727,NA,NA,TRUE
-slu,2016,1439.65,10.1186/s41065-016-0011-3,FALSE,BioMed Central,Hereditas,1601-5223,NA,1601-5223,NA,NA,TRUE,28096769,PMC5226109,NA,NA,TRUE
-slu,2016,1450.57,10.3389/fpubh.2016.00137,FALSE,Frontiers,Frontiers in Public Health,2296-2565,NA,2296-2565,NA,NA,TRUE,27446901,PMC4923150,NA,NA,TRUE
-slu,2016,1456.76,10.3390/ijms17101673,FALSE,MDPI,International Journal of Molecular Sciences,1422-0067,NA,1422-0067,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1478.67,10.3390/rs8090724,FALSE,MDPI,Remote Sensing,2072-4292,NA,2072-4292,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1478.67,10.3390/rs8090736,FALSE,MDPI,Remote Sensing,2072-4292,NA,2072-4292,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1484,10.3390/ijerph13121229,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1487,10.1186/s13028-016-0261-0,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1495.39,10.1186/s12936-016-1656-0,FALSE,BioMed Central,Malaria Journal,1475-2875,NA,1475-2875,NA,NA,TRUE,28114992,PMC5259891,NA,NA,TRUE
-slu,2016,1496.36,10.1186/s12917-016-0743-3,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,NA,1746-6148,NA,NA,TRUE,27329086,PMC4915148,NA,NA,TRUE
-slu,2016,1500,10.1016/j.gecco.2016.09.005,FALSE,Elsevier,Global Ecology and Conservation,2351-9894,2351-9894,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1503.75,10.1002/ecs2.1541,FALSE,Wiley,Ecosphere,2150-8925,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1512,10.1186/s12865-016-0155-y,FALSE,BioMed Central,BMC Immunology,1471-2172,NA,1471-2172,NA,NA,TRUE,27267469,PMC4897876,NA,NA,TRUE
-slu,2016,1512.87,10.1186/1297-9686-44-31,FALSE,BioMed Central,Genetics Selection Evolution,1297-9686,1297-9686,NA,NA,NA,TRUE,23110538,PMC3524047,NA,NA,TRUE
-slu,2016,1514.11,10.1186/s13028-016-0257-9,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1530,10.1002/ece3.2003,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27099712,PMC4831447,NA,NA,TRUE
-slu,2016,1530.61,10.1186/s12870-016-0706-7,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,NA,NA,TRUE,26786587,PMC4719685,NA,NA,TRUE
-slu,2016,1530.61,10.1186/s12889-015-2574-8,FALSE,BioMed Central,BMC Public Health,1471-2458,NA,1471-2458,NA,http://www.springer.com/tdm,TRUE,26654879,PMC4676886,NA,NA,TRUE
-slu,2016,1555.74,10.1186/s12936-016-1386-3,FALSE,BioMed Central,Malaria Journal,1475-2875,NA,1475-2875,NA,NA,TRUE,27439360,PMC4955153,NA,NA,TRUE
-slu,2016,1559.03,10.1186/s12864-016-2561-1,FALSE,BioMed Central,BMC Genomics,1471-2164,NA,1471-2164,NA,NA,TRUE,26988094,PMC4794925,NA,NA,TRUE
-slu,2016,1560.61,10.1186/s12868-016-0258-7,FALSE,BioMed Central,BMC Neuroscience,1471-2202,NA,1471-2202,NA,NA,TRUE,27246183,PMC4888552,NA,NA,TRUE
-slu,2016,1561.95,10.1016/j.ijppaw.2016.03.001,FALSE,Elsevier,International Journal for Parasitology: Parasites and Wildlife,2213-2244,2213-2244,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27054089,PMC4804384,NA,NA,TRUE
-slu,2016,1576.36,10.1186/s13028-016-0266-8,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1578,10.1016/j.ijpddr.2016.06.004,FALSE,Elsevier,International Journal for Parasitology: Drugs and Drug Resistance,2211-3207,2211-3207,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27380550,PMC4933035,NA,NA,TRUE
-slu,2016,1588,10.1186/s12917-016-0868-4,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,NA,1746-6148,NA,NA,TRUE,27793205,PMC5084410,NA,NA,TRUE
-slu,2016,1594.89,10.1186/s12936-016-1308-4,FALSE,BioMed Central,Malaria Journal,1475-2875,NA,1475-2875,NA,NA,TRUE,27142303,PMC4855760,NA,NA,TRUE
-slu,2016,1606.57,10.1016/j.landusepol.2016.05.001,TRUE,Elsevier,Land Use Policy,0264-8377,0264-8377,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,1606.57,10.1016/j.molbiopara.2016.02.004,TRUE,Elsevier,Molecular and Biochemical Parasitology,0166-6851,0166-6851,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26880419,NA,NA,NA,FALSE
-slu,2016,1617,10.1136/vetreco-2016-000173,FALSE,BMJ,Veterinary Record Open,2052-6113,NA,2052-6113,NA,NA,TRUE,27547424,PMC4964167,NA,NA,TRUE
-slu,2016,1623.53,10.1016/j.landusepol.2016.09.016,TRUE,Elsevier,Land Use Policy,0264-8377,0264-8377,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,1623.53,10.1016/j.ppees.2016.09.005,TRUE,Elsevier,"Perspectives in Plant Ecology, Evolution and Systematics",1433-8319,1433-8319,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,1623.98,10.1186/s40575-015-0029-2,FALSE,BioMed Central,Canine Genetics and Epidemiology,2052-6687,NA,2052-6687,NA,NA,TRUE,26457193,PMC4599337,NA,NA,TRUE
-slu,2016,1639.86,10.1186/s13028-016-0217-4,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,27245578,PMC4888634,NA,NA,TRUE
-slu,2016,1639.86,10.1186/s13028-016-0263-y,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1639.86,10.1186/s13028-016-0265-9,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,28031036,PMC5192580,NA,NA,TRUE
-slu,2016,1646.46,10.1186/s12870-016-0939-5,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,NA,NA,TRUE,27863470,PMC5116219,NA,NA,TRUE
-slu,2016,1653.86,10.1186/s13068-016-0543-9,FALSE,BioMed Central,Biotechnology for Biofuels,1754-6834,NA,1754-6834,NA,NA,TRUE,27330562,PMC4912747,NA,NA,TRUE
-slu,2016,1656.24,10.3390/molecules21040372,FALSE,MDPI,Molecules,1420-3049,NA,1420-3049,NA,NA,TRUE,27043500,NA,NA,NA,TRUE
-slu,2016,1658.17,10.3390/s16111950,FALSE,MDPI,Sensors,1424-8220,NA,1424-8220,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1661,10.1186/s13028-015-0178-z,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,26655039,PMC4676829,NA,NA,TRUE
-slu,2016,1667.47,10.1186/s13028-016-0274-8,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,28049540,PMC5210291,NA,NA,TRUE
-slu,2016,1686.22,10.1186/s13028-016-0213-8,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,27207437,PMC4875734,NA,NA,TRUE
-slu,2016,1701.32,10.3389/fvets.2016.00057,FALSE,Frontiers,Frontiers in Veterinary Science,2297-1769,NA,2297-1769,NA,NA,TRUE,27500137,PMC4956668,NA,NA,TRUE
-slu,2016,1729.2,10.3389/fbioe.2016.00089,FALSE,Frontiers,Frontiers in Bioengineering and Biotechnology,2296-4185,NA,2296-4185,NA,NA,TRUE,28066762,PMC5165279,NA,NA,TRUE
-slu,2016,1737,10.3389/fevo.2015.00155,FALSE,Frontiers,Frontiers in Ecology and Evolution,2296-701X,NA,2296-701X,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1748.84,10.3389/fgene.2016.00057,FALSE,Frontiers,Frontiers in Genetics,1664-8021,NA,1664-8021,NA,NA,TRUE,27148354,PMC4832587,NA,NA,TRUE
-slu,2016,1748.84,10.3389/fvets.2016.00031,FALSE,Frontiers,Frontiers in Veterinary Science,2297-1769,NA,2297-1769,NA,NA,TRUE,27148545,PMC4831202,NA,NA,TRUE
-slu,2016,1781,10.1186/s13028-016-0236-1,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1802.53,10.1186/s12863-015-0304-y,FALSE,BioMed Central,BMC Genetics,1471-2156,NA,1471-2156,NA,NA,TRUE,26706685,PMC4691297,NA,NA,TRUE
-slu,2016,1816.38,10.1186/s13068-016-0454-9,FALSE,BioMed Central,Biotechnology for Biofuels,1754-6834,NA,1754-6834,NA,NA,TRUE,26925165,PMC4769498,NA,NA,TRUE
-slu,2016,1823,10.1111/gcbb.12373,FALSE,Wiley,GCB Bioenergy,1757-1693,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,1823,10.1111/gcbb.12399,FALSE,Wiley,GCB Bioenergy,1757-1693,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,1858.85,10.3389/fpls.2016.00654,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,NA,NA,TRUE,27242855,PMC4870230,NA,NA,TRUE
-slu,2016,1881.94,10.1186/s13750-016-0080-9,FALSE,BioMed Central,Environmental Evidence,2047-2382,NA,2047-2382,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,1912,10.1002/ece3.2594,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28070294,PMC5216668,NA,NA,TRUE
-slu,2016,1912,10.1002/ece3.2598,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,28035275,PMC5192942,NA,NA,TRUE
-slu,2016,1935.14,10.1093/nar/gkx087,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,NA,NA,TRUE,28175342,PMC5389543,NA,NA,TRUE
-slu,2016,1976.1,10.1371/journal.pgen.1005924,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27100965,PMC4839602,NA,NA,TRUE
-slu,2016,2000.46,10.1186/s13068-016-0640-9,FALSE,BioMed Central,Biotechnology for Biofuels,1754-6834,NA,1754-6834,NA,NA,TRUE,27800015,PMC5078929,NA,NA,TRUE
-slu,2016,2020.43,10.1371/journal.pntd.0005043,FALSE,Public Library of Science (PLoS),PLOS Neglected Tropical Diseases,1935-2735,NA,1935-2735,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27768698,PMC5074459,NA,NA,TRUE
-slu,2016,2087.34,10.1186/s13071-016-1503-8,FALSE,BioMed Central,Parasites & Vectors,1756-3305,NA,1756-3305,NA,NA,TRUE,27094215,PMC4837528,NA,NA,TRUE
-slu,2016,2132,10.1017/S0024282916000359,TRUE,Cambridge University Press (CUP),The Lichenologist,0024-2829,0024-2829,1096-1135,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s00227-016-2977-9,TRUE,Springer,Marine Biology,0025-3162,0025-3162,1432-1793,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s00299-016-2062-3,TRUE,Springer,Plant Cell Reports,0721-7714,0721-7714,1432-203X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27699473,PMC5206254,NA,NA,FALSE
-slu,2016,2200,10.1007/s00334-016-0586-7,TRUE,Springer,Vegetation History and Archaeobotany,0939-6314,0939-6314,1617-6278,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s00425-016-2580-9,TRUE,Springer,Planta,0032-0935,0032-0935,1432-2048,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27541497,PMC5226999,NA,NA,FALSE
-slu,2016,2200,10.1007/s00442-016-3742-y,TRUE,Springer,Oecologia,0029-8549,0029-8549,1432-1939,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27718064,PMC5239808,NA,NA,FALSE
-slu,2016,2200,10.1007/s00449-016-1726-2,TRUE,Springer,Bioprocess and Biosystems Engineering,1615-7591,1615-7591,1615-7605,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28025700,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s00468-016-1495-1,TRUE,Springer,Trees,0931-1890,0931-1890,1432-2285,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s10342-016-0981-8,TRUE,Springer,European Journal of Forest Research,1612-4669,1612-4669,1612-4677,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s10531-016-1217-4,TRUE,Springer,Biodiversity and Conservation,0960-3115,0960-3115,1572-9710,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s10533-016-0266-9,TRUE,Springer,Biogeochemistry,0168-2563,0168-2563,1573-515X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s10669-016-9605-6,TRUE,Springer,Environment Systems and Decisions,2194-5403,2194-5403,2194-5411,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s10695-016-0297-0,TRUE,Springer,Fish Physiology and Biochemistry,0920-1742,0920-1742,1573-5168,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27677483,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s10811-016-0950-0,TRUE,Springer,Journal of Applied Phycology,0921-8971,0921-8971,1573-5176,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28344390,PMC5346144,NA,NA,FALSE
-slu,2016,2200,10.1007/s10886-016-0753-4,TRUE,Springer,Journal of Chemical Ecology,0098-0331,0098-0331,1573-1561,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27624066,PMC5101348,NA,NA,FALSE
-slu,2016,2200,10.1007/s10980-016-0434-2,TRUE,Springer,Landscape Ecology,0921-2973,0921-2973,1572-9761,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s11104-016-3104-x,TRUE,Springer,Plant and Soil,0032-079X,0032-079X,1573-5036,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s11240-016-1111-5,TRUE,Springer,"Plant Cell, Tissue and Organ Culture (PCTOC)",0167-6857,0167-6857,1573-5044,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s11250-015-0992-3,TRUE,Springer,Tropical Animal Health and Production,0049-4747,0049-4747,1573-7438,NA,NA,TRUE,26779709,PMC4766211,NA,NA,FALSE
-slu,2016,2200,10.1007/s11250-016-1168-5,TRUE,Springer,Tropical Animal Health and Production,0049-4747,0049-4747,1573-7438,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27743146,PMC5203845,NA,NA,FALSE
-slu,2016,2200,10.1007/s11250-016-1197-0,TRUE,Springer,Tropical Animal Health and Production,0049-4747,0049-4747,1573-7438,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27966070,PMC5253150,NA,NA,FALSE
-slu,2016,2200,10.1007/s11273-016-9524-9,TRUE,Springer,Wetlands Ecology and Management,0923-4861,0923-4861,1572-9834,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s11295-016-0974-2,TRUE,Springer,Tree Genetics & Genomes,1614-2942,1614-2942,1614-2950,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s11295-016-1065-0,TRUE,Springer,Tree Genetics & Genomes,1614-2942,1614-2942,1614-2950,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s11295-016-1073-0,TRUE,Springer,Tree Genetics & Genomes,1614-2942,1614-2942,1614-2950,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s11306-016-1124-4,TRUE,Springer,Metabolomics,1573-3882,1573-3882,1573-3890,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s11540-016-9328-6,TRUE,Springer,Potato Research,0014-3065,0014-3065,1871-4528,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s11676-016-0306-2,TRUE,Springer,Journal of Forestry Research,1007-662X,1007-662X,1993-0607,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s11676-016-0307-1,TRUE,Springer,Journal of Forestry Research,1007-662X,1007-662X,1993-0607,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s11676-016-0341-z,TRUE,Springer,Journal of Forestry Research,1007-662X,1007-662X,1993-0607,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s11842-016-9359-5,TRUE,Springer,Small-scale Forestry,1873-7617,1873-7617,1873-7854,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s13277-016-5024-z,TRUE,Springer,Tumor Biology,1010-4283,1010-4283,1423-0380,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27079872,PMC5080325,NA,NA,FALSE
-slu,2016,2200,10.1007/s13280-016-0816-3,TRUE,Springer,Ambio,0044-7447,0044-7447,1654-7209,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27651268,PMC5274620,NA,NA,FALSE
-slu,2016,2200,10.1007/s13364-016-0301-1,TRUE,Springer,Mammal Research,2199-2401,2199-2401,2199-241X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s13592-015-0412-8,TRUE,Springer,Apidologie,0044-8435,0044-8435,1297-9678,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2200,10.1007/s13595-016-0590-1,TRUE,Springer,Annals of Forest Science,1286-4560,1286-4560,1297-966X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2210,10.1111/pbi.12550,TRUE,Wiley,Plant Biotechnology Journal,1467-7644,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26914183,PMC5069604,NA,NA,FALSE
-slu,2016,2235.94,10.3389/fimmu.2016.00368,FALSE,Frontiers,Frontiers in Immunology,1664-3224,NA,1664-3224,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,2254,10.1016/j.anireprosci.2016.12.002,TRUE,Elsevier,Animal Reproduction Science,0378-4320,0378-4320,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27939589,NA,NA,NA,FALSE
-slu,2016,232.02,10.3390/foods5040089,FALSE,MDPI,Foods,2304-8158,NA,2304-8158,NA,NA,TRUE,28231184,PMC5302432,NA,NA,TRUE
-slu,2016,2347.59,10.3389/fpls.2016.02032,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,NA,NA,TRUE,28119714,PMC5220066,NA,NA,TRUE
-slu,2016,2454.49,10.1016/j.biocon.2016.05.007,TRUE,Elsevier,Biological Conservation,0006-3207,0006-3207,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2454.49,10.1016/j.marpolbul.2016.01.050,TRUE,Elsevier,Marine Pollution Bulletin,0025-326X,0025-326X,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26856645,NA,NA,NA,FALSE
-slu,2016,2454.49,10.1016/j.scitotenv.2016.03.230,TRUE,Elsevier,Science of The Total Environment,0048-9697,0048-9697,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27096491,NA,NA,NA,FALSE
-slu,2016,2454.49,10.1016/j.scitotenv.2016.04.147,TRUE,Elsevier,Science of The Total Environment,0048-9697,0048-9697,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27177134,NA,NA,NA,FALSE
-slu,2016,2480.39,10.1016/j.geoderma.2016.06.024,TRUE,Elsevier,Geoderma,0016-7061,0016-7061,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2480.39,10.1016/j.geoderma.2016.06.026,TRUE,Elsevier,Geoderma,0016-7061,0016-7061,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2488,10.1071/RD15315,TRUE,CSIRO Publishing,"Reproduction, Fertility and Development",1031-3613,1031-3613,NA,NA,NA,TRUE,26922243,NA,NA,NA,FALSE
-slu,2016,2631.49,10.1111/1365-2664.12709,TRUE,Wiley,Journal of Applied Ecology,0021-8901,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2634.8,10.1111/1365-2664.12654,TRUE,Wiley,Journal of Applied Ecology,0021-8901,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2677.62,10.1016/j.apsoil.2016.05.011,TRUE,Elsevier,Applied Soil Ecology,0929-1393,0929-1393,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2677.62,10.1016/j.cropro.2016.04.003,TRUE,Elsevier,Crop Protection,0261-2194,0261-2194,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2677.62,10.1016/j.foodqual.2016.04.009,TRUE,Elsevier,Food Quality and Preference,0950-3293,0950-3293,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2704.79,10.1111/1365-2664.12719,TRUE,Wiley,Journal of Applied Ecology,0021-8901,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2704.79,10.1111/eff.12290,TRUE,Wiley,Ecology of Freshwater Fish,0906-6691,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2705.88,10.1016/j.ecss.2016.10.027,TRUE,Elsevier,"Estuarine, Coastal and Shelf Science",0272-7714,0272-7714,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2705.88,10.1016/j.forpol.2016.06.008,TRUE,Elsevier,Forest Policy and Economics,1389-9341,1389-9341,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2705.88,10.1016/j.funeco.2016.07.003,TRUE,Elsevier,Fungal Ecology,1754-5048,1754-5048,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2705.88,10.1016/j.scitotenv.2016.08.036,TRUE,Elsevier,Science of The Total Environment,0048-9697,0048-9697,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27639782,NA,NA,NA,FALSE
-slu,2016,2705.88,10.1016/j.soilbio.2016.08.006,TRUE,Elsevier,Soil Biology and Biochemistry,0038-0717,0038-0717,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2705.88,10.1016/j.wasman.2016.12.016,TRUE,Elsevier,Waste Management,0956-053X,0956-053X,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,28038908,NA,NA,NA,FALSE
-slu,2016,2765.22,10.1111/apm.12531,TRUE,Wiley,APMIS,0903-4641,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26991032,NA,NA,NA,FALSE
-slu,2016,2765.22,10.1890/14-2413,FALSE,Wiley,Ecological Applications,1051-0761,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27209794,NA,NA,NA,FALSE
-slu,2016,2976.47,10.1016/j.apenergy.2016.06.061,TRUE,Elsevier,Applied Energy,0306-2619,0306-2619,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,2976.47,10.1016/j.biombioe.2016.12.002,TRUE,Elsevier,Biomass and Bioenergy,0961-9534,0961-9534,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,3156.86,10.1016/j.watres.2015.06.051,TRUE,Elsevier,Water Research,0043-1354,0043-1354,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26250754,NA,NA,NA,FALSE
-slu,2016,3247.06,10.1016/j.cej.2016.06.107,TRUE,Elsevier,Chemical Engineering Journal,1385-8947,1385-8947,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,3247.06,10.1016/j.foreco.2016.06.028,TRUE,Elsevier,Forest Ecology and Management,0378-1127,0378-1127,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,3581.73,10.1111/mec.13797,TRUE,Wiley,Molecular Ecology,0962-1083,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27497431,PMC5054837,NA,NA,FALSE
-slu,2016,424.26,10.3389/fpls.2016.01999,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,NA,NA,TRUE,28105036,PMC5215382,NA,NA,TRUE
-slu,2016,446.27,10.1016/j.dib.2015.12.048,FALSE,Elsevier,Data in Brief,2352-3409,2352-3409,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26900591,PMC4716456,NA,NA,TRUE
-slu,2016,446.27,10.1016/j.dib.2016.04.029,FALSE,Elsevier,Data in Brief,2352-3409,2352-3409,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27366783,PMC4910185,NA,NA,TRUE
-slu,2016,566.99,10.3389/fevo.2016.00024,FALSE,Frontiers,Frontiers in Ecology and Evolution,2296-701X,NA,2296-701X,NA,NA,TRUE,NA,NA,NA,NA,TRUE
+slu,2015,1646.26,10.1186/s12864-015-1829-1,FALSE,BioMed Central,BMC Genomics,1471-2164,NA,1471-2164,1471-2164,NA,TRUE,26293353,PMC4546216,ut:000359764100001,NA,TRUE
+slu,2015,1646.26,10.1186/s12917-015-0447-0,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,NA,1746-6148,1746-6148,NA,TRUE,26054940,PMC4459679,ut:000356039600001,NA,TRUE
+slu,2015,1653.61,10.1186/s12870-015-0630-2,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,1471-2229,NA,TRUE,26458893,PMC4604075,ut:000362536200001,NA,TRUE
+slu,2015,1655.9,10.3168/jds.2014-9118,TRUE,American Dairy Science Association,Journal of Dairy Science,0022-0302,0022-0302,NA,0022-0302,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25771050,NA,ut:000353267900053,NA,FALSE
+slu,2015,1656,10.1186/s12870-015-0579-1,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,1471-2229,NA,TRUE,26253704,PMC4528408,ut:000359283000001,NA,TRUE
+slu,2015,1674.63,10.1186/s12864-015-1538-9,FALSE,BioMed Central,BMC Genomics,1471-2164,NA,1471-2164,1471-2164,NA,TRUE,25896169,PMC4404599,ut:000353186100001,NA,TRUE
+slu,2015,1680,10.1186/s13028-015-0122-2,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,26109477,PMC4489116,ut:000357250500001,NA,TRUE
+slu,2015,1703.62,10.3389/fevo.2015.00121,FALSE,Frontiers,Frontiers in Ecology and Evolution,2296-701X,NA,2296-701X,2296-701X,NA,TRUE,NA,NA,NA,NA,TRUE
+slu,2015,1712.11,10.1186/s13028-015-0103-5,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,0044-605X,NA,TRUE,25887040,PMC4359795,ut:000350857000001,NA,TRUE
+slu,2015,1714,10.1186/s12917-015-0352-6,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,1746-6148,NA,1746-6148,NA,TRUE,25886633,PMC4349773,ut:000350321300001,NA,TRUE
+slu,2015,1716.95,10.1186/s12859-015-0657-2,FALSE,BioMed Central,BMC Bioinformatics,1471-2105,NA,1471-2105,1471-2105,http://www.springer.com/tdm,TRUE,26224486,PMC4520095,ut:000358635700002,NA,TRUE
+slu,2015,1727.38,10.1186/s13028-015-0107-1,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,25884463,PMC4389305,ut:000352347400001,NA,TRUE
+slu,2015,1728.84,10.1186/s12862-015-0461-7,FALSE,BioMed Central,BMC Evolutionary Biology,1471-2148,NA,1471-2148,1471-2148,NA,TRUE,26376815,PMC4574262,ut:000361275800003,NA,TRUE
+slu,2015,1730,10.1186/s40066-015-0029-1,FALSE,BioMed Central,Agriculture & Food Security,2048-7010,NA,2048-7010,2048-7010,NA,TRUE,NA,NA,NA,NA,TRUE
+slu,2015,1764,10.1186/s13028-015-0124-0,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,26104188,PMC4491221,ut:000357454900001,NA,TRUE
+slu,2015,1794.58,10.3389/fpls.2015.01186,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,1664-462X,NA,TRUE,26779220,PMC4702147,NA,NA,TRUE
+slu,2015,1800,10.3920/CEP140024,TRUE,Wageningen Academic Publishers,Comparative Exercise Physiology,1755-2540,1755-2540,1755-2559,1755-2540,NA,TRUE,NA,NA,ut:000215103500005,NA,FALSE
+slu,2015,1800,10.3920/CEP150005,TRUE,Wageningen Academic Publishers,Comparative Exercise Physiology,1755-2540,1755-2540,1755-2559,1755-2540,NA,TRUE,NA,NA,ut:000215103600006,NA,FALSE
+slu,2015,1808.39,10.1186/s13002-015-0036-0,FALSE,BioMed Central,Journal of Ethnobiology and Ethnomedicine,1746-4269,NA,1746-4269,1746-4269,NA,TRUE,26077671,PMC4474580,ut:000356580900001,NA,TRUE
+slu,2015,1858.23,10.1186/s12866-015-0537-y,FALSE,BioMed Central,BMC Microbiology,1471-2180,NA,1471-2180,1471-2180,NA,TRUE,26458507,PMC4603578,ut:000362587100001,NA,TRUE
+slu,2015,1860.56,10.1111/jav.00623,TRUE,Wiley,Journal of Avian Biology,0908-8857,NA,NA,0908-8857,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000357949300001,NA,FALSE
+slu,2015,1978,10.1186/s13028-015-0101-7,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,1751-0147,NA,0044-605X,NA,TRUE,25884361,PMC4340676,ut:000349916300001,NA,TRUE
+slu,2015,1995.02,10.1186/s12915-015-0188-3,FALSE,BioMed Central,BMC Biology,1741-7007,NA,1741-7007,1741-7007,NA,TRUE,26377197,PMC4571119,ut:000361426900001,NA,TRUE
+slu,2015,1995.05,10.1016/j.anireprosci.2014.12.011,TRUE,Elsevier,Animal Reproduction Science,0378-4320,0378-4320,NA,0378-4320,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25576030,NA,ut:000349426400011,NA,FALSE
+slu,2015,2019.58,10.1371/journal.pgen.1005295,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,1553-7390,http://creativecommons.org/licenses/by/4.0/,TRUE,26086217,PMC4472357,ut:000357341600041,NA,TRUE
+slu,2015,2045.78,10.1371/journal.pgen.1005648,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,1553-7390,http://creativecommons.org/licenses/by/4.0/,TRUE,26599497,PMC4657900,ut:000366179000030,NA,TRUE
+slu,2015,2048.46,10.1186/s13059-015-0785-z,FALSE,BioMed Central,Genome Biology,1474-760X,NA,1474-760X,1474-7596,NA,TRUE,26438066,PMC4595211,ut:000362244800001,NA,TRUE
+slu,2015,2064.46,10.1105/tpc.114.132043,TRUE,American Society of Plant Biologists (ASPB),The Plant Cell Online,1040-4651,1040-4651,1532-298X,1040-4651,NA,TRUE,25681156,NA,ut:000350765300013,NA,FALSE
+slu,2015,2064.46,10.1105/tpc.114.134494,TRUE,American Society of Plant Biologists (ASPB),The Plant Cell,1040-4651,1040-4651,1532-298X,1040-4651,NA,TRUE,25736060,NA,ut:000354640200032,NA,FALSE
+slu,2015,2064.46,10.1105/tpc.114.132043,TRUE,American Society of Plant Biologists,NA,NA,NA,NA,NA,NA,FALSE,NA,NA,ut:000350765300013,NA,NA
+slu,2015,2064.46,10.1105/tpc.114.134494,TRUE,American Society of Plant Biologists,NA,NA,NA,NA,NA,NA,FALSE,NA,NA,ut:000354640200032,NA,NA
+slu,2015,2112,10.1186/s12917-015-0328-6,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,1746-6148,NA,1746-6148,NA,TRUE,25636335,PMC4318355,ut:000348822900001,NA,TRUE
+slu,2015,2125,10.1371/journal.pgen.1005541,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,1553-7390,http://creativecommons.org/licenses/by/4.0/,TRUE,26397943,PMC4580642,ut:000362269000052,NA,TRUE
+slu,2015,2130.83,10.1186/s13068-015-0328-6,FALSE,BioMed Central,Biotechnology for Biofuels,1754-6834,NA,1754-6834,1754-6834,NA,TRUE,26396592,PMC4578335,ut:000361587500003,NA,TRUE
+slu,2015,2200,10.1007/s00267-015-0613-y,TRUE,Springer,Environmental Management,0364-152X,0364-152X,1432-1009,0364-152X,NA,TRUE,26395184,PMC4712240,ut:000368638500001,NA,FALSE
+slu,2015,2200,10.1007/s00442-015-3326-2,TRUE,Springer,Oecologia,0029-8549,0029-8549,1432-1939,0029-8549,NA,TRUE,25943193,PMC4553151,ut:000360547000013,NA,FALSE
+slu,2015,2200,10.1007/s00442-015-3345-z,TRUE,Springer,Oecologia,0029-8549,0029-8549,1432-1939,0029-8549,NA,TRUE,26001605,PMC4568007,ut:000361472300021,NA,FALSE
+slu,2015,2200,10.1007/s10344-015-0968-7,TRUE,Springer,European Journal of Wildlife Research,1612-4642,1612-4642,1439-0574,1439-0574,NA,TRUE,NA,NA,ut:000362673800014,NA,FALSE
+slu,2015,2200,10.1007/s10530-015-0915-2,TRUE,Springer,Biological Invasions,1387-3547,1387-3547,1573-1464,1387-3547,NA,TRUE,NA,NA,ut:000361460300006,NA,FALSE
+slu,2015,2200,10.1007/s10661-015-4385-x,TRUE,Springer,Environmental Monitoring and Assessment,0167-6369,0167-6369,1573-2959,0167-6369,http://creativecommons.org/licenses/by/4.0,TRUE,25787168,PMC4365174,ut:000352113200016,NA,FALSE
+slu,2015,2200,10.1007/s10705-015-9712-7,TRUE,Springer,Nutrient Cycling in Agroecosystems,1385-1314,1385-1314,1573-0867,1385-1314,NA,TRUE,NA,NA,ut:000358166000007,NA,FALSE
+slu,2015,2200,10.1007/s10750-015-2605-6,TRUE,Springer,Hydrobiologia,0018-8158,0018-8158,1573-5117,0018-8158,NA,TRUE,NA,NA,ut:000371632800004,NA,FALSE
+slu,2015,2200,10.1007/s10818-015-9209-0,TRUE,Springer,Journal of Bioeconomics,1387-6996,1387-6996,1573-6989,1387-6996,NA,TRUE,NA,NA,NA,NA,FALSE
+slu,2015,2200,10.1007/s10980-015-0210-8,TRUE,Springer,Landscape Ecology,0921-2973,0921-2973,1572-9761,0921-2973,NA,TRUE,NA,NA,ut:000360673200013,NA,FALSE
+slu,2015,2200,10.1007/s10980-015-0246-9,TRUE,Springer,Landscape Ecology,0921-2973,0921-2973,1572-9761,0921-2973,NA,TRUE,NA,NA,ut:000372318900011,NA,FALSE
+slu,2015,2200,10.1007/s11104-015-2456-y,TRUE,Springer,Plant and Soil,0032-079X,0032-079X,1573-5036,0032-079X,NA,TRUE,NA,NA,ut:000355152300019,NA,FALSE
+slu,2015,2200,10.1007/s11250-015-0911-7,TRUE,Springer,Tropical Animal Health and Production,0049-4747,0049-4747,1573-7438,0049-4747,NA,TRUE,26374208,PMC4710656,ut:000369009100002,NA,FALSE
+slu,2015,2200,10.1007/s11306-015-0814-7,TRUE,Springer,Metabolomics,1573-3882,1573-3882,1573-3890,1573-3882,NA,TRUE,26491421,PMC4605972,ut:000363040600018,NA,FALSE
+slu,2015,2200,10.1007/s13165-014-0094-y,TRUE,Springer,Organic Agriculture,1879-4238,1879-4238,1879-4246,1879-4238,NA,TRUE,NA,NA,NA,NA,FALSE
+slu,2015,2200,10.1007/s13165-015-0125-3,TRUE,Springer,Organic Agriculture,1879-4238,1879-4238,1879-4246,1879-4238,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+slu,2015,2200,10.1007/s13280-015-0706-0,TRUE,Springer,Ambio,0044-7447,0044-7447,1654-7209,0044-7447,NA,TRUE,26508343,PMC4623861,ut:000363840100005,NA,FALSE
+slu,2015,2214.75,10.1016/j.ecocom.2015.04.001,TRUE,Elsevier,Ecological Complexity,1476-945X,1476-945X,NA,1476-945X,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000356196900019,NA,FALSE
+slu,2015,2214.75,10.1016/j.marpolbul.2015.02.010,TRUE,Elsevier,Marine Pollution Bulletin,0025-326X,0025-326X,NA,0025-326X,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25726066,NA,ut:000353733400024,NA,FALSE
+slu,2015,2214.75,10.1016/j.marpolbul.2015.04.033,TRUE,Elsevier,Marine Pollution Bulletin,0025-326X,0025-326X,NA,0025-326X,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26066862,NA,ut:000360417800059,NA,FALSE
+slu,2015,2214.75,10.1016/j.wasman.2015.02.009,TRUE,Elsevier,Waste Management,0956-053X,0956-053X,NA,0956-053X,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25728090,NA,ut:000354152300012,NA,FALSE
+slu,2015,2231.35,10.1016/j.fcr.2015.11.006,TRUE,Elsevier,Field Crops Research,0378-4290,0378-4290,NA,0378-4290,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000369200100010,NA,FALSE
+slu,2015,2241,10.1016/j.plantsci.2015.08.021,TRUE,Elsevier,Plant Science,0168-9452,0168-9452,NA,0168-9452,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26566822,NA,ut:000367106100004,NA,FALSE
+slu,2015,2241.55,10.1016/j.jveb.2015.05.004,TRUE,Elsevier,Journal of Veterinary Behavior: Clinical Applications and Research,1558-7878,1558-7878,NA,1558-7878,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000360648200008,NA,FALSE
+slu,2015,2255.33,10.1186/s13028-015-0135-x,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,26289447,PMC4545324,ut:000359766900001,NA,TRUE
+slu,2015,2303.34,10.1016/j.jchromb.2015.07.009,TRUE,Elsevier,Journal of Chromatography B,1570-0232,1570-0232,NA,1570-0232,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26218771,NA,ut:000359874700014,NA,FALSE
+slu,2015,2315.41,10.1080/02827581.2015.1028435,TRUE,Taylor & Francis,Scandinavian Journal of Forest Research,0282-7581,0282-7581,1651-1891,0282-7581,NA,TRUE,NA,NA,ut:000356500300004,NA,FALSE
+slu,2015,2331.26,10.1186/s40793-015-0092-z,FALSE,BioMed Central,Standards in Genomic Sciences,1944-3277,NA,1944-3277,1944-3277,NA,TRUE,26566424,PMC4642661,ut:000368002100005,NA,TRUE
+slu,2015,2337,10.1017/S1751731115000750,TRUE,Cambridge University Press (CUP),animal,1751-7311,1751-7311,1751-732X,1751-7311,NA,TRUE,25959256,PMC4762244,ut:000377121500013,NA,FALSE
+slu,2015,2369.93,10.1186/s12885-015-1073-8,FALSE,BioMed Central,BMC Cancer,1471-2407,NA,1471-2407,1471-2407,http://www.springer.com/tdm,TRUE,25881026,PMC4336758,ut:000349792900001,NA,TRUE
+slu,2015,2622.5,10.1111/1751-7915.12330,FALSE,Wiley,Microbial Biotechnology,1751-7915,NA,NA,1751-7915,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26686366,PMC4767286,ut:000371234500005,NA,TRUE
+slu,2015,2647,10.1080/02827581.2015.1046482,TRUE,Taylor & Francis,Scandinavian Journal of Forest Research,0282-7581,0282-7581,1651-1891,0282-7581,NA,TRUE,NA,NA,ut:000361601800011,NA,FALSE
+slu,2015,265.42,10.5539/jas.v7n11p28,FALSE,Canadian Center of Science and Education,Journal of Agricultural Science,1916-9760,1916-9752,1916-9760,1916-9752,NA,TRUE,NA,NA,NA,NA,FALSE
+slu,2015,2654.21,10.1111/age.12334,TRUE,Wiley,Animal Genetics,0268-9146,NA,NA,0268-9146,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26417640,PMC5054924,ut:000364704300010,NA,FALSE
+slu,2015,2654.21,10.1111/wre.12183,TRUE,Wiley,Weed Research,0043-1737,NA,NA,0043-1737,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000368590800005,NA,FALSE
+slu,2015,2668,10.2527/jas.2014-8598,TRUE,American Society of Animal Science (ASAS),Journal of Animal Science,1525-3163,NA,1525-3163,0021-8812,NA,TRUE,26020760,NA,NA,NA,FALSE
+slu,2015,2675.75,10.1111/evj.12446,TRUE,Wiley,Equine Veterinary Journal,0425-1644,NA,NA,0425-1644,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25808700,PMC5032979,ut:000373926100011,NA,FALSE
+slu,2015,2677.62,10.1016/j.vetimm.2015.10.002,TRUE,Elsevier,Veterinary Immunology and Immunopathology,0165-2427,0165-2427,NA,0165-2427,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26547884,NA,ut:000369772700015,NA,FALSE
+slu,2015,2686.72,10.1111/ppl.12397,TRUE,Wiley,Physiologia Plantarum,0031-9317,NA,NA,0031-9317,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000370171900001,NA,FALSE
+slu,2015,2689,10.1016/j.watres.2015.08.024,TRUE,Elsevier,Water Research,0043-1354,0043-1354,NA,0043-1354,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26342182,NA,ut:000363355700031,NA,FALSE
+slu,2015,2690,10.1016/j.tplants.2015.08.007,TRUE,Elsevier,Trends in Plant Science,1360-1385,1360-1385,NA,1360-1385,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26447042,NA,ut:000365371000005,NA,FALSE
+slu,2015,2692.78,10.1111/1744-7917.12233,TRUE,Wiley,Insect Science,1672-9609,NA,NA,1672-9609,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25959579,NA,ut:000390702100008,NA,FALSE
+slu,2015,2726,10.1136/vr.102960,TRUE,BMJ,Veterinary Record,0042-4900,0042-4900,2042-7670,0042-4900,NA,TRUE,26089352,PMC4518756,ut:000358591200021,NA,FALSE
+slu,2015,2744.2,10.1111/efp.12236,TRUE,Wiley,Forest Pathology,1437-4781,NA,NA,1437-4781,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000369152100010,NA,FALSE
+slu,2015,2747.67,10.1111/anti.12170,TRUE,Wiley,Antipode,0066-4812,NA,NA,0066-4812,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000370238200004,NA,FALSE
+slu,2015,2747.67,10.1111/een.12247,TRUE,Wiley,Ecological Entomology,0307-6946,NA,NA,0307-6946,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000360220600006,NA,FALSE
+slu,2015,2747.67,10.1111/nph.13536,TRUE,Wiley,New Phytologist,0028-646X,NA,NA,0028-646X,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26115363,PMC5034847,ut:000365393000010,NA,FALSE
+slu,2015,2790.85,10.1111/imb.12176,TRUE,Wiley,Insect Molecular Biology,0962-1075,NA,NA,0962-1075,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26033210,NA,ut:000357883500009,NA,FALSE
+slu,2015,2833.55,10.1111/jvs.12387,TRUE,Wiley,Journal of Vegetation Science,1100-9233,NA,NA,1100-9233,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000375147500007,NA,FALSE
+slu,2015,2945.38,10.1016/j.agee.2015.12.021,TRUE,Elsevier,"Agriculture, Ecosystems & Environment",0167-8809,0167-8809,NA,0167-8809,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000370100800017,NA,FALSE
+slu,2015,3134.5,10.1002/2015JG003190,TRUE,Wiley,Journal of Geophysical Research: Biogeosciences,2169-8953,NA,NA,2169-8953,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000368908700019,NA,FALSE
+slu,2015,3283.78,10.1111/gcb.12872,TRUE,Wiley,Global Change Biology,1354-1013,NA,NA,1354-1013,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25611952,NA,ut:000358485200014,NA,FALSE
+slu,2015,3305.81,10.3168/jds.2015-9755,TRUE,American Dairy Science Association,Journal of Dairy Science,0022-0302,0022-0302,NA,0022-0302,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26547638,NA,ut:000367214700054,NA,FALSE
+slu,2015,3365,10.1242/jeb.116798,TRUE,Company of Biologists,Journal of Experimental Biology,0022-0949,0022-0949,1477-9145,0022-0949,NA,TRUE,26056246,PMC4528704,ut:000359009100028,NA,FALSE
+slu,2015,428.93,10.3390/insects6010183,FALSE,MDPI,Insects,2075-4450,NA,2075-4450,2075-4450,NA,TRUE,26463074,PMC4553537,NA,NA,TRUE
+slu,2015,566,10.1155/2015/610391,FALSE,Hindawi Publishing Corporation,International Journal of Biodiversity,2314-4149,2314-4149,2314-4157,2314-4149,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,NA,NA,TRUE
+slu,2015,575,10.3389/fpls.2015.00130,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,1664-462X,NA,TRUE,25806038,PMC4353180,ut:000350970300001,NA,TRUE
+slu,2015,612.5,10.3389/fgene.2015.00044,FALSE,Frontiers,Frontiers in Genetics,1664-8021,NA,1664-8021,1664-8021,NA,TRUE,25741364,PMC4330917,ut:000352759800001,NA,TRUE
+slu,2015,669.4,10.1016/j.gecco.2015.10.009,FALSE,Elsevier,Global Ecology and Conservation,2351-9894,2351-9894,NA,2351-9894,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,TRUE
+slu,2015,748.37,10.3390/su7021142,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,2071-1050,NA,TRUE,NA,NA,ut:000350217700003,NA,TRUE
+slu,2015,750,10.5194/bg-13-1119-2016,FALSE,Copernicus Publications,Biogeosciences,1726-4189,NA,1726-4189,1726-4170,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000372082200015,NA,TRUE
+slu,2015,768,10.3389/fevo.2015.00131,FALSE,Frontiers,Frontiers in Ecology and Evolution,2296-701X,NA,2296-701X,2296-701X,NA,TRUE,NA,NA,NA,NA,TRUE
+slu,2015,770,10.3389/fevo.2015.00056,FALSE,Frontiers,Frontiers in Ecology and Evolution,2296-701X,NA,2296-701X,2296-701X,NA,TRUE,NA,NA,NA,NA,TRUE
+slu,2015,784.56,10.3389/fpls.2015.00970,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,1664-462X,NA,TRUE,26579190,PMC4630563,ut:000364581000001,NA,TRUE
+slu,2015,803,10.1186/s40064-015-1285-z,FALSE,BioMed Central,SpringerPlus,2193-1801,NA,2193-1801,2193-1801,NA,TRUE,26380165,PMC4565800,ut:000361011900001,NA,FALSE
+slu,2015,814,10.3389/fpls.2015.00279,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,1664-462X,NA,TRUE,25983736,PMC4416443,ut:000356899600001,NA,TRUE
+slu,2015,826.95,10.3390/f6124384,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000367531900012,NA,TRUE
+slu,2015,862.04,10.3390/f6041145,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000353775500015,NA,TRUE
+slu,2015,870,10.5194/bg-12-3241-2015,FALSE,Copernicus Publications,Biogeosciences,1726-4189,NA,1726-4189,1726-4170,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000356179800006,NA,TRUE
+slu,2015,870,10.5194/bg-13-1-2016,FALSE,Copernicus Publications,Biogeosciences,1726-4189,NA,1726-4189,1726-4170,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000369524000001,NA,TRUE
+slu,2015,889,10.1111/jvim.13815,FALSE,Wiley,Journal of Veterinary Internal Medicine,0891-6640,NA,NA,0891-6640,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26683136,PMC4913634,ut:000368808800012,NA,FALSE
+slu,2015,889,10.1111/jvim.13829,FALSE,Wiley,Journal of Veterinary Internal Medicine,0891-6640,NA,NA,0891-6640,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26812988,PMC4913606,ut:000372981500010,NA,FALSE
+slu,2015,917.11,10.3390/f6114001,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000365704000011,NA,TRUE
+slu,2015,922.32,10.3390/f6103594,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000364230800012,NA,TRUE
+slu,2015,946.74,10.3390/f6082785,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000360319200015,NA,TRUE
+slu,2015,946.74,10.3390/f6092982,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000362558500005,NA,TRUE
+slu,2015,960,10.3389/fgene.2015.00049,FALSE,Frontiers,Frontiers in Genetics,1664-8021,NA,1664-8021,1664-8021,NA,TRUE,25750652,PMC4335173,ut:000352760600001,NA,TRUE
+slu,2015,981.79,10.1016/j.foodpol.2015.10.008,TRUE,Elsevier,Food Policy,0306-9192,0306-9192,NA,0306-9192,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000369212500001,NA,FALSE
+slu,2015,981.79,10.1016/j.foodpol.2015.11.002,TRUE,Elsevier,Food Policy,0306-9192,0306-9192,NA,0306-9192,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000369212500002,NA,FALSE
+slu,2016,1062.79,10.3390/su8090865,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,2071-1050,NA,TRUE,NA,NA,ut:000385529400037,NA,TRUE
+slu,2016,1082.35,10.1016/j.atmosenv.2016.08.033,TRUE,Elsevier,Atmospheric Environment,1352-2310,1352-2310,NA,1352-2310,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000388051700023,NA,FALSE
+slu,2016,1104,10.3390/su8040340,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,2071-1050,NA,TRUE,NA,NA,ut:000375155800050,NA,TRUE
+slu,2016,1164.5,10.1186/s12863-015-0261-5,FALSE,BioMed Central,BMC Genetics,1471-2156,NA,1471-2156,1471-2156,NA,TRUE,26286720,PMC4541747,ut:000359699000001,NA,TRUE
+slu,2016,1165,10.1038/srep21895,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,26900083,PMC4761999,ut:000370517500001,NA,TRUE
+slu,2016,1165,10.1038/srep21930,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,26908158,PMC4764941,ut:000370742000001,NA,TRUE
+slu,2016,1165,10.1038/srep22806,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,26960555,PMC4785398,ut:000371684600001,NA,TRUE
+slu,2016,1165,10.1038/srep23198,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,26979573,PMC4793264,ut:000372055500001,NA,TRUE
+slu,2016,1165,10.1038/srep23518,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,27006164,PMC4804390,ut:000372607900001,NA,TRUE
+slu,2016,1165,10.1038/srep28498,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,27346604,PMC4921962,ut:000378519800001,NA,TRUE
+slu,2016,1165,10.1038/srep31314,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,27499001,PMC4976314,ut:000381009400001,NA,TRUE
+slu,2016,1165,10.1038/srep37930,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,27901056,PMC5128813,ut:000388806400001,NA,TRUE
+slu,2016,1165,10.1038/srep39208,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,27966627,PMC5155301,ut:000389741100001,NA,TRUE
+slu,2016,1178.36,10.1186/s12711-016-0219-8,FALSE,BioMed Central,Genetics Selection Evolution,1297-9686,NA,1297-9686,0999-193X,NA,TRUE,27286957,PMC4901500,ut:000378486600002,NA,TRUE
+slu,2016,1203,10.1002/ecs2.1257,FALSE,Wiley,Ecosphere,2150-8925,NA,NA,2150-8925,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000374896800020,NA,TRUE
+slu,2016,1203,10.1002/ecs2.1583,FALSE,Wiley,Ecosphere,2150-8925,NA,NA,2150-8925,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000392207600030,NA,TRUE
+slu,2016,1222,10.1111/jvim.13830,FALSE,Wiley,Journal of Veterinary Internal Medicine,0891-6640,NA,NA,0891-6640,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26822126,PMC4913616,ut:000372981500011,NA,FALSE
+slu,2016,1224,10.1002/ece3.2032,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27217946,PMC4863019,ut:000376149400027,NA,TRUE
+slu,2016,1224,10.1002/ece3.2279,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27547341,PMC4983578,ut:000381578400005,NA,TRUE
+slu,2016,1224,10.1002/ece3.2597,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28070296,PMC5216661,ut:000392069500027,NA,TRUE
+slu,2016,1224,10.1002/ece3.2601,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28070299,PMC5216679,ut:000392069500030,NA,TRUE
+slu,2016,1228.64,10.1371/journal.pone.0166510,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27846312,PMC5113013,ut:000387794600073,NA,TRUE
+slu,2016,123.57,10.5897/JEN2016.0159,FALSE,Academic Journals,Journal of Entomology and Nematology,2006-9855,NA,2006-9855,2006-9855,NA,TRUE,NA,NA,NA,NA,FALSE
+slu,2016,1234.34,10.1371/journal.pone.0147004,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26799558,PMC4723141,ut:000368655300052,NA,TRUE
+slu,2016,1234.34,10.1371/journal.pone.0147791,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26840533,PMC4739691,ut:000369550200059,NA,TRUE
+slu,2016,1237.47,10.1371/journal.pone.0148960,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26866480,PMC4750853,ut:000370050700048,NA,TRUE
+slu,2016,1262.25,10.1186/s13028-016-0191-x,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,26829925,PMC4736141,ut:000369127400001,NA,TRUE
+slu,2016,1279.91,10.3389/fimmu.2016.00247,FALSE,Frontiers,Frontiers in Immunology,1664-3224,NA,1664-3224,1664-3224,NA,TRUE,27446077,PMC4917549,ut:000378377600001,NA,TRUE
+slu,2016,1299.8,10.1186/s13071-016-1897-3,FALSE,BioMed Central,Parasites & Vectors,1756-3305,NA,1756-3305,1756-3305,NA,TRUE,27899131,PMC5129611,ut:000388902800004,NA,TRUE
+slu,2016,1311,10.1371/journal.pone.0156151,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27223472,PMC4880347,ut:000376881700066,NA,TRUE
+slu,2016,1311.36,10.1371/journal.pone.0155541,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27171471,PMC4865114,ut:000376588600050,NA,TRUE
+slu,2016,1311.36,10.1371/journal.pone.0157136,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27270445,PMC4896472,ut:000377561000066,NA,TRUE
+slu,2016,1313.01,10.1371/journal.pone.0152966,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27070818,PMC4829256,ut:000373900700023,NA,TRUE
+slu,2016,1313.01,10.1371/journal.pone.0155137,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27223473,PMC4880312,ut:000376881700016,NA,TRUE
+slu,2016,1315.75,10.1155/2016/3841803,FALSE,Hindawi Publishing Corporation,Oxidative Medicine and Cellular Longevity,1942-0900,1942-0900,1942-0994,1942-0994,http://creativecommons.org/licenses/by/4.0/,TRUE,27429708,PMC4939354,ut:000379477800001,NA,TRUE
+slu,2016,1337.72,10.1371/journal.pone.0165742,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27828995,PMC5102373,ut:000387724300057,NA,TRUE
+slu,2016,1338,10.1371/journal.pone.0161346,FALSE,BioMed Central,PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27584666,PMC5008833,ut:000382855600022,NA,TRUE
+slu,2016,1338.67,10.1371/journal.pone.0162086,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27580120,PMC5007034,ut:000382877400057,NA,TRUE
+slu,2016,1338.81,10.1016/j.jfe.2016.04.002,TRUE,Elsevier,Journal of Forest Economics,1104-6899,1104-6899,NA,1104-6899,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000396377500006,NA,FALSE
+slu,2016,1338.81,10.1016/j.ufug.2015.04.003,TRUE,Elsevier,Urban Forestry & Urban Greening,1618-8667,1618-8667,NA,1610-8167,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000357146400024,NA,FALSE
+slu,2016,1338.81,10.1016/j.ufug.2016.04.012,TRUE,Elsevier,Urban Forestry & Urban Greening,1618-8667,1618-8667,NA,1610-8167,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000384913600021,NA,FALSE
+slu,2016,1342.46,10.1371/journal.pone.0162751,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27682810,PMC5040392,ut:000384171400022,NA,TRUE
+slu,2016,1342.79,10.1371/journal.pone.0157972,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27333328,PMC4917106,ut:000378212800062,NA,TRUE
+slu,2016,1342.79,10.1371/journal.pone.0157977,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27322387,PMC4913902,ut:000378212000058,NA,TRUE
+slu,2016,1347.89,10.1371/journal.pone.0160334,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27479078,PMC4968819,ut:000381110300041,NA,TRUE
+slu,2016,1350,10.5194/hess-20-2811-2016,FALSE,Copernicus Publications,Hydrology and Earth System Sciences,1607-7938,NA,1607-7938,1027-5606,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000381101700001,NA,TRUE
+slu,2016,1350.21,10.1186/s12917-016-0924-0,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,NA,1746-6148,1746-6148,NA,TRUE,28056957,PMC5217653,ut:000391626500009,NA,TRUE
+slu,2016,1352.94,10.1016/j.ufug.2016.08.012,TRUE,Elsevier,Urban Forestry & Urban Greening,1618-8667,1618-8667,NA,1610-8167,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000391471000012,NA,FALSE
+slu,2016,1352.94,10.1016/j.ufug.2016.12.006,TRUE,Elsevier,Urban Forestry & Urban Greening,1618-8667,1618-8667,NA,1610-8167,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000397054000024,NA,FALSE
+slu,2016,1360.61,10.1371/journal.pone.0166520,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27851830,PMC5113046,ut:000387909300060,NA,TRUE
+slu,2016,1360.61,10.1371/journal.pone.0166863,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27907010,PMC5131951,ut:000389482700045,NA,TRUE
+slu,2016,1366,10.1371/journal.pone.0148896,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26859145,PMC4747562,ut:000370038400101,NA,TRUE
+slu,2016,1376,10.1371/journal.pone.0151904,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27028005,PMC4814071,ut:000373116500032,NA,TRUE
+slu,2016,1376.06,10.1371/journal.pone.0150870,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26986618,PMC4795764,ut:000372580300032,NA,TRUE
+slu,2016,1376.06,10.1371/journal.pone.0151481,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26982708,PMC4794121,ut:000372574900088,NA,TRUE
+slu,2016,1376.06,10.1371/journal.pone.0151969,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27002525,PMC4803345,ut:000372697400062,NA,TRUE
+slu,2016,1377,10.1002/ece3.2076,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27096081,PMC4829048,ut:000376646700011,NA,TRUE
+slu,2016,1378,10.1371/journal.pone.0149594,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26938257,PMC4777320,ut:000371735200029,NA,TRUE
+slu,2016,1408.19,10.1186/s40793-016-0199-x,FALSE,BioMed Central,Standards in Genomic Sciences,1944-3277,NA,1944-3277,1944-3277,NA,TRUE,NA,NA,ut:000385317700003,NA,TRUE
+slu,2016,1408.19,10.1186/s41065-016-0014-0,FALSE,BioMed Central,Hereditas,1601-5223,NA,1601-5223,0018-0661,NA,TRUE,28096772,PMC5226105,ut:000383771200001,NA,TRUE
+slu,2016,1409.5,10.1371/journal.pone.0167964,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27936149,PMC5148084,ut:000389587100241,NA,TRUE
+slu,2016,1409.5,10.1371/journal.pone.0168776,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28002449,PMC5176316,ut:000392853100067,NA,TRUE
+slu,2016,1416.62,10.3389/fpubh.2016.00098,FALSE,Frontiers,Frontiers in Public Health,2296-2565,NA,2296-2565,2296-2565,NA,TRUE,27242990,PMC4871859,ut:000408278400002,NA,TRUE
+slu,2016,1428.09,10.1186/s13742-016-0132-7,FALSE,Oxford University Press (OUP),GigaScience,2047-217X,NA,2047-217X,2047-217X,NA,TRUE,27267963,PMC4897895,ut:000377153700001,NA,TRUE
+slu,2016,1435.1,10.1186/s12864-016-2458-z,FALSE,BioMed Central,BMC Genomics,1471-2164,NA,1471-2164,1471-2164,NA,TRUE,26887814,PMC4758094,ut:000370225400001,NA,TRUE
+slu,2016,1435.69,10.1186/s12870-016-0952-8,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,1471-2229,NA,TRUE,28061815,PMC5219727,ut:000393335700003,NA,TRUE
+slu,2016,1439.65,10.1186/s41065-016-0011-3,FALSE,BioMed Central,Hereditas,1601-5223,NA,1601-5223,0018-0661,NA,TRUE,28096769,PMC5226109,ut:000378866600001,NA,TRUE
+slu,2016,1450.57,10.3389/fpubh.2016.00137,FALSE,Frontiers,Frontiers in Public Health,2296-2565,NA,2296-2565,2296-2565,NA,TRUE,27446901,PMC4923150,ut:000408313300001,NA,TRUE
+slu,2016,1456.76,10.3390/ijms17101673,FALSE,MDPI,International Journal of Molecular Sciences,1422-0067,NA,1422-0067,1422-0067,NA,TRUE,NA,NA,ut:000387768300107,NA,TRUE
+slu,2016,1478.67,10.3390/rs8090724,FALSE,MDPI,Remote Sensing,2072-4292,NA,2072-4292,2072-4292,NA,TRUE,NA,NA,ut:000385488000034,NA,TRUE
+slu,2016,1478.67,10.3390/rs8090736,FALSE,MDPI,Remote Sensing,2072-4292,NA,2072-4292,2072-4292,NA,TRUE,NA,NA,ut:000385488000046,NA,TRUE
+slu,2016,1484,10.3390/ijerph13121229,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,1660-4601,NA,TRUE,NA,NA,ut:000389571900056,NA,TRUE
+slu,2016,1487,10.1186/s13028-016-0261-0,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,NA,NA,ut:000388328200001,NA,TRUE
+slu,2016,1495.39,10.1186/s12936-016-1656-0,FALSE,BioMed Central,Malaria Journal,1475-2875,NA,1475-2875,1475-2875,NA,TRUE,28114992,PMC5259891,ut:000392761600002,NA,TRUE
+slu,2016,1496.36,10.1186/s12917-016-0743-3,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,NA,1746-6148,1746-6148,NA,TRUE,27329086,PMC4915148,ut:000378314400003,NA,TRUE
+slu,2016,1500,10.1016/j.gecco.2016.09.005,FALSE,Elsevier,Global Ecology and Conservation,2351-9894,2351-9894,NA,2351-9894,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,TRUE
+slu,2016,1503.75,10.1002/ecs2.1541,FALSE,Wiley,Ecosphere,2150-8925,NA,NA,2150-8925,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000392207600031,NA,TRUE
+slu,2016,1512,10.1186/s12865-016-0155-y,FALSE,BioMed Central,BMC Immunology,1471-2172,NA,1471-2172,1471-2172,NA,TRUE,27267469,PMC4897876,ut:000379305000001,NA,TRUE
+slu,2016,1512.87,10.1186/1297-9686-44-31,FALSE,BioMed Central,Genetics Selection Evolution,1297-9686,1297-9686,NA,0999-193X,NA,TRUE,23110538,PMC3524047,ut:000312987900001,NA,TRUE
+slu,2016,1514.11,10.1186/s13028-016-0257-9,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,NA,NA,ut:000388328200003,NA,TRUE
+slu,2016,1530,10.1002/ece3.2003,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27099712,PMC4831447,ut:000374052000022,NA,TRUE
+slu,2016,1530.61,10.1186/s12870-016-0706-7,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,1471-2229,NA,TRUE,26786587,PMC4719685,ut:000368417000001,NA,TRUE
+slu,2016,1530.61,10.1186/s12889-015-2574-8,FALSE,BioMed Central,BMC Public Health,1471-2458,NA,1471-2458,1471-2458,http://www.springer.com/tdm,TRUE,26654879,PMC4676886,ut:000366551200001,NA,TRUE
+slu,2016,1555.74,10.1186/s12936-016-1386-3,FALSE,BioMed Central,Malaria Journal,1475-2875,NA,1475-2875,1475-2875,NA,TRUE,27439360,PMC4955153,ut:000385528400001,NA,TRUE
+slu,2016,1559.03,10.1186/s12864-016-2561-1,FALSE,BioMed Central,BMC Genomics,1471-2164,NA,1471-2164,1471-2164,NA,TRUE,26988094,PMC4794925,ut:000372567700002,NA,TRUE
+slu,2016,1560.61,10.1186/s12868-016-0258-7,FALSE,BioMed Central,BMC Neuroscience,1471-2202,NA,1471-2202,1471-2202,NA,TRUE,27246183,PMC4888552,ut:000376956600001,NA,TRUE
+slu,2016,1561.95,10.1016/j.ijppaw.2016.03.001,FALSE,Elsevier,International Journal for Parasitology: Parasites and Wildlife,2213-2244,2213-2244,NA,2213-2244,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27054089,PMC4804384,NA,NA,TRUE
+slu,2016,1576.36,10.1186/s13028-016-0266-8,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,NA,NA,ut:000390051100001,NA,TRUE
+slu,2016,1578,10.1016/j.ijpddr.2016.06.004,FALSE,Elsevier,International Journal for Parasitology: Drugs and Drug Resistance,2211-3207,2211-3207,NA,2211-3207,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27380550,PMC4933035,ut:000393046300001,NA,TRUE
+slu,2016,1588,10.1186/s12917-016-0868-4,FALSE,BioMed Central,BMC Veterinary Research,1746-6148,NA,1746-6148,1746-6148,NA,TRUE,27793205,PMC5084410,ut:000386297800001,NA,TRUE
+slu,2016,1594.89,10.1186/s12936-016-1308-4,FALSE,BioMed Central,Malaria Journal,1475-2875,NA,1475-2875,1475-2875,NA,TRUE,27142303,PMC4855760,ut:000375344800002,NA,TRUE
+slu,2016,1606.57,10.1016/j.landusepol.2016.05.001,TRUE,Elsevier,Land Use Policy,0264-8377,0264-8377,NA,0264-8377,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000379557000016,NA,FALSE
+slu,2016,1606.57,10.1016/j.molbiopara.2016.02.004,TRUE,Elsevier,Molecular and Biochemical Parasitology,0166-6851,0166-6851,NA,0166-6851,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26880419,NA,ut:000375498600004,NA,FALSE
+slu,2016,1617,10.1136/vetreco-2016-000173,FALSE,BMJ,Veterinary Record Open,2052-6113,NA,2052-6113,2052-6113,NA,TRUE,27547424,PMC4964167,NA,NA,TRUE
+slu,2016,1623.53,10.1016/j.landusepol.2016.09.016,TRUE,Elsevier,Land Use Policy,0264-8377,0264-8377,NA,0264-8377,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000387519600037,NA,FALSE
+slu,2016,1623.53,10.1016/j.ppees.2016.09.005,TRUE,Elsevier,"Perspectives in Plant Ecology, Evolution and Systematics",1433-8319,1433-8319,NA,1433-8319,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000392562200002,NA,FALSE
+slu,2016,1623.98,10.1186/s40575-015-0029-2,FALSE,BioMed Central,Canine Genetics and Epidemiology,2052-6687,NA,2052-6687,2052-6687,NA,TRUE,26457193,PMC4599337,NA,NA,TRUE
+slu,2016,1639.86,10.1186/s13028-016-0217-4,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,27245578,PMC4888634,ut:000378588400001,NA,TRUE
+slu,2016,1639.86,10.1186/s13028-016-0263-y,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,NA,NA,ut:000388328600001,NA,TRUE
+slu,2016,1639.86,10.1186/s13028-016-0265-9,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,28031036,PMC5192580,ut:000391892500001,NA,TRUE
+slu,2016,1646.46,10.1186/s12870-016-0939-5,FALSE,BioMed Central,BMC Plant Biology,1471-2229,NA,1471-2229,1471-2229,NA,TRUE,27863470,PMC5116219,ut:000389481700001,NA,TRUE
+slu,2016,1653.86,10.1186/s13068-016-0543-9,FALSE,BioMed Central,Biotechnology for Biofuels,1754-6834,NA,1754-6834,1754-6834,NA,TRUE,27330562,PMC4912747,ut:000378870600001,NA,TRUE
+slu,2016,1656.24,10.3390/molecules21040372,FALSE,MDPI,Molecules,1420-3049,NA,1420-3049,1420-3049,NA,TRUE,27043500,NA,ut:000375155000005,NA,TRUE
+slu,2016,1658.17,10.3390/s16111950,FALSE,MDPI,Sensors,1424-8220,NA,1424-8220,1424-8220,NA,TRUE,NA,NA,ut:000389641700183,NA,TRUE
+slu,2016,1661,10.1186/s13028-015-0178-z,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,26655039,PMC4676829,ut:000366682500001,NA,TRUE
+slu,2016,1667.47,10.1186/s13028-016-0274-8,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,28049540,PMC5210291,ut:000391892700001,NA,TRUE
+slu,2016,1686.22,10.1186/s13028-016-0213-8,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,27207437,PMC4875734,ut:000376369700001,NA,TRUE
+slu,2016,1701.32,10.3389/fvets.2016.00057,FALSE,Frontiers,Frontiers in Veterinary Science,2297-1769,NA,2297-1769,2297-1769,NA,TRUE,27500137,PMC4956668,NA,NA,TRUE
+slu,2016,1729.2,10.3389/fbioe.2016.00089,FALSE,Frontiers,Frontiers in Bioengineering and Biotechnology,2296-4185,NA,2296-4185,2296-4185,NA,TRUE,28066762,PMC5165279,NA,NA,TRUE
+slu,2016,1737,10.3389/fevo.2015.00155,FALSE,Frontiers,Frontiers in Ecology and Evolution,2296-701X,NA,2296-701X,2296-701X,NA,TRUE,NA,NA,NA,NA,TRUE
+slu,2016,1748.84,10.3389/fgene.2016.00057,FALSE,Frontiers,Frontiers in Genetics,1664-8021,NA,1664-8021,1664-8021,NA,TRUE,27148354,PMC4832587,ut:000374515000001,NA,TRUE
+slu,2016,1748.84,10.3389/fvets.2016.00031,FALSE,Frontiers,Frontiers in Veterinary Science,2297-1769,NA,2297-1769,2297-1769,NA,TRUE,27148545,PMC4831202,NA,NA,TRUE
+slu,2016,1781,10.1186/s13028-016-0236-1,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,NA,NA,ut:000383946500001,NA,TRUE
+slu,2016,1802.53,10.1186/s12863-015-0304-y,FALSE,BioMed Central,BMC Genetics,1471-2156,NA,1471-2156,1471-2156,NA,TRUE,26706685,PMC4691297,ut:000367134100001,NA,TRUE
+slu,2016,1816.38,10.1186/s13068-016-0454-9,FALSE,BioMed Central,Biotechnology for Biofuels,1754-6834,NA,1754-6834,1754-6834,NA,TRUE,26925165,PMC4769498,ut:000370942100002,NA,TRUE
+slu,2016,1823,10.1111/gcbb.12373,FALSE,Wiley,GCB Bioenergy,1757-1693,NA,NA,1757-1693,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000390216800016,NA,FALSE
+slu,2016,1823,10.1111/gcbb.12399,FALSE,Wiley,GCB Bioenergy,1757-1693,NA,NA,1757-1693,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000402742500011,NA,FALSE
+slu,2016,1858.85,10.3389/fpls.2016.00654,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,1664-462X,NA,TRUE,27242855,PMC4870230,NA,NA,TRUE
+slu,2016,1881.94,10.1186/s13750-016-0080-9,FALSE,BioMed Central,Environmental Evidence,2047-2382,NA,2047-2382,2047-2382,NA,TRUE,NA,NA,NA,NA,TRUE
+slu,2016,1912,10.1002/ece3.2594,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28070294,PMC5216668,ut:000392069500025,NA,TRUE
+slu,2016,1912,10.1002/ece3.2598,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,28035275,PMC5192942,ut:000392063300019,NA,TRUE
+slu,2016,1935.14,10.1093/nar/gkx087,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,0305-1048,NA,TRUE,28175342,PMC5389543,ut:000398376200035,NA,TRUE
+slu,2016,1976.1,10.1371/journal.pgen.1005924,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,1553-7390,http://creativecommons.org/licenses/by/4.0/,TRUE,27100965,PMC4839602,ut:000375231900007,NA,TRUE
+slu,2016,2000.46,10.1186/s13068-016-0640-9,FALSE,BioMed Central,Biotechnology for Biofuels,1754-6834,NA,1754-6834,1754-6834,NA,TRUE,27800015,PMC5078929,ut:000386092900001,NA,TRUE
+slu,2016,2020.43,10.1371/journal.pntd.0005043,FALSE,Public Library of Science (PLoS),PLOS Neglected Tropical Diseases,1935-2735,NA,1935-2735,1935-2727,http://creativecommons.org/licenses/by/4.0/,TRUE,27768698,PMC5074459,ut:000386676200031,NA,TRUE
+slu,2016,2087.34,10.1186/s13071-016-1503-8,FALSE,BioMed Central,Parasites & Vectors,1756-3305,NA,1756-3305,1756-3305,NA,TRUE,27094215,PMC4837528,ut:000375038700001,NA,TRUE
+slu,2016,2132,10.1017/S0024282916000359,TRUE,Cambridge University Press (CUP),The Lichenologist,0024-2829,0024-2829,1096-1135,0024-2829,NA,TRUE,NA,NA,ut:000385656500010,NA,FALSE
+slu,2016,2200,10.1007/s00227-016-2977-9,TRUE,Springer,Marine Biology,0025-3162,0025-3162,1432-1793,0025-3162,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000386356100005,NA,FALSE
+slu,2016,2200,10.1007/s00299-016-2062-3,TRUE,Springer,Plant Cell Reports,0721-7714,0721-7714,1432-203X,0721-7714,http://creativecommons.org/licenses/by/4.0,TRUE,27699473,PMC5206254,ut:000391396000008,NA,FALSE
+slu,2016,2200,10.1007/s00334-016-0586-7,TRUE,Springer,Vegetation History and Archaeobotany,0939-6314,0939-6314,1617-6278,0939-6314,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000398929000001,NA,FALSE
+slu,2016,2200,10.1007/s00425-016-2580-9,TRUE,Springer,Planta,0032-0935,0032-0935,1432-2048,0032-0935,http://creativecommons.org/licenses/by/4.0,TRUE,27541497,PMC5226999,ut:000392420500002,NA,FALSE
+slu,2016,2200,10.1007/s00442-016-3742-y,TRUE,Springer,Oecologia,0029-8549,0029-8549,1432-1939,0029-8549,http://creativecommons.org/licenses/by/4.0,TRUE,27718064,PMC5239808,ut:000392391300006,NA,FALSE
+slu,2016,2200,10.1007/s00449-016-1726-2,TRUE,Springer,Bioprocess and Biosystems Engineering,1615-7591,1615-7591,1615-7605,1615-7591,http://creativecommons.org/licenses/by/4.0,TRUE,28025700,NA,ut:000398725800013,NA,FALSE
+slu,2016,2200,10.1007/s00468-016-1495-1,TRUE,Springer,Trees,0931-1890,0931-1890,1432-2285,0931-1890,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000398106900020,NA,FALSE
+slu,2016,2200,10.1007/s10342-016-0981-8,TRUE,Springer,European Journal of Forest Research,1612-4669,1612-4669,1612-4677,1612-4669,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000384571700008,NA,FALSE
+slu,2016,2200,10.1007/s10531-016-1217-4,TRUE,Springer,Biodiversity and Conservation,0960-3115,0960-3115,1572-9710,0960-3115,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000387715100009,NA,FALSE
+slu,2016,2200,10.1007/s10533-016-0266-9,TRUE,Springer,Biogeochemistry,0168-2563,0168-2563,1573-515X,0168-2563,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000391423500006,NA,FALSE
+slu,2016,2200,10.1007/s10669-016-9605-6,TRUE,Springer,Environment Systems and Decisions,2194-5403,2194-5403,2194-5411,2194-5411,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+slu,2016,2200,10.1007/s10695-016-0297-0,TRUE,Springer,Fish Physiology and Biochemistry,0920-1742,0920-1742,1573-5168,0920-1742,http://creativecommons.org/licenses/by/4.0,TRUE,27677483,NA,ut:000399017500011,NA,FALSE
+slu,2016,2200,10.1007/s10811-016-0950-0,TRUE,Springer,Journal of Applied Phycology,0921-8971,0921-8971,1573-5176,0921-8971,http://creativecommons.org/licenses/by/4.0,TRUE,28344390,PMC5346144,ut:000396344800024,NA,FALSE
+slu,2016,2200,10.1007/s10886-016-0753-4,TRUE,Springer,Journal of Chemical Ecology,0098-0331,0098-0331,1573-1561,0098-0331,http://creativecommons.org/licenses/by/4.0,TRUE,27624066,PMC5101348,ut:000387605500002,NA,FALSE
+slu,2016,2200,10.1007/s10980-016-0434-2,TRUE,Springer,Landscape Ecology,0921-2973,0921-2973,1572-9761,0921-2973,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392301500013,NA,FALSE
+slu,2016,2200,10.1007/s11104-016-3104-x,TRUE,Springer,Plant and Soil,0032-079X,0032-079X,1573-5036,0032-079X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000399742000008,NA,FALSE
+slu,2016,2200,10.1007/s11240-016-1111-5,TRUE,Springer,"Plant Cell, Tissue and Organ Culture (PCTOC)",0167-6857,0167-6857,1573-5044,0167-6857,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000393748500007,NA,FALSE
+slu,2016,2200,10.1007/s11250-015-0992-3,TRUE,Springer,Tropical Animal Health and Production,0049-4747,0049-4747,1573-7438,0049-4747,NA,TRUE,26779709,PMC4766211,ut:000371160800012,NA,FALSE
+slu,2016,2200,10.1007/s11250-016-1168-5,TRUE,Springer,Tropical Animal Health and Production,0049-4747,0049-4747,1573-7438,0049-4747,http://creativecommons.org/licenses/by/4.0,TRUE,27743146,PMC5203845,ut:000391393000015,NA,FALSE
+slu,2016,2200,10.1007/s11250-016-1197-0,TRUE,Springer,Tropical Animal Health and Production,0049-4747,0049-4747,1573-7438,0049-4747,http://creativecommons.org/licenses/by/4.0,TRUE,27966070,PMC5253150,ut:000393122200015,NA,FALSE
+slu,2016,2200,10.1007/s11273-016-9524-9,TRUE,Springer,Wetlands Ecology and Management,0923-4861,0923-4861,1572-9834,0923-4861,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000406288200003,NA,FALSE
+slu,2016,2200,10.1007/s11295-016-0974-2,TRUE,Springer,Tree Genetics & Genomes,1614-2942,1614-2942,1614-2950,1614-2942,NA,TRUE,NA,NA,ut:000372272300004,NA,FALSE
+slu,2016,2200,10.1007/s11295-016-1065-0,TRUE,Springer,Tree Genetics & Genomes,1614-2942,1614-2942,1614-2950,1614-2942,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000397238800023,NA,FALSE
+slu,2016,2200,10.1007/s11295-016-1073-0,TRUE,Springer,Tree Genetics & Genomes,1614-2942,1614-2942,1614-2950,1614-2942,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000397238800010,NA,FALSE
+slu,2016,2200,10.1007/s11306-016-1124-4,TRUE,Springer,Metabolomics,1573-3882,1573-3882,1573-3890,1573-3882,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000385356700012,NA,FALSE
+slu,2016,2200,10.1007/s11540-016-9328-6,TRUE,Springer,Potato Research,0014-3065,0014-3065,1871-4528,0014-3065,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388171000006,NA,FALSE
+slu,2016,2200,10.1007/s11676-016-0306-2,TRUE,Springer,Journal of Forestry Research,1007-662X,1007-662X,1993-0607,1007-662X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000395076000002,NA,FALSE
+slu,2016,2200,10.1007/s11676-016-0307-1,TRUE,Springer,Journal of Forestry Research,1007-662X,1007-662X,1993-0607,1007-662X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000399164900013,NA,FALSE
+slu,2016,2200,10.1007/s11676-016-0341-z,TRUE,Springer,Journal of Forestry Research,1007-662X,1007-662X,1993-0607,1007-662X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000399164900002,NA,FALSE
+slu,2016,2200,10.1007/s11842-016-9359-5,TRUE,Springer,Small-scale Forestry,1873-7617,1873-7617,1873-7854,1873-7617,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000401258600008,NA,FALSE
+slu,2016,2200,10.1007/s13277-016-5024-z,TRUE,Springer,Tumor Biology,1010-4283,1010-4283,1423-0380,1010-4283,http://creativecommons.org/licenses/by/4.0,TRUE,27079872,PMC5080325,ut:000387075400037,NA,FALSE
+slu,2016,2200,10.1007/s13280-016-0816-3,TRUE,Springer,Ambio,0044-7447,0044-7447,1654-7209,0044-7447,http://creativecommons.org/licenses/by/4.0,TRUE,27651268,PMC5274620,ut:000395124300002,NA,FALSE
+slu,2016,2200,10.1007/s13364-016-0301-1,TRUE,Springer,Mammal Research,2199-2401,2199-2401,2199-241X,2199-241X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392323900001,NA,FALSE
+slu,2016,2200,10.1007/s13592-015-0412-8,TRUE,Springer,Apidologie,0044-8435,0044-8435,1297-9678,0044-8435,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000379000100010,NA,FALSE
+slu,2016,2200,10.1007/s13595-016-0590-1,TRUE,Springer,Annals of Forest Science,1286-4560,1286-4560,1297-966X,1286-4560,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000390004000010,NA,FALSE
+slu,2016,2210,10.1111/pbi.12550,TRUE,Wiley,Plant Biotechnology Journal,1467-7644,NA,NA,1467-7644,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26914183,PMC5069604,ut:000383626600009,NA,FALSE
+slu,2016,2235.94,10.3389/fimmu.2016.00368,FALSE,Frontiers,Frontiers in Immunology,1664-3224,NA,1664-3224,1664-3224,NA,TRUE,NA,NA,ut:000383683000001,NA,TRUE
+slu,2016,2254,10.1016/j.anireprosci.2016.12.002,TRUE,Elsevier,Animal Reproduction Science,0378-4320,0378-4320,NA,0378-4320,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27939589,NA,ut:000393267800002,NA,FALSE
+slu,2016,232.02,10.3390/foods5040089,FALSE,MDPI,Foods,2304-8158,NA,2304-8158,2304-8158,NA,TRUE,28231184,PMC5302432,ut:000392383800011,NA,TRUE
+slu,2016,2347.59,10.3389/fpls.2016.02032,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,1664-462X,NA,TRUE,28119714,PMC5220066,ut:000391335700002,NA,TRUE
+slu,2016,2454.49,10.1016/j.biocon.2016.05.007,TRUE,Elsevier,Biological Conservation,0006-3207,0006-3207,NA,0006-3207,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000379559600016,NA,FALSE
+slu,2016,2454.49,10.1016/j.marpolbul.2016.01.050,TRUE,Elsevier,Marine Pollution Bulletin,0025-326X,0025-326X,NA,0025-326X,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26856645,NA,ut:000374198100028,NA,FALSE
+slu,2016,2454.49,10.1016/j.scitotenv.2016.03.230,TRUE,Elsevier,Science of The Total Environment,0048-9697,0048-9697,NA,0048-9697,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27096491,NA,ut:000375137100013,NA,FALSE
+slu,2016,2454.49,10.1016/j.scitotenv.2016.04.147,TRUE,Elsevier,Science of The Total Environment,0048-9697,0048-9697,NA,0048-9697,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27177134,NA,ut:000378206300026,NA,FALSE
+slu,2016,2480.39,10.1016/j.geoderma.2016.06.024,TRUE,Elsevier,Geoderma,0016-7061,0016-7061,NA,0016-7061,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000381544000007,NA,FALSE
+slu,2016,2480.39,10.1016/j.geoderma.2016.06.026,TRUE,Elsevier,Geoderma,0016-7061,0016-7061,NA,0016-7061,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000390632000007,NA,FALSE
+slu,2016,2488,10.1071/RD15315,TRUE,CSIRO Publishing,"Reproduction, Fertility and Development",1031-3613,1031-3613,NA,1031-3613,NA,TRUE,26922243,NA,ut:000399309500004,NA,FALSE
+slu,2016,2631.49,10.1111/1365-2664.12709,TRUE,Wiley,Journal of Applied Ecology,0021-8901,NA,NA,0021-8901,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000387768800019,NA,FALSE
+slu,2016,2634.8,10.1111/1365-2664.12654,TRUE,Wiley,Journal of Applied Ecology,0021-8901,NA,NA,0021-8901,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000380065600018,NA,FALSE
+slu,2016,2677.62,10.1016/j.apsoil.2016.05.011,TRUE,Elsevier,Applied Soil Ecology,0929-1393,0929-1393,NA,0929-1393,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000384860400006,NA,FALSE
+slu,2016,2677.62,10.1016/j.cropro.2016.04.003,TRUE,Elsevier,Crop Protection,0261-2194,0261-2194,NA,0261-2194,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000377310400006,NA,FALSE
+slu,2016,2677.62,10.1016/j.foodqual.2016.04.009,TRUE,Elsevier,Food Quality and Preference,0950-3293,0950-3293,NA,0950-3293,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000377739000017,NA,FALSE
+slu,2016,2704.79,10.1111/1365-2664.12719,TRUE,Wiley,Journal of Applied Ecology,0021-8901,NA,NA,0021-8901,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000397930300023,NA,FALSE
+slu,2016,2704.79,10.1111/eff.12290,TRUE,Wiley,Ecology of Freshwater Fish,0906-6691,NA,NA,0906-6691,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,NA,NA,FALSE
+slu,2016,2705.88,10.1016/j.ecss.2016.10.027,TRUE,Elsevier,"Estuarine, Coastal and Shelf Science",0272-7714,0272-7714,NA,0272-7714,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000390726900006,NA,FALSE
+slu,2016,2705.88,10.1016/j.forpol.2016.06.008,TRUE,Elsevier,Forest Policy and Economics,1389-9341,1389-9341,NA,1389-9341,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000381534100016,NA,FALSE
+slu,2016,2705.88,10.1016/j.funeco.2016.07.003,TRUE,Elsevier,Fungal Ecology,1754-5048,1754-5048,NA,1878-0083,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000384786900012,NA,FALSE
+slu,2016,2705.88,10.1016/j.scitotenv.2016.08.036,TRUE,Elsevier,Science of The Total Environment,0048-9697,0048-9697,NA,0048-9697,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27639782,NA,ut:000389090100121,NA,FALSE
+slu,2016,2705.88,10.1016/j.soilbio.2016.08.006,TRUE,Elsevier,Soil Biology and Biochemistry,0038-0717,0038-0717,NA,0038-0717,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000388775400006,NA,FALSE
+slu,2016,2705.88,10.1016/j.wasman.2016.12.016,TRUE,Elsevier,Waste Management,0956-053X,0956-053X,NA,0956-053X,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,28038908,NA,NA,NA,FALSE
+slu,2016,2765.22,10.1111/apm.12531,TRUE,Wiley,APMIS,0903-4641,NA,NA,0903-4641,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26991032,NA,ut:000376602800010,NA,FALSE
+slu,2016,2765.22,10.1890/14-2413,FALSE,Wiley,Ecological Applications,1051-0761,NA,NA,1051-0761,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27209794,NA,ut:000374118700018,NA,FALSE
+slu,2016,2976.47,10.1016/j.apenergy.2016.06.061,TRUE,Elsevier,Applied Energy,0306-2619,0306-2619,NA,0306-2619,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000383291800011,NA,FALSE
+slu,2016,2976.47,10.1016/j.biombioe.2016.12.002,TRUE,Elsevier,Biomass and Bioenergy,0961-9534,0961-9534,NA,0961-9534,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000393527300004,NA,FALSE
+slu,2016,3156.86,10.1016/j.watres.2015.06.051,TRUE,Elsevier,Water Research,0043-1354,0043-1354,NA,0043-1354,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26250754,NA,ut:000376786100013,NA,FALSE
+slu,2016,3247.06,10.1016/j.cej.2016.06.107,TRUE,Elsevier,Chemical Engineering Journal,1385-8947,1385-8947,NA,1385-8947,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000384777200051,NA,FALSE
+slu,2016,3247.06,10.1016/j.foreco.2016.06.028,TRUE,Elsevier,Forest Ecology and Management,0378-1127,0378-1127,NA,0378-1127,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000389163500002,NA,FALSE
+slu,2016,3581.73,10.1111/mec.13797,TRUE,Wiley,Molecular Ecology,0962-1083,NA,NA,0962-1083,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27497431,PMC5054837,ut:000384810000005,NA,FALSE
+slu,2016,424.26,10.3389/fpls.2016.01999,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,1664-462X,NA,TRUE,28105036,PMC5215382,ut:000391328000001,NA,TRUE
+slu,2016,446.27,10.1016/j.dib.2015.12.048,FALSE,Elsevier,Data in Brief,2352-3409,2352-3409,NA,2352-3409,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26900591,PMC4716456,NA,NA,TRUE
+slu,2016,446.27,10.1016/j.dib.2016.04.029,FALSE,Elsevier,Data in Brief,2352-3409,2352-3409,NA,2352-3409,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27366783,PMC4910185,NA,NA,TRUE
+slu,2016,566.99,10.3389/fevo.2016.00024,FALSE,Frontiers,Frontiers in Ecology and Evolution,2296-701X,NA,2296-701X,2296-701X,NA,TRUE,NA,NA,NA,NA,TRUE
 slu,2016,662.73,10.4172/Antimicro.1000107,FALSE,OMICS Publishing Group,NA,NA,NA,NA,NA,NA,FALSE,NA,NA,NA,NA,NA
-slu,2016,787.56,10.3390/f7100233,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,811.94,10.3390/f7010008,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,827.25,10.1186/s13104-016-2193-1,FALSE,BioMed Central,BMC Research Notes,1756-0500,NA,1756-0500,NA,NA,TRUE,27484122,PMC4969733,NA,NA,TRUE
-slu,2016,886.23,10.1186/s40064-016-3288-9,FALSE,Springer,SpringerPlus,2193-1801,NA,2193-1801,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-slu,2016,900.17,10.1186/s40064-016-2831-z,FALSE,Springer,SpringerPlus,2193-1801,NA,2193-1801,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27512633,PMC4960079,NA,NA,FALSE
-slu,2016,901.96,10.1016/j.aqrep.2016.12.003,FALSE,Elsevier,Aquaculture Reports,2352-5134,2352-5134,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,902.15,10.3390/f7030061,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,910.48,10.3390/f7090206,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,910.48,10.3390/f7090207,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,914.33,10.1371/journal.pone.0147796,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26820846,PMC4731209,NA,NA,TRUE
-slu,2016,914.33,10.3389/fpls.2016.00119,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,NA,NA,TRUE,26904081,PMC4746258,NA,NA,TRUE
-slu,2016,914.54,10.3390/f7050100,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-slu,2016,932,10.1038/srep35958,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,27775050,PMC5075900,NA,NA,TRUE
-su,2012,2630,10.1080/08920753.2012.727738,TRUE,Taylor & Francis,Coastal Management,0892-0753,0892-0753,1521-0421,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2013,2132,10.1080/17449626.2013.773180,TRUE,Taylor & Francis,Journal of Global Ethics,1744-9626,1744-9626,1744-9634,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2013,2429,10.1080/16506073.2013.809141,TRUE,Taylor & Francis,Cognitive Behaviour Therapy,1650-6073,1650-6073,1651-2316,NA,NA,TRUE,23898817,PMC3869050,NA,NA,FALSE
-su,2013,2429,10.1080/19371918.2013.776320,TRUE,Taylor & Francis,Social Work in Public Health,1937-1918,1937-1918,1937-190X,NA,NA,TRUE,24405195,PMC3919150,NA,NA,FALSE
-su,2014,1769,10.5194/acp-15-2545-2015,FALSE,Copernicus Publications,Atmospheric Chemistry and Physics,1680-7324,NA,1680-7324,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://www.atmos-chem-phys.net/15/2545/2015/acp-15-2545-2015.pdf,TRUE
-su,2014,2429,10.1080/16506073.2014.939593,TRUE,Taylor & Francis,Cognitive Behaviour Therapy,1650-6073,1650-6073,1651-2316,NA,NA,TRUE,25204370,PMC4260663,NA,NA,FALSE
-su,2014,755,10.1159/000369132,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,NA,NA,TRUE,25759713,PMC4282043,NA,NA,TRUE
-su,2015,1169,10.1080/23311940.2015.1058465,FALSE,Taylor & Francis,Cogent Physics,2331-1940,NA,2331-1940,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-su,2015,1530,10.1002/ece3.1773,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27069602,PMC4813107,NA,http://onlinelibrary.wiley.com/doi/10.1002/ece3.1773/full,TRUE
-su,2015,1686,10.3389/fpsyg.2015.00944,FALSE,Frontiers,Frontiers in Psychology,1664-1078,NA,1664-1078,NA,NA,TRUE,26191035,PMC4488603,NA,http://journal.frontiersin.org/article/10.3389/fpsyg.2015.00944/full,TRUE
-su,2015,2230,10.1136/jech-2014-205058,TRUE,BMJ,Journal of Epidemiology and Community Health,0143-005X,0143-005X,1470-2738,NA,NA,TRUE,25922471,PMC4516006,NA,http://jech.bmj.com/content/69/8/769.full,FALSE
-su,2015,2429,10.1080/00268976.2014.1003985,TRUE,Taylor & Francis,Molecular Physics,0026-8976,0026-8976,1362-3028,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2015,787,10.1186/s40488-015-0031-y,FALSE,Springer,Journal of Statistical Distributions and Applications,2195-5832,NA,2195-5832,NA,NA,TRUE,NA,NA,NA,http://jsdajournal.springeropen.com/articles/10.1186/s40488-015-0031-y,TRUE
-su,2016,0,10.1080/20004508.2016.1275187,FALSE,Taylor & Francis,Education Inquiry,2000-4508,NA,2000-4508,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-su,2016,1007.31,10.5751/ES-08368-210140,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,1708-3087,NA,NA,TRUE,NA,NA,NA,http://www.ecologyandsociety.org/vol21/iss1/art40/,TRUE
-su,2016,1008.99,10.5751/ES-08812-210425,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,1708-3087,NA,NA,TRUE,NA,NA,NA,http://www.ecologyandsociety.org/vol21/iss4/art25/,TRUE
-su,2016,1012.25,10.3390/w8120572,FALSE,MDPI,Water,2073-4441,NA,2073-4441,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-su,2016,1022.82,10.5751/ES-09051-220128,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,NA,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-su,2016,1065,10.1093/nar/gkw356,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,NA,NA,TRUE,27151197,PMC4987909,NA,NA,TRUE
-su,2016,1065,10.1093/nar/gkw849,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,NA,NA,TRUE,27664219,PMC5314790,NA,NA,TRUE
-su,2016,1065,10.1093/nar/gkw923,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,NA,NA,TRUE,27742821,PMC5210627,NA,NA,TRUE
-su,2016,1071,10.1016/j.childyouth.2016.05.011,TRUE,Elsevier,Children and Youth Services Review,0190-7409,0190-7409,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S0190740916301554,FALSE
-su,2016,1080,10.5194/nhess-16-1571-2016,TRUE,Copernicus Publications,Natural Hazards and Earth System Sciences,1684-9981,NA,1684-9981,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,NA,TRUE
-su,2016,1103.7,10.5751/ES-08605-210316,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,1708-3087,NA,NA,TRUE,NA,NA,NA,http://www.ecologyandsociety.org/vol21/iss3/art16/,TRUE
-su,2016,1120,10.1002/ece3.2536,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,2045-7758,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28031795,PMC5167037,NA,http://onlinelibrary.wiley.com/doi/10.1002/ece3.2536/full,TRUE
-su,2016,1138,10.1108/JFMM-04-2016-0033,TRUE,Emerald,Journal of Fashion Marketing and Management,1361-2026,1361-2026,NA,NA,http://www.emeraldinsight.com/page/tdm,TRUE,NA,NA,NA,http://www.emeraldinsight.com/doi/full/10.1108/JFMM-04-2016-0033,FALSE
-su,2016,1165,10.1038/srep21203,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,26883070,PMC4756319,NA,NA,TRUE
-su,2016,1165,10.1038/srep26620,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,27197757,PMC4873736,NA,NA,TRUE
-su,2016,1165,10.1038/srep27749,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,NA,NA,TRUE,27324057,PMC4914976,NA,NA,TRUE
-su,2016,1165,10.1038/srep33509,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,NA,http://www.springer.com/tdm,TRUE,27698390,PMC5048106,NA,NA,TRUE
-su,2016,1165,10.1038/srep34098,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,NA,NA,TRUE,27682138,PMC5040959,NA,NA,TRUE
-su,2016,1165,10.1038/srep36243,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,NA,NA,TRUE,27805056,PMC5090251,NA,NA,TRUE
-su,2016,1165,10.1038/srep38821,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,NA,NA,TRUE,27958327,PMC5153840,NA,NA,TRUE
-su,2016,1173,10.1016/j.childyouth.2016.09.021,TRUE,Elsevier,Children and Youth Services Review,0190-7409,0190-7409,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S0190740916303000,FALSE
-su,2016,1180,10.1186/s12911-016-0309-0,FALSE,BioMed Central,BMC Medical Informatics and Decision Making,1472-6947,NA,1472-6947,NA,NA,TRUE,27459846,PMC4965720,NA,https://bmcmedinformdecismak.biomedcentral.com/articles/10.1186/s12911-016-0309-0,TRUE
-su,2016,1180,10.1186/s12911-016-0311-6,FALSE,BioMed Central,BMC Medical Informatics and Decision Making,1472-6947,NA,1472-6947,NA,NA,TRUE,27459993,PMC4965710,NA,http://bmcmedinformdecismak.biomedcentral.com/articles/10.1186/s12911-016-0311-6,TRUE
-su,2016,1197.07,10.5751/ES-08920-220102,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,1708-3087,NA,NA,TRUE,NA,NA,NA,http://www.ecologyandsociety.org/vol22/iss1/art2/,TRUE
-su,2016,1200.74,10.1136/bmjopen-2015-009440,FALSE,BMJ,BMJ Open,2044-6055,2044-6055,2044-6055,NA,NA,TRUE,27113233,PMC4853986,NA,NA,TRUE
-su,2016,1224,10.1002/ece3.2310,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,2045-7758,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27547340,PMC4983577,NA,http://onlinelibrary.wiley.com/doi/10.1002/ece3.2310/full,TRUE
-su,2016,1239,10.1371/journal.pone.0147924,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,26820737,PMC4731055,NA,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0147924,TRUE
-su,2016,1260,10.5194/gmd-9-2741-2016,FALSE,Copernicus Publications,Geoscientific Model Development,1991-9603,1991-959X,1991-9603,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://www.geosci-model-dev.net/9/2741/2016/,TRUE
-su,2016,1261.35,10.1371/journal.pone.0163091,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27732600,PMC5061329,NA,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0163091,TRUE
-su,2016,1284.87,10.1371/journal.pone.0155295,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27223898,PMC4880328,NA,NA,TRUE
-su,2016,1285.2,10.5194/acp-16-15135-2016,FALSE,Copernicus Publications,Atmospheric Chemistry and Physics,1680-7324,NA,1680-7324,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,NA,TRUE
-su,2016,1308,10.5751/ES-08826-220114,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,NA,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-su,2016,1312.12,10.3390/rs8020140,FALSE,MDPI,Remote Sensing,2072-4292,NA,2072-4292,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-su,2016,1330,10.1163/24056480-00104001,TRUE,Brill Academic Publishers,Journal of World Literature,2405-6472,2405-6472,2405-6480,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,1365,10.1371/journal.pone.0156855,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27253326,PMC4890767,NA,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0156855,TRUE
-su,2016,1379,10.1142/S1363919616400132,TRUE,World Scientific Publishing,International Journal of Innovation Management,1363-9196,1363-9196,1757-5877,NA,NA,TRUE,NA,NA,NA,http://www.worldscientific.com/doi/10.1142/S1363919616400132,FALSE
-su,2016,1397.6,10.1371/journal.pone.0151993,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,NA,TRUE,26998832,PMC4801336,NA,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0151993,TRUE
-su,2016,1397.6,10.1371/journal.pone.0152745,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,NA,TRUE,27030968,PMC4816578,NA,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0152745,TRUE
-su,2016,1397.6,10.1371/journal.pone.0158326,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,NA,TRUE,27410261,PMC4943737,NA,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0158326,TRUE
-su,2016,1397.6,10.1371/journal.pone.0159684,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27434640,PMC4951072,NA,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0159684,TRUE
-su,2016,1397.6,10.1371/journal.pone.0164241,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27788154,PMC5082882,NA,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0164241,TRUE
-su,2016,1398,10.1038/srep30469,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,NA,NA,TRUE,27461918,PMC4962034,NA,NA,TRUE
-su,2016,1398,10.1038/srep32446,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,NA,NA,TRUE,27573668,PMC5004158,NA,NA,TRUE
-su,2016,1398.91,10.1021/jacs.6b09240,TRUE,American Chemical Society (ACS),Journal of the American Chemical Society,0002-7863,0002-7863,1520-5126,NA,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,NA,NA,NA,http://pubs.acs.org/doi/full/10.1021/jacs.6b09240,FALSE
-su,2016,1399,10.1186/s12889-016-3685-6,FALSE,BioMed Central,BMC Public Health,1471-2458,NA,1471-2458,NA,NA,TRUE,NA,NA,NA,https://bmcpublichealth.biomedcentral.com/articles/10.1186/s12889-016-3685-6,TRUE
-su,2016,1400.27,10.1021/acs.accounts.6b00050,TRUE,American Chemical Society (ACS),Accounts of Chemical Research,0001-4842,0001-4842,1520-4898,NA,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,27082700,NA,NA,http://pubs.acs.org/doi/full/10.1021/acs.accounts.6b00050,FALSE
-su,2016,1404,10.1371/journal.pone.0156570,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,NA,TRUE,27300292,PMC4907435,NA,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0156570,TRUE
-su,2016,1405.96,10.1021/acscatal.6b01562,TRUE,American Chemical Society (ACS),ACS Catalysis,2155-5435,2155-5435,2155-5435,NA,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,NA,NA,NA,http://pubs.acs.org/doi/full/10.1021/acscatal.6b01562,FALSE
-su,2016,1406.02,10.3390/ijerph13030249,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,NA,NA,TRUE,26927139,PMC4808912,NA,NA,TRUE
-su,2016,1407,10.1371/journal.pone.0164611,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27727314,PMC5058505,NA,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0164611,TRUE
-su,2016,1412.55,10.1371/journal.pone.0165799,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27832117,PMC5104468,NA,NA,TRUE
-su,2016,1415.64,10.1371/journal.pone.0154099,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,NA,TRUE,27101307,PMC4839650,NA,NA,TRUE
-su,2016,1415.64,10.1371/journal.pone.0155063,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27176452,PMC4866784,NA,NA,TRUE
-su,2016,1415.64,10.1371/journal.pone.0155836,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,NA,TRUE,27196748,PMC4873139,NA,NA,TRUE
-su,2016,1415.64,10.1371/journal.pone.0167493,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27936111,PMC5147920,NA,NA,TRUE
-su,2016,1415.64,10.1371/journal.pone.0169276,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,28036376,PMC5201274,NA,NA,TRUE
-su,2016,1418.18,10.1021/acscatal.6b02842,TRUE,American Chemical Society (ACS),ACS Catalysis,2155-5435,2155-5435,2155-5435,NA,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,NA,NA,NA,NA,FALSE
-su,2016,1420.51,10.1098/rsob.160152,FALSE,The Royal Society,Open Biology,2046-2441,NA,2046-2441,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-su,2016,1423.31,10.1371/journal.pone.0163476,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27695120,PMC5047452,NA,NA,TRUE
-su,2016,1423.31,10.1371/journal.pone.0166066,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27902694,PMC5130257,NA,NA,TRUE
-su,2016,1423.31,10.1371/journal.pone.0168357,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27992585,PMC5161503,NA,NA,TRUE
-su,2016,1424,10.1002/ece3.2067,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,2045-7758,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27217940,PMC4863005,NA,http://onlinelibrary.wiley.com/doi/10.1002/ece3.2067/full,TRUE
-su,2016,1439.5,10.1186/s13195-016-0231-9,FALSE,BioMed Central,Alzheimer's Research & Therapy,1758-9193,NA,1758-9193,NA,NA,TRUE,28137305,PMC5282900,NA,NA,TRUE
-su,2016,1500,10.1002/iid3.115,FALSE,Wiley,"Immunity, Inflammation and Disease",2050-4527,NA,2050-4527,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27621814,PMC5004286,NA,http://onlinelibrary.wiley.com/doi/10.1002/iid3.115/full,TRUE
-su,2016,1500,10.5271/sjweh.3610,TRUE,Nordic Association of Occupational Safety and Health (NOROSH),Scandinavian Journal of Work Environment and Health,0355-3140,0355-3140,1795-990X,NA,NA,TRUE,27942734,NA,NA,NA,FALSE
-su,2016,1530,10.5194/acp-16-6577-2016,TRUE,Copernicus Publications,Atmospheric Chemistry and Physics,1680-7324,NA,1680-7324,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,NA,TRUE
-su,2016,1533,10.1016/j.npep.2016.08.008,TRUE,Elsevier,Neuropeptides,0143-4179,0143-4179,1532-2785,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27592409,NA,NA,http://www.sciencedirect.com/science/article/pii/S0143417916300427,FALSE
-su,2016,1550,10.3354/meps11592,TRUE,Inter-Research Science Center,Marine Ecology Progress Series,0171-8630,0171-8630,1616-1599,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,1607,10.1016/j.avb.2016.02.006,TRUE,Elsevier,Aggression and Violent Behavior,1359-1789,1359-1789,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1359178916300064,FALSE
-su,2016,1620,10.5194/bg-13-6121-2016,FALSE,Copernicus Publications,Biogeosciences,1726-4189,1726-4170,1726-4189,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://www.biogeosciences.net/13/6121/2016/,TRUE
-su,2016,1642.5,10.1002/2016EF000434,FALSE,Wiley,Earth's Future,2328-4277,NA,2328-4277,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,http://onlinelibrary.wiley.com/doi/10.1002/2016EF000434/full,TRUE
-su,2016,1725,10.5194/acp-16-10941-2016,FALSE,Copernicus Publications,Atmospheric Chemistry and Physics,1680-7324,1680-7316,1680-7324,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://www.atmos-chem-phys.net/16/10941/2016/,TRUE
-su,2016,1727,10.1136/jech-2015-206547,TRUE,BMJ,Journal of Epidemiology and Community Health,0143-005X,0143-005X,1470-2738,NA,NA,TRUE,26733672,PMC4893147,NA,http://jech.bmj.com/content/70/6/569.full,FALSE
-su,2016,1740,10.3389/fnagi.2016.00034,FALSE,Frontiers,Frontiers in Aging Neuroscience,1663-4365,NA,1663-4365,NA,NA,TRUE,26973509,PMC4773588,NA,http://journal.frontiersin.org/article/10.3389/fnagi.2016.00034/full,TRUE
-su,2016,1750,10.1002/ange.201605999,TRUE,Wiley,Angewandte Chemie,0044-8249,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,NA,FALSE
-su,2016,1758.82,10.1016/j.concog.2016.06.012,TRUE,Elsevier,Consciousness and Cognition,1053-8100,1053-8100,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27351780,NA,NA,NA,FALSE
-su,2016,1773,10.1144/M46.118,TRUE,Geological Society of London,"Geological Society, London, Memoirs",0435-4052,0435-4052,2041-4722,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,1773,10.1144/M46.182,TRUE,Geological Society of London,"Geological Society, London, Memoirs",0435-4052,0435-4052,2041-4722,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,1773,10.1144/M46.183,TRUE,Geological Society of London,"Geological Society, London, Memoirs",0435-4052,0435-4052,2041-4722,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,1798,10.3389/fnins.2016.00007,FALSE,Frontiers,Frontiers in Neuroscience,1662-453X,NA,1662-453X,NA,NA,TRUE,26834534,PMC4718990,NA,NA,TRUE
-su,2016,1806.96,10.3389/fevo.2016.00134,FALSE,Frontiers,Frontiers in Ecology and Evolution,2296-701X,NA,2296-701X,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-su,2016,1806.96,10.3389/fimmu.2016.00096,FALSE,Frontiers,Frontiers in Immunology,1664-3224,NA,1664-3224,NA,NA,TRUE,27014275,PMC4794487,NA,NA,TRUE
-su,2016,1806.96,10.3389/fmicb.2016.01043,FALSE,Frontiers,Frontiers in Microbiology,1664-302X,NA,1664-302X,NA,NA,TRUE,27458440,PMC4933709,NA,NA,TRUE
-su,2016,1806.96,10.3389/fphys.2016.00068,FALSE,Frontiers,Frontiers in Physiology,1664-042X,NA,1664-042X,NA,NA,TRUE,26973536,PMC4770038,NA,NA,TRUE
-su,2016,1820.7,10.5194/bg-13-5003-2016,FALSE,Copernicus Publications,Biogeosciences,1726-4189,1726-4170,1726-4189,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://www.biogeosciences.net/13/5003/2016/,TRUE
-su,2016,1867,10.1016/j.atmosenv.2016.05.041,TRUE,Elsevier,Atmospheric Environment,1352-2310,1352-2310,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S1352231016303880,FALSE
-su,2016,1874.16,10.1021/acs.jced.6b00196,TRUE,American Chemical Society (ACS),Journal of Chemical & Engineering Data,0021-9568,0021-9568,1520-5134,NA,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,NA,NA,NA,http://pubs.acs.org/doi/full/10.1021/acs.jced.6b00196,FALSE
-su,2016,1875,10.5194/tc-10-2291-2016,FALSE,Copernicus Publications,The Cryosphere,1994-0424,1994-0416,1994-0424,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://www.the-cryosphere.net/10/2291/2016/,TRUE
-su,2016,1878,10.1177/1460458216656471,TRUE,SAGE Publications,Health Informatics Journal,1460-4582,1460-4582,1741-2811,NA,NA,TRUE,NA,NA,NA,http://journals.sagepub.com/doi/full/10.1177/1460458216656471,FALSE
-su,2016,1890.85,10.1021/acs.chemrestox.5b00416,TRUE,American Chemical Society (ACS),Chemical Research in Toxicology,0893-228X,0893-228X,1520-5010,NA,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,26686552,NA,NA,NA,FALSE
-su,2016,1890.85,10.1021/jacs.6b10017,TRUE,American Chemical Society (ACS),Journal of the American Chemical Society,0002-7863,0002-7863,1520-5126,NA,http://pubs.acs.org/page/policy/authorchoice_ccby_termsofuse.html,TRUE,27966922,NA,NA,NA,FALSE
-su,2016,1892.45,10.1177/0958928715588707,TRUE,SAGE Publications,Journal of European Social Policy,0958-9287,0958-9287,1461-7269,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,1926.7,10.1186/s12864-016-2383-1,FALSE,BioMed Central,BMC Genomics,1471-2164,NA,1471-2164,NA,NA,TRUE,26758761,PMC4711038,NA,http://bmcgenomics.biomedcentral.com/articles/10.1186/s12864-016-2383-1,TRUE
-su,2016,1948,10.1016/j.landusepol.2016.08.023,TRUE,Elsevier,Land Use Policy,0264-8377,0264-8377,1873-5754,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S0264837716304458,FALSE
-su,2016,1950,10.1088/0952-4746/36/4/721,TRUE,IOP Publishing,Journal of Radiological Protection,0952-4746,0952-4746,1361-6498,NA,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,NA,NA,FALSE
-su,2016,1950,10.1088/0953-4075/49/13/134004,TRUE,IOP Publishing,"Journal of Physics B: Atomic, Molecular and Optical Physics",0953-4075,0953-4075,1361-6455,NA,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,NA,NA,FALSE
-su,2016,1950,10.1088/0965-0393/24/4/045002,TRUE,IOP Publishing,Modelling and Simulation in Materials Science and Engineering,0965-0393,0965-0393,1361-651X,NA,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,NA,NA,FALSE
-su,2016,1950,10.1093/eurpub/ckw053,TRUE,Oxford University Press (OUP),European Journal of Public Health,1101-1262,1101-1262,1464-360X,NA,NA,TRUE,27085193,PMC5054271,NA,https://academic.oup.com/eurpub/article-lookup/doi/10.1093/eurpub/ckw053,FALSE
-su,2016,1950,10.1093/eurpub/ckw057,TRUE,Oxford University Press (OUP),European Journal of Public Health,1101-1262,1101-1262,1464-360X,NA,NA,TRUE,27085195,PMC4946411,NA,NA,FALSE
-su,2016,1955.86,10.1088/1367-2630/17/6/065007,FALSE,IOP Publishing,New Journal of Physics,1367-2630,NA,1367-2630,NA,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,NA,NA,TRUE
-su,2016,1955.86,10.1088/1367-2630/18/6/065004,FALSE,IOP Publishing,New Journal of Physics,1367-2630,NA,1367-2630,NA,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,NA,NA,TRUE
-su,2016,2000,10.5271/sjweh.3565,TRUE,Nordic Association of Occupational Safety and Health (NOROSH),Scandinavian Journal of Work Environment and Health,0355-3140,0355-3140,1795-990X,NA,NA,TRUE,27128433,NA,NA,NA,FALSE
-su,2016,2012.29,10.1098/rsif.2016.0288,TRUE,The Royal Society,Interface,1742-5689,1742-5689,1742-5662,NA,NA,TRUE,27581480,PMC5014060,NA,NA,FALSE
-su,2016,2013.45,10.3389/fmicb.2016.01209,FALSE,Frontiers,Frontiers in Microbiology,1664-302X,NA,1664-302X,NA,NA,TRUE,27536293,PMC4971087,NA,NA,TRUE
-su,2016,2108.8,10.1111/1365-2435.12670,TRUE,Wiley,Functional Ecology,0269-8463,NA,1365-2435,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,http://onlinelibrary.wiley.com/doi/10.1111/1365-2435.12670/full,FALSE
-su,2016,2121,10.1073/pnas.1522445113,TRUE,National Academy of Sciences,Proceedings of the National Academy of Sciences,0027-8424,0027-8424,1091-6490,NA,NA,TRUE,27185950,PMC4896668,NA,http://www.pnas.org/content/113/22/6160.long,FALSE
-su,2016,2132,10.1080/16506073.2016.1143526,TRUE,Taylor & Francis,Cognitive Behaviour Therapy,1650-6073,1650-6073,1651-2316,NA,NA,TRUE,26886248,PMC4867878,NA,NA,FALSE
-su,2016,2132,10.2752/147800415X14224554625154,TRUE,Taylor & Francis,Cultural and Social History,1478-0038,1478-0038,1478-0046,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2139.81,10.1371/journal.pgen.1006522,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27941972,PMC5189948,NA,NA,TRUE
-su,2016,2142,10.1016/j.fct.2016.03.028,TRUE,Elsevier,Food and Chemical Toxicology,0278-6915,0278-6915,1873-6351,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27046699,NA,NA,http://www.sciencedirect.com/science/article/pii/S0278691516300928,FALSE
-su,2016,2142,10.1016/j.tiv.2016.05.014,TRUE,Elsevier,Toxicology in Vitro,0887-2333,0887-2333,1879-3177,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27241584,NA,NA,http://www.sciencedirect.com/science/article/pii/S0887233316301096,FALSE
-su,2016,2150,10.1080/01431161.2016.1230289,TRUE,Taylor & Francis,International Journal of Remote Sensing,0143-1161,0143-1161,1366-5901,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2150,10.1080/02678373.2016.1163804,TRUE,Taylor & Francis,Work & Stress,0267-8373,0267-8373,1464-5335,NA,NA,TRUE,27226678,PMC4867881,NA,http://www.tandfonline.com/doi/full/10.1080/02678373.2016.1163804,FALSE
-su,2016,2150,10.1080/03585522.2016.1191534,TRUE,Taylor & Francis,Scandinavian Economic History Review,0358-5522,0358-5522,1750-2837,NA,NA,TRUE,NA,NA,NA,http://www.tandfonline.com/doi/full/10.1080/03585522.2016.1191534?scroll=top&needAccess=true,FALSE
-su,2016,2150,10.1080/03585522.2016.1258007,TRUE,Taylor & Francis,Scandinavian Economic History Review,0358-5522,0358-5522,1750-2837,NA,NA,TRUE,NA,NA,NA,http://www.tandfonline.com/doi/full/10.1080/03585522.2016.1258007?scroll=top&needAccess=true,FALSE
-su,2016,2150,10.1080/09243453.2016.1253591,TRUE,Taylor & Francis,School Effectiveness and School Improvement,0924-3453,0924-3453,1744-5124,NA,NA,TRUE,NA,NA,NA,http://www.tandfonline.com/doi/full/10.1080/09243453.2016.1253591?scroll=top&needAccess=true,FALSE
-su,2016,2150,10.1080/23744731.2016.1152155,TRUE,Taylor & Francis,Science and Technology for the Built Environment,2374-4731,2374-4731,2374-474X,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s00018-016-2371-2,TRUE,Springer,Cellular and Molecular Life Sciences,1420-682X,1420-682X,1420-9071,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27730255,PMC5306230,NA,NA,FALSE
-su,2016,2200,10.1007/s00038-016-0931-8,TRUE,Springer,International Journal of Public Health,1661-8556,1661-8556,1661-8564,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27942747,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s00153-016-0514-7,TRUE,Springer,Archive for Mathematical Logic,0933-5846,0933-5846,1432-0665,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s00216-016-9570-4,TRUE,Springer,Analytical and Bioanalytical Chemistry,1618-2642,1618-2642,1618-2650,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27137515,PMC4909800,NA,NA,FALSE
-su,2016,2200,10.1007/s00227-016-3032-6,TRUE,Springer,Marine Biology,0025-3162,0025-3162,1432-1793,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s00382-016-3299-9,TRUE,Springer,Climate Dynamics,0930-7575,0930-7575,1432-0894,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s00426-016-0787-9,TRUE,Springer,Psychological Research,0340-0727,0340-0727,1430-2772,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s00442-016-3740-0,TRUE,Springer,Oecologia,0029-8549,0029-8549,1432-1939,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27722799,PMC5239807,NA,NA,FALSE
-su,2016,2200,10.1007/s00531-016-1423-z,TRUE,Springer,International Journal of Earth Sciences,1437-3254,1437-3254,1437-3262,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s00606-016-1335-1,TRUE,Springer,Plant Systematics and Evolution,0378-2697,0378-2697,2199-6881,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s00712-016-0503-7,TRUE,Springer,Journal of Economics,0931-8658,0931-8658,1617-7134,NA,NA,FALSE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s10113-016-0982-7,TRUE,Springer,Regional Environmental Change,1436-3798,1436-3798,1436-378X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s10113-016-1039-7,TRUE,Springer,Regional Environmental Change,1436-3798,1436-3798,1436-378X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s10270-016-0554-9,TRUE,Springer,Software & Systems Modeling,1619-1366,1619-1366,1619-1374,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s10592-016-0910-x,TRUE,Springer,Conservation Genetics,1566-0621,1566-0621,1572-9737,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s10714-016-2155-x,TRUE,Springer,General Relativity and Gravitation,0001-7701,0001-7701,1572-9532,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s10726-016-9494-6,TRUE,Springer,Group Decision and Negotiation,0926-2644,0926-2644,1572-9907,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s10964-016-0564-5,TRUE,Springer,Journal of Youth and Adolescence,0047-2891,0047-2891,1573-6601,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s11009-016-9530-7,TRUE,Springer,Methodology and Computing in Applied Probability,1387-5841,1387-5841,1573-7713,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s11049-016-9348-6,TRUE,Springer,Natural Language & Linguistic Theory,0167-806X,0167-806X,1573-0859,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s11150-016-9349-6,TRUE,Springer,Review of Economics of the Household,1569-5239,1569-5239,1573-7152,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s11158-016-9336-z,TRUE,Springer,Res Publica,1356-4765,1356-4765,1572-8692,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s11191-016-9859-x,TRUE,Springer,Science & Education,0926-7220,0926-7220,1573-1901,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s11205-016-1271-z,TRUE,Springer,Social Indicators Research,0303-8300,0303-8300,1573-0921,NA,NA,TRUE,NA,NA,NA,http://link.springer.com/article/10.1007/s11205-016-1271-z,FALSE
-su,2016,2200,10.1007/s11205-016-1528-6,TRUE,Springer,Social Indicators Research,0303-8300,0303-8300,1573-0921,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s11214-016-0294-8,TRUE,Springer,Space Science Reviews,0038-6308,0038-6308,1572-9672,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s11229-016-1186-x,TRUE,Springer,Synthese,0039-7857,0039-7857,1573-0964,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s11229-016-1244-4,TRUE,Springer,Synthese,0039-7857,0039-7857,1573-0964,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s11356-016-6241-0,TRUE,Springer,Environmental Science and Pollution Research,0944-1344,0944-1344,1614-7499,NA,http://creativecommons.org/licenses/by/4.0,TRUE,26873824,PMC4871913,NA,NA,FALSE
-su,2016,2200,10.1007/s11356-016-7375-9,TRUE,Springer,Environmental Science and Pollution Research,0944-1344,0944-1344,1614-7499,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s11356-016-7883-7,TRUE,Springer,Environmental Science and Pollution Research,0944-1344,0944-1344,1614-7499,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27766522,PMC5219026,NA,NA,FALSE
-su,2016,2200,10.1007/s11356-016-7991-4,TRUE,Springer,Environmental Science and Pollution Research,0944-1344,0944-1344,1614-7499,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s11406-016-9761-4,TRUE,Springer,Philosophia,0048-3893,0048-3893,1574-9274,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s11625-016-0397-x,TRUE,Springer,Sustainability Science,1862-4065,1862-4065,1862-4057,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s11625-016-0409-x,TRUE,Springer,Sustainability Science,1862-4065,1862-4065,1862-4057,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s11698-016-0144-7,TRUE,Springer,Cliometrica,1863-2505,1863-2505,1863-2513,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,http://link.springer.com/article/10.1007/s11698-016-0144-7,FALSE
-su,2016,2200,10.1007/s12132-016-9294-8,TRUE,Springer,Urban Forum,1015-3802,1015-3802,1874-6330,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s13280-016-0776-7,TRUE,Springer,Ambio,0044-7447,0044-7447,1654-7209,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27098316,PMC5012997,NA,NA,FALSE
-su,2016,2200,10.1007/s13280-016-0847-9,TRUE,Springer,Ambio,0044-7447,0044-7447,1654-7209,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s13524-016-0498-2,TRUE,Springer,Demography,0070-3370,0070-3370,1533-7790,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2200,10.1007/s40675-016-0055-y,TRUE,Springer,Current Sleep Medicine Reports,2198-6401,NA,2198-6401,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28003955,NA,NA,NA,FALSE
+slu,2016,787.56,10.3390/f7100233,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000388670800024,NA,TRUE
+slu,2016,811.94,10.3390/f7010008,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000369493400003,NA,TRUE
+slu,2016,827.25,10.1186/s13104-016-2193-1,FALSE,BioMed Central,BMC Research Notes,1756-0500,NA,1756-0500,1756-0500,NA,TRUE,27484122,PMC4969733,NA,NA,TRUE
+slu,2016,886.23,10.1186/s40064-016-3288-9,FALSE,Springer,SpringerPlus,2193-1801,NA,2193-1801,2193-1801,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000391801700014,NA,FALSE
+slu,2016,900.17,10.1186/s40064-016-2831-z,FALSE,Springer,SpringerPlus,2193-1801,NA,2193-1801,2193-1801,http://creativecommons.org/licenses/by/4.0,TRUE,27512633,PMC4960079,ut:000381637800007,NA,FALSE
+slu,2016,901.96,10.1016/j.aqrep.2016.12.003,FALSE,Elsevier,Aquaculture Reports,2352-5134,2352-5134,NA,2352-5134,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,TRUE
+slu,2016,902.15,10.3390/f7030061,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000373700800021,NA,TRUE
+slu,2016,910.48,10.3390/f7090206,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000385428900024,NA,TRUE
+slu,2016,910.48,10.3390/f7090207,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000385428900025,NA,TRUE
+slu,2016,914.33,10.1371/journal.pone.0147796,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26820846,PMC4731209,ut:000369528400045,NA,TRUE
+slu,2016,914.33,10.3389/fpls.2016.00119,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,1664-462X,NA,TRUE,26904081,PMC4746258,ut:000369802700001,NA,TRUE
+slu,2016,914.54,10.3390/f7050100,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000377793800009,NA,TRUE
+slu,2016,932,10.1038/srep35958,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,27775050,PMC5075900,ut:000386058500001,NA,TRUE
+su,2012,2630,10.1080/08920753.2012.727738,TRUE,Taylor & Francis,Coastal Management,0892-0753,0892-0753,1521-0421,0892-0753,NA,TRUE,NA,NA,ut:000310594700004,NA,FALSE
+su,2013,2132,10.1080/17449626.2013.773180,TRUE,Taylor & Francis,Journal of Global Ethics,1744-9626,1744-9626,1744-9634,1744-9626,NA,TRUE,NA,NA,NA,NA,FALSE
+su,2013,2429,10.1080/16506073.2013.809141,TRUE,Taylor & Francis,Cognitive Behaviour Therapy,1650-6073,1650-6073,1651-2316,1650-6073,NA,TRUE,23898817,PMC3869050,ut:000328243900004,NA,FALSE
+su,2013,2429,10.1080/19371918.2013.776320,TRUE,Taylor & Francis,Social Work in Public Health,1937-1918,1937-1918,1937-190X,1937-190X,NA,TRUE,24405195,PMC3919150,ut:000329775900002,NA,FALSE
+su,2014,1769,10.5194/acp-15-2545-2015,FALSE,Copernicus Publications,Atmospheric Chemistry and Physics,1680-7324,NA,1680-7324,1680-7316,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000350559700021,http://www.atmos-chem-phys.net/15/2545/2015/acp-15-2545-2015.pdf,TRUE
+su,2014,2429,10.1080/16506073.2014.939593,TRUE,Taylor & Francis,Cognitive Behaviour Therapy,1650-6073,1650-6073,1651-2316,1650-6073,NA,TRUE,25204370,PMC4260663,ut:000344862500005,NA,FALSE
+su,2014,755,10.1159/000369132,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,1664-5464,NA,TRUE,25759713,PMC4282043,NA,NA,TRUE
+su,2015,1169,10.1080/23311940.2015.1058465,FALSE,Taylor & Francis,Cogent Physics,2331-1940,NA,2331-1940,2331-1940,NA,TRUE,NA,NA,NA,NA,TRUE
+su,2015,1530,10.1002/ece3.1773,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27069602,PMC4813107,ut:000367433000007,http://onlinelibrary.wiley.com/doi/10.1002/ece3.1773/full,TRUE
+su,2015,1686,10.3389/fpsyg.2015.00944,FALSE,Frontiers,Frontiers in Psychology,1664-1078,NA,1664-1078,1664-1078,NA,TRUE,26191035,PMC4488603,ut:000357611400001,http://journal.frontiersin.org/article/10.3389/fpsyg.2015.00944/full,TRUE
+su,2015,2230,10.1136/jech-2014-205058,TRUE,BMJ,Journal of Epidemiology and Community Health,0143-005X,0143-005X,1470-2738,0143-005X,NA,TRUE,25922471,PMC4516006,ut:000357720500009,http://jech.bmj.com/content/69/8/769.full,FALSE
+su,2015,2429,10.1080/00268976.2014.1003985,TRUE,Taylor & Francis,Molecular Physics,0026-8976,0026-8976,1362-3028,0026-8976,NA,TRUE,NA,NA,ut:000360906000007,NA,FALSE
+su,2015,787,10.1186/s40488-015-0031-y,FALSE,Springer,Journal of Statistical Distributions and Applications,2195-5832,NA,2195-5832,2195-5832,NA,TRUE,NA,NA,NA,http://jsdajournal.springeropen.com/articles/10.1186/s40488-015-0031-y,TRUE
+su,2016,0,10.1080/20004508.2016.1275187,FALSE,Taylor & Francis,Education Inquiry,2000-4508,NA,2000-4508,2000-4508,NA,TRUE,NA,NA,NA,NA,TRUE
+su,2016,1007.31,10.5751/ES-08368-210140,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,1708-3087,1708-3087,NA,TRUE,NA,NA,ut:000373935100043,http://www.ecologyandsociety.org/vol21/iss1/art40/,TRUE
+su,2016,1008.99,10.5751/ES-08812-210425,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,1708-3087,1708-3087,NA,TRUE,NA,NA,ut:000391199400028,http://www.ecologyandsociety.org/vol21/iss4/art25/,TRUE
+su,2016,1012.25,10.3390/w8120572,FALSE,MDPI,Water,2073-4441,NA,2073-4441,2073-4441,NA,TRUE,NA,NA,ut:000392480200025,NA,TRUE
+su,2016,1022.82,10.5751/ES-09051-220128,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,NA,1708-3087,NA,TRUE,NA,NA,ut:000399397700035,NA,TRUE
+su,2016,1065,10.1093/nar/gkw356,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,0305-1048,NA,TRUE,27151197,PMC4987909,ut:000379786800018,NA,TRUE
+su,2016,1065,10.1093/nar/gkw849,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,0305-1048,NA,TRUE,27664219,PMC5314790,ut:000396576300003,NA,TRUE
+su,2016,1065,10.1093/nar/gkw923,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,0305-1048,NA,TRUE,27742821,PMC5210627,ut:000396575500096,NA,TRUE
+su,2016,1071,10.1016/j.childyouth.2016.05.011,TRUE,Elsevier,Children and Youth Services Review,0190-7409,0190-7409,NA,0190-7409,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000379097800019,http://www.sciencedirect.com/science/article/pii/S0190740916301554,FALSE
+su,2016,1080,10.5194/nhess-16-1571-2016,TRUE,Copernicus Publications,Natural Hazards and Earth System Sciences,1684-9981,NA,1684-9981,1561-8633,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000379421700003,NA,TRUE
+su,2016,1103.7,10.5751/ES-08605-210316,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,1708-3087,1708-3087,NA,TRUE,NA,NA,ut:000385720400020,http://www.ecologyandsociety.org/vol21/iss3/art16/,TRUE
+su,2016,1120,10.1002/ece3.2536,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,2045-7758,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28031795,PMC5167037,ut:000392062100009,http://onlinelibrary.wiley.com/doi/10.1002/ece3.2536/full,TRUE
+su,2016,1138,10.1108/JFMM-04-2016-0033,TRUE,Emerald,Journal of Fashion Marketing and Management,1361-2026,1361-2026,NA,1361-2026,http://www.emeraldinsight.com/page/tdm,TRUE,NA,NA,ut:000387174000010,http://www.emeraldinsight.com/doi/full/10.1108/JFMM-04-2016-0033,FALSE
+su,2016,1165,10.1038/srep21203,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,26883070,PMC4756319,ut:000370230600002,NA,TRUE
+su,2016,1165,10.1038/srep26620,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,27197757,PMC4873736,ut:000376193100001,NA,TRUE
+su,2016,1165,10.1038/srep27749,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,NA,TRUE,27324057,PMC4914976,ut:000378230100001,NA,TRUE
+su,2016,1165,10.1038/srep33509,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,27698390,PMC5048106,ut:000384595800001,NA,TRUE
+su,2016,1165,10.1038/srep34098,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,NA,TRUE,27682138,PMC5040959,ut:000384175800001,NA,TRUE
+su,2016,1165,10.1038/srep36243,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,NA,TRUE,27805056,PMC5090251,ut:000387137900001,NA,TRUE
+su,2016,1165,10.1038/srep38821,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,NA,TRUE,27958327,PMC5153840,ut:000389688300001,NA,TRUE
+su,2016,1173,10.1016/j.childyouth.2016.09.021,TRUE,Elsevier,Children and Youth Services Review,0190-7409,0190-7409,NA,0190-7409,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S0190740916303000,FALSE
+su,2016,1180,10.1186/s12911-016-0309-0,FALSE,BioMed Central,BMC Medical Informatics and Decision Making,1472-6947,NA,1472-6947,1472-6947,NA,TRUE,27459846,PMC4965720,ut:000405363700001,https://bmcmedinformdecismak.biomedcentral.com/articles/10.1186/s12911-016-0309-0,TRUE
+su,2016,1180,10.1186/s12911-016-0311-6,FALSE,BioMed Central,BMC Medical Informatics and Decision Making,1472-6947,NA,1472-6947,1472-6947,NA,TRUE,27459993,PMC4965710,ut:000405363700003,http://bmcmedinformdecismak.biomedcentral.com/articles/10.1186/s12911-016-0311-6,TRUE
+su,2016,1197.07,10.5751/ES-08920-220102,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,1708-3087,1708-3087,NA,TRUE,NA,NA,ut:000399397700013,http://www.ecologyandsociety.org/vol22/iss1/art2/,TRUE
+su,2016,1200.74,10.1136/bmjopen-2015-009440,FALSE,BMJ,BMJ Open,2044-6055,2044-6055,2044-6055,2044-6055,NA,TRUE,27113233,PMC4853986,ut:000376391400016,NA,TRUE
+su,2016,1224,10.1002/ece3.2310,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,2045-7758,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27547340,PMC4983577,ut:000381578400004,http://onlinelibrary.wiley.com/doi/10.1002/ece3.2310/full,TRUE
+su,2016,1239,10.1371/journal.pone.0147924,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26820737,PMC4731055,ut:000369528400055,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0147924,TRUE
+su,2016,1260,10.5194/gmd-9-2741-2016,FALSE,Copernicus Publications,Geoscientific Model Development,1991-9603,1991-959X,1991-9603,1991-959X,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000383794400001,http://www.geosci-model-dev.net/9/2741/2016/,TRUE
+su,2016,1261.35,10.1371/journal.pone.0163091,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27732600,PMC5061329,ut:000385505300009,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0163091,TRUE
+su,2016,1284.87,10.1371/journal.pone.0155295,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27223898,PMC4880328,ut:000376881700019,NA,TRUE
+su,2016,1285.2,10.5194/acp-16-15135-2016,FALSE,Copernicus Publications,Atmospheric Chemistry and Physics,1680-7324,NA,1680-7324,1680-7316,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000390648900002,NA,TRUE
+su,2016,1308,10.5751/ES-08826-220114,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,NA,1708-3087,NA,TRUE,NA,NA,ut:000399397700006,NA,TRUE
+su,2016,1312.12,10.3390/rs8020140,FALSE,MDPI,Remote Sensing,2072-4292,NA,2072-4292,2072-4292,NA,TRUE,NA,NA,ut:000371898800035,NA,TRUE
+su,2016,1330,10.1163/24056480-00104001,TRUE,Brill Academic Publishers,Journal of World Literature,2405-6472,2405-6472,2405-6480,2405-6472,NA,TRUE,NA,NA,NA,NA,FALSE
+su,2016,1365,10.1371/journal.pone.0156855,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27253326,PMC4890767,ut:000377218700066,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0156855,TRUE
+su,2016,1379,10.1142/S1363919616400132,TRUE,World Scientific Publishing,International Journal of Innovation Management,1363-9196,1363-9196,1757-5877,1363-9196,NA,TRUE,NA,NA,ut:000394501400005,http://www.worldscientific.com/doi/10.1142/S1363919616400132,FALSE
+su,2016,1397.6,10.1371/journal.pone.0151993,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,NA,TRUE,26998832,PMC4801336,ut:000372694700091,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0151993,TRUE
+su,2016,1397.6,10.1371/journal.pone.0152745,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,NA,TRUE,27030968,PMC4816578,ut:000373121800132,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0152745,TRUE
+su,2016,1397.6,10.1371/journal.pone.0158326,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,NA,TRUE,27410261,PMC4943737,ut:000379508300021,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0158326,TRUE
+su,2016,1397.6,10.1371/journal.pone.0159684,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27434640,PMC4951072,ut:000380169600081,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0159684,TRUE
+su,2016,1397.6,10.1371/journal.pone.0164241,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27788154,PMC5082882,ut:000389604900014,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0164241,TRUE
+su,2016,1398,10.1038/srep30469,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,NA,TRUE,27461918,PMC4962034,ut:000380798500001,NA,TRUE
+su,2016,1398,10.1038/srep32446,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,NA,TRUE,27573668,PMC5004158,ut:000391982700001,NA,TRUE
+su,2016,1398.91,10.1021/jacs.6b09240,TRUE,American Chemical Society (ACS),Journal of the American Chemical Society,0002-7863,0002-7863,1520-5126,0002-7863,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,NA,NA,ut:000386540500021,http://pubs.acs.org/doi/full/10.1021/jacs.6b09240,FALSE
+su,2016,1399,10.1186/s12889-016-3685-6,FALSE,BioMed Central,BMC Public Health,1471-2458,NA,1471-2458,1471-2458,NA,TRUE,NA,NA,ut:000384700300007,https://bmcpublichealth.biomedcentral.com/articles/10.1186/s12889-016-3685-6,TRUE
+su,2016,1400.27,10.1021/acs.accounts.6b00050,TRUE,American Chemical Society (ACS),Accounts of Chemical Research,0001-4842,0001-4842,1520-4898,0001-4842,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,27082700,NA,ut:000376331400025,http://pubs.acs.org/doi/full/10.1021/acs.accounts.6b00050,FALSE
+su,2016,1404,10.1371/journal.pone.0156570,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,NA,TRUE,27300292,PMC4907435,ut:000377822200010,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0156570,TRUE
+su,2016,1405.96,10.1021/acscatal.6b01562,TRUE,American Chemical Society (ACS),ACS Catalysis,2155-5435,2155-5435,2155-5435,2155-5435,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,NA,NA,ut:000389399400016,http://pubs.acs.org/doi/full/10.1021/acscatal.6b01562,FALSE
+su,2016,1406.02,10.3390/ijerph13030249,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,1660-4601,NA,TRUE,26927139,PMC4808912,ut:000373528600032,NA,TRUE
+su,2016,1407,10.1371/journal.pone.0164611,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27727314,PMC5058505,ut:000385504400046,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0164611,TRUE
+su,2016,1412.55,10.1371/journal.pone.0165799,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27832117,PMC5104468,ut:000387725000035,NA,TRUE
+su,2016,1415.64,10.1371/journal.pone.0154099,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,NA,TRUE,27101307,PMC4839650,ut:000374898500143,NA,TRUE
+su,2016,1415.64,10.1371/journal.pone.0155063,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27176452,PMC4866784,ut:000376589400066,NA,TRUE
+su,2016,1415.64,10.1371/journal.pone.0155836,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,NA,TRUE,27196748,PMC4873139,ut:000376291100111,NA,TRUE
+su,2016,1415.64,10.1371/journal.pone.0167493,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27936111,PMC5147920,ut:000389587100110,NA,TRUE
+su,2016,1415.64,10.1371/journal.pone.0169276,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28036376,PMC5201274,ut:000391229300070,NA,TRUE
+su,2016,1418.18,10.1021/acscatal.6b02842,TRUE,American Chemical Society (ACS),ACS Catalysis,2155-5435,2155-5435,2155-5435,2155-5435,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,NA,NA,ut:000389399400051,NA,FALSE
+su,2016,1420.51,10.1098/rsob.160152,FALSE,The Royal Society,Open Biology,2046-2441,NA,2046-2441,2046-2441,NA,TRUE,NA,NA,ut:000390348200002,NA,TRUE
+su,2016,1423.31,10.1371/journal.pone.0163476,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27695120,PMC5047452,ut:000385553100034,NA,TRUE
+su,2016,1423.31,10.1371/journal.pone.0166066,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27902694,PMC5130257,ut:000389474100010,NA,TRUE
+su,2016,1423.31,10.1371/journal.pone.0168357,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27992585,PMC5161503,ut:000392758000038,NA,TRUE
+su,2016,1424,10.1002/ece3.2067,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,2045-7758,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27217940,PMC4863005,ut:000376149400013,http://onlinelibrary.wiley.com/doi/10.1002/ece3.2067/full,TRUE
+su,2016,1439.5,10.1186/s13195-016-0231-9,FALSE,BioMed Central,Alzheimer's Research & Therapy,1758-9193,NA,1758-9193,1758-9193,NA,TRUE,28137305,PMC5282900,ut:000392998000001,NA,TRUE
+su,2016,1500,10.1002/iid3.115,FALSE,Wiley,"Immunity, Inflammation and Disease",2050-4527,NA,2050-4527,2050-4527,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27621814,PMC5004286,ut:000383521400006,http://onlinelibrary.wiley.com/doi/10.1002/iid3.115/full,TRUE
+su,2016,1500,10.5271/sjweh.3610,TRUE,Nordic Association of Occupational Safety and Health (NOROSH),Scandinavian Journal of Work Environment and Health,0355-3140,0355-3140,1795-990X,0355-3140,NA,TRUE,27942734,NA,ut:000395849200003,NA,FALSE
+su,2016,1530,10.5194/acp-16-6577-2016,TRUE,Copernicus Publications,Atmospheric Chemistry and Physics,1680-7324,NA,1680-7324,1680-7316,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000378354100033,NA,TRUE
+su,2016,1533,10.1016/j.npep.2016.08.008,TRUE,Elsevier,Neuropeptides,0143-4179,0143-4179,1532-2785,0143-4179,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27592409,NA,ut:000389398800011,http://www.sciencedirect.com/science/article/pii/S0143417916300427,FALSE
+su,2016,1550,10.3354/meps11592,TRUE,Inter-Research Science Center,Marine Ecology Progress Series,0171-8630,0171-8630,1616-1599,0171-8630,NA,TRUE,NA,NA,ut:000371142500006,NA,FALSE
+su,2016,1607,10.1016/j.avb.2016.02.006,TRUE,Elsevier,Aggression and Violent Behavior,1359-1789,1359-1789,NA,1359-1789,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000375516300003,http://www.sciencedirect.com/science/article/pii/S1359178916300064,FALSE
+su,2016,1620,10.5194/bg-13-6121-2016,FALSE,Copernicus Publications,Biogeosciences,1726-4189,1726-4170,1726-4189,1726-4170,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000387864200001,http://www.biogeosciences.net/13/6121/2016/,TRUE
+su,2016,1642.5,10.1002/2016EF000434,FALSE,Wiley,Earth's Future,2328-4277,NA,2328-4277,2328-4277,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000395001800008,http://onlinelibrary.wiley.com/doi/10.1002/2016EF000434/full,TRUE
+su,2016,1725,10.5194/acp-16-10941-2016,FALSE,Copernicus Publications,Atmospheric Chemistry and Physics,1680-7324,1680-7316,1680-7324,1680-7316,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000383963200001,http://www.atmos-chem-phys.net/16/10941/2016/,TRUE
+su,2016,1727,10.1136/jech-2015-206547,TRUE,BMJ,Journal of Epidemiology and Community Health,0143-005X,0143-005X,1470-2738,0143-005X,NA,TRUE,26733672,PMC4893147,ut:000376596100008,http://jech.bmj.com/content/70/6/569.full,FALSE
+su,2016,1740,10.3389/fnagi.2016.00034,FALSE,Frontiers,Frontiers in Aging Neuroscience,1663-4365,NA,1663-4365,1663-4365,NA,TRUE,26973509,PMC4773588,ut:000371113200001,http://journal.frontiersin.org/article/10.3389/fnagi.2016.00034/full,TRUE
+su,2016,1750,10.1002/ange.201605999,TRUE,Wiley,Angewandte Chemie,0044-8249,NA,NA,0044-8249,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,NA,FALSE
+su,2016,1758.82,10.1016/j.concog.2016.06.012,TRUE,Elsevier,Consciousness and Cognition,1053-8100,1053-8100,NA,1053-8100,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27351780,NA,ut:000383638800004,NA,FALSE
+su,2016,1773,10.1144/M46.118,TRUE,Geological Society of London,"Geological Society, London, Memoirs",0435-4052,0435-4052,2041-4722,0435-4052,NA,TRUE,NA,NA,NA,NA,FALSE
+su,2016,1773,10.1144/M46.182,TRUE,Geological Society of London,"Geological Society, London, Memoirs",0435-4052,0435-4052,2041-4722,0435-4052,NA,TRUE,NA,NA,NA,NA,FALSE
+su,2016,1773,10.1144/M46.183,TRUE,Geological Society of London,"Geological Society, London, Memoirs",0435-4052,0435-4052,2041-4722,0435-4052,NA,TRUE,NA,NA,NA,NA,FALSE
+su,2016,1798,10.3389/fnins.2016.00007,FALSE,Frontiers,Frontiers in Neuroscience,1662-453X,NA,1662-453X,1662-453X,NA,TRUE,26834534,PMC4718990,ut:000368584900001,NA,TRUE
+su,2016,1806.96,10.3389/fevo.2016.00134,FALSE,Frontiers,Frontiers in Ecology and Evolution,2296-701X,NA,2296-701X,2296-701X,NA,TRUE,NA,NA,NA,NA,TRUE
+su,2016,1806.96,10.3389/fimmu.2016.00096,FALSE,Frontiers,Frontiers in Immunology,1664-3224,NA,1664-3224,1664-3224,NA,TRUE,27014275,PMC4794487,ut:000372147600001,NA,TRUE
+su,2016,1806.96,10.3389/fmicb.2016.01043,FALSE,Frontiers,Frontiers in Microbiology,1664-302X,NA,1664-302X,1664-302X,NA,TRUE,27458440,PMC4933709,NA,NA,TRUE
+su,2016,1806.96,10.3389/fphys.2016.00068,FALSE,Frontiers,Frontiers in Physiology,1664-042X,NA,1664-042X,1664-042X,NA,TRUE,26973536,PMC4770038,ut:000371096300001,NA,TRUE
+su,2016,1820.7,10.5194/bg-13-5003-2016,FALSE,Copernicus Publications,Biogeosciences,1726-4189,1726-4170,1726-4189,1726-4170,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000383963700003,http://www.biogeosciences.net/13/5003/2016/,TRUE
+su,2016,1867,10.1016/j.atmosenv.2016.05.041,TRUE,Elsevier,Atmospheric Environment,1352-2310,1352-2310,NA,1352-2310,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000380083200001,http://www.sciencedirect.com/science/article/pii/S1352231016303880,FALSE
+su,2016,1874.16,10.1021/acs.jced.6b00196,TRUE,American Chemical Society (ACS),Journal of Chemical & Engineering Data,0021-9568,0021-9568,1520-5134,0021-9568,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,NA,NA,ut:000383005500021,http://pubs.acs.org/doi/full/10.1021/acs.jced.6b00196,FALSE
+su,2016,1875,10.5194/tc-10-2291-2016,FALSE,Copernicus Publications,The Cryosphere,1994-0424,1994-0416,1994-0424,1994-0416,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000385413800001,http://www.the-cryosphere.net/10/2291/2016/,TRUE
+su,2016,1878,10.1177/1460458216656471,TRUE,SAGE Publications,Health Informatics Journal,1460-4582,1460-4582,1741-2811,1460-4582,NA,TRUE,NA,NA,NA,http://journals.sagepub.com/doi/full/10.1177/1460458216656471,FALSE
+su,2016,1890.85,10.1021/acs.chemrestox.5b00416,TRUE,American Chemical Society (ACS),Chemical Research in Toxicology,0893-228X,0893-228X,1520-5010,0893-228X,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,26686552,NA,ut:000368562400008,NA,FALSE
+su,2016,1890.85,10.1021/jacs.6b10017,TRUE,American Chemical Society (ACS),Journal of the American Chemical Society,0002-7863,0002-7863,1520-5126,0002-7863,http://pubs.acs.org/page/policy/authorchoice_ccby_termsofuse.html,TRUE,27966922,NA,ut:000392036900001,NA,FALSE
+su,2016,1892.45,10.1177/0958928715588707,TRUE,SAGE Publications,Journal of European Social Policy,0958-9287,0958-9287,1461-7269,0958-9287,NA,TRUE,NA,NA,ut:000357736200005,NA,FALSE
+su,2016,1926.7,10.1186/s12864-016-2383-1,FALSE,BioMed Central,BMC Genomics,1471-2164,NA,1471-2164,1471-2164,NA,TRUE,26758761,PMC4711038,ut:000368073600003,http://bmcgenomics.biomedcentral.com/articles/10.1186/s12864-016-2383-1,TRUE
+su,2016,1948,10.1016/j.landusepol.2016.08.023,TRUE,Elsevier,Land Use Policy,0264-8377,0264-8377,1873-5754,0264-8377,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000387519600010,http://www.sciencedirect.com/science/article/pii/S0264837716304458,FALSE
+su,2016,1950,10.1088/0952-4746/36/4/721,TRUE,IOP Publishing,Journal of Radiological Protection,0952-4746,0952-4746,1361-6498,0952-4746,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,ut:000385422900001,NA,FALSE
+su,2016,1950,10.1088/0953-4075/49/13/134004,TRUE,IOP Publishing,"Journal of Physics B: Atomic, Molecular and Optical Physics",0953-4075,0953-4075,1361-6455,0953-4075,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,ut:000378325600007,NA,FALSE
+su,2016,1950,10.1088/0965-0393/24/4/045002,TRUE,IOP Publishing,Modelling and Simulation in Materials Science and Engineering,0965-0393,0965-0393,1361-651X,0965-0393,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,ut:000375596400002,NA,FALSE
+su,2016,1950,10.1093/eurpub/ckw053,TRUE,Oxford University Press (OUP),European Journal of Public Health,1101-1262,1101-1262,1464-360X,1101-1262,NA,TRUE,27085193,PMC5054271,ut:000386451800013,https://academic.oup.com/eurpub/article-lookup/doi/10.1093/eurpub/ckw053,FALSE
+su,2016,1950,10.1093/eurpub/ckw057,TRUE,Oxford University Press (OUP),European Journal of Public Health,1101-1262,1101-1262,1464-360X,1101-1262,NA,TRUE,27085195,PMC4946411,ut:000383233800015,NA,FALSE
+su,2016,1955.86,10.1088/1367-2630/17/6/065007,FALSE,IOP Publishing,New Journal of Physics,1367-2630,NA,1367-2630,1367-2630,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,ut:000358927100001,NA,TRUE
+su,2016,1955.86,10.1088/1367-2630/18/6/065004,FALSE,IOP Publishing,New Journal of Physics,1367-2630,NA,1367-2630,1367-2630,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,ut:000379291400001,NA,TRUE
+su,2016,2000,10.5271/sjweh.3565,TRUE,Nordic Association of Occupational Safety and Health (NOROSH),Scandinavian Journal of Work Environment and Health,0355-3140,0355-3140,1795-990X,0355-3140,NA,TRUE,27128433,NA,ut:000380231500008,NA,FALSE
+su,2016,2012.29,10.1098/rsif.2016.0288,TRUE,The Royal Society,Interface,1742-5689,1742-5689,1742-5662,1742-5662,NA,TRUE,27581480,PMC5014060,ut:000385993000010,NA,FALSE
+su,2016,2013.45,10.3389/fmicb.2016.01209,FALSE,Frontiers,Frontiers in Microbiology,1664-302X,NA,1664-302X,1664-302X,NA,TRUE,27536293,PMC4971087,ut:000380658100001,NA,TRUE
+su,2016,2108.8,10.1111/1365-2435.12670,TRUE,Wiley,Functional Ecology,0269-8463,NA,1365-2435,0269-8463,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000387362600010,http://onlinelibrary.wiley.com/doi/10.1111/1365-2435.12670/full,FALSE
+su,2016,2121,10.1073/pnas.1522445113,TRUE,National Academy of Sciences,Proceedings of the National Academy of Sciences,0027-8424,0027-8424,1091-6490,0027-8424,NA,TRUE,27185950,PMC4896668,ut:000376784600036,http://www.pnas.org/content/113/22/6160.long,FALSE
+su,2016,2132,10.1080/16506073.2016.1143526,TRUE,Taylor & Francis,Cognitive Behaviour Therapy,1650-6073,1650-6073,1651-2316,1650-6073,NA,TRUE,26886248,PMC4867878,ut:000374581500002,NA,FALSE
+su,2016,2132,10.2752/147800415X14224554625154,TRUE,Taylor & Francis,Cultural and Social History,1478-0038,1478-0038,1478-0046,1478-0038,NA,TRUE,NA,NA,ut:000354228300002,NA,FALSE
+su,2016,2139.81,10.1371/journal.pgen.1006522,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,1553-7390,http://creativecommons.org/licenses/by/4.0/,TRUE,27941972,PMC5189948,ut:000392138700051,NA,TRUE
+su,2016,2142,10.1016/j.fct.2016.03.028,TRUE,Elsevier,Food and Chemical Toxicology,0278-6915,0278-6915,1873-6351,0278-6915,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27046699,NA,ut:000376804400011,http://www.sciencedirect.com/science/article/pii/S0278691516300928,FALSE
+su,2016,2142,10.1016/j.tiv.2016.05.014,TRUE,Elsevier,Toxicology in Vitro,0887-2333,0887-2333,1879-3177,0887-2333,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27241584,NA,ut:000380603700013,http://www.sciencedirect.com/science/article/pii/S0887233316301096,FALSE
+su,2016,2150,10.1080/01431161.2016.1230289,TRUE,Taylor & Francis,International Journal of Remote Sensing,0143-1161,0143-1161,1366-5901,0143-1161,NA,TRUE,NA,NA,ut:000394652900012,NA,FALSE
+su,2016,2150,10.1080/02678373.2016.1163804,TRUE,Taylor & Francis,Work & Stress,0267-8373,0267-8373,1464-5335,0267-8373,NA,TRUE,27226678,PMC4867881,ut:000375478000003,http://www.tandfonline.com/doi/full/10.1080/02678373.2016.1163804,FALSE
+su,2016,2150,10.1080/03585522.2016.1191534,TRUE,Taylor & Francis,Scandinavian Economic History Review,0358-5522,0358-5522,1750-2837,0358-5522,NA,TRUE,NA,NA,ut:000390047900003,http://www.tandfonline.com/doi/full/10.1080/03585522.2016.1191534?scroll=top&needAccess=true,FALSE
+su,2016,2150,10.1080/03585522.2016.1258007,TRUE,Taylor & Francis,Scandinavian Economic History Review,0358-5522,0358-5522,1750-2837,0358-5522,NA,TRUE,NA,NA,ut:000400004700005,http://www.tandfonline.com/doi/full/10.1080/03585522.2016.1258007?scroll=top&needAccess=true,FALSE
+su,2016,2150,10.1080/09243453.2016.1253591,TRUE,Taylor & Francis,School Effectiveness and School Improvement,0924-3453,0924-3453,1744-5124,0924-3453,NA,TRUE,NA,NA,ut:000395201600009,http://www.tandfonline.com/doi/full/10.1080/09243453.2016.1253591?scroll=top&needAccess=true,FALSE
+su,2016,2150,10.1080/23744731.2016.1152155,TRUE,Taylor & Francis,Science and Technology for the Built Environment,2374-4731,2374-4731,2374-474X,2374-4731,NA,TRUE,NA,NA,ut:000375862900011,NA,FALSE
+su,2016,2200,10.1007/s00018-016-2371-2,TRUE,Springer,Cellular and Molecular Life Sciences,1420-682X,1420-682X,1420-9071,1420-682X,http://creativecommons.org/licenses/by/4.0,TRUE,27730255,PMC5306230,ut:000394318300009,NA,FALSE
+su,2016,2200,10.1007/s00038-016-0931-8,TRUE,Springer,International Journal of Public Health,1661-8556,1661-8556,1661-8564,1661-8556,http://creativecommons.org/licenses/by/4.0,TRUE,27942747,NA,ut:000398821500003,NA,FALSE
+su,2016,2200,10.1007/s00153-016-0514-7,TRUE,Springer,Archive for Mathematical Logic,0933-5846,0933-5846,1432-0665,0933-5846,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392295400004,NA,FALSE
+su,2016,2200,10.1007/s00216-016-9570-4,TRUE,Springer,Analytical and Bioanalytical Chemistry,1618-2642,1618-2642,1618-2650,1618-2642,http://creativecommons.org/licenses/by/4.0,TRUE,27137515,PMC4909800,ut:000378725200025,NA,FALSE
+su,2016,2200,10.1007/s00227-016-3032-6,TRUE,Springer,Marine Biology,0025-3162,0025-3162,1432-1793,0025-3162,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388685000020,NA,FALSE
+su,2016,2200,10.1007/s00382-016-3299-9,TRUE,Springer,Climate Dynamics,0930-7575,0930-7575,1432-0894,0930-7575,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000402122200018,NA,FALSE
+su,2016,2200,10.1007/s00426-016-0787-9,TRUE,Springer,Psychological Research,0340-0727,0340-0727,1430-2772,0340-0727,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000403594800005,NA,FALSE
+su,2016,2200,10.1007/s00442-016-3740-0,TRUE,Springer,Oecologia,0029-8549,0029-8549,1432-1939,0029-8549,http://creativecommons.org/licenses/by/4.0,TRUE,27722799,PMC5239807,ut:000392391300005,NA,FALSE
+su,2016,2200,10.1007/s00531-016-1423-z,TRUE,Springer,International Journal of Earth Sciences,1437-3254,1437-3254,1437-3262,1437-3254,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000407925800020,NA,FALSE
+su,2016,2200,10.1007/s00606-016-1335-1,TRUE,Springer,Plant Systematics and Evolution,0378-2697,0378-2697,2199-6881,0378-2697,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000385192100012,NA,FALSE
+su,2016,2200,10.1007/s00712-016-0503-7,TRUE,Springer,Journal of Economics,0931-8658,0931-8658,1617-7134,0931-8658,NA,FALSE,NA,NA,ut:000394378700002,NA,FALSE
+su,2016,2200,10.1007/s10113-016-0982-7,TRUE,Springer,Regional Environmental Change,1436-3798,1436-3798,1436-378X,1436-3798,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+su,2016,2200,10.1007/s10113-016-1039-7,TRUE,Springer,Regional Environmental Change,1436-3798,1436-3798,1436-378X,1436-3798,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000394276200017,NA,FALSE
+su,2016,2200,10.1007/s10270-016-0554-9,TRUE,Springer,Software & Systems Modeling,1619-1366,1619-1366,1619-1374,1619-1366,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000407367800005,NA,FALSE
+su,2016,2200,10.1007/s10592-016-0910-x,TRUE,Springer,Conservation Genetics,1566-0621,1566-0621,1572-9737,1566-0621,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000396341900009,NA,FALSE
+su,2016,2200,10.1007/s10714-016-2155-x,TRUE,Springer,General Relativity and Gravitation,0001-7701,0001-7701,1572-9532,0001-7701,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388615400008,NA,FALSE
+su,2016,2200,10.1007/s10726-016-9494-6,TRUE,Springer,Group Decision and Negotiation,0926-2644,0926-2644,1572-9907,0926-2644,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000404230500003,NA,FALSE
+su,2016,2200,10.1007/s10964-016-0564-5,TRUE,Springer,Journal of Youth and Adolescence,0047-2891,0047-2891,1573-6601,0047-2891,NA,TRUE,NA,NA,ut:000401351200011,NA,FALSE
+su,2016,2200,10.1007/s11009-016-9530-7,TRUE,Springer,Methodology and Computing in Applied Probability,1387-5841,1387-5841,1573-7713,1387-5841,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+su,2016,2200,10.1007/s11049-016-9348-6,TRUE,Springer,Natural Language & Linguistic Theory,0167-806X,0167-806X,1573-0859,0167-806X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000398751000006,NA,FALSE
+su,2016,2200,10.1007/s11150-016-9349-6,TRUE,Springer,Review of Economics of the Household,1569-5239,1569-5239,1573-7152,1569-5239,NA,TRUE,NA,NA,ut:000394991400014,NA,FALSE
+su,2016,2200,10.1007/s11158-016-9336-z,TRUE,Springer,Res Publica,1356-4765,1356-4765,1572-8692,1356-4765,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+su,2016,2200,10.1007/s11191-016-9859-x,TRUE,Springer,Science & Education,0926-7220,0926-7220,1573-1901,0926-7220,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000397064100005,NA,FALSE
+su,2016,2200,10.1007/s11205-016-1271-z,TRUE,Springer,Social Indicators Research,0303-8300,0303-8300,1573-0921,0303-8300,NA,TRUE,NA,NA,ut:000398056100017,http://link.springer.com/article/10.1007/s11205-016-1271-z,FALSE
+su,2016,2200,10.1007/s11205-016-1528-6,TRUE,Springer,Social Indicators Research,0303-8300,0303-8300,1573-0921,0303-8300,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+su,2016,2200,10.1007/s11214-016-0294-8,TRUE,Springer,Space Science Reviews,0038-6308,0038-6308,1572-9672,0038-6308,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+su,2016,2200,10.1007/s11229-016-1186-x,TRUE,Springer,Synthese,0039-7857,0039-7857,1573-0964,0039-7857,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+su,2016,2200,10.1007/s11229-016-1244-4,TRUE,Springer,Synthese,0039-7857,0039-7857,1573-0964,0039-7857,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+su,2016,2200,10.1007/s11356-016-6241-0,TRUE,Springer,Environmental Science and Pollution Research,0944-1344,0944-1344,1614-7499,0944-1344,http://creativecommons.org/licenses/by/4.0,TRUE,26873824,PMC4871913,ut:000376421400085,NA,FALSE
+su,2016,2200,10.1007/s11356-016-7375-9,TRUE,Springer,Environmental Science and Pollution Research,0944-1344,0944-1344,1614-7499,0944-1344,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+su,2016,2200,10.1007/s11356-016-7883-7,TRUE,Springer,Environmental Science and Pollution Research,0944-1344,0944-1344,1614-7499,0944-1344,http://creativecommons.org/licenses/by/4.0,TRUE,27766522,PMC5219026,ut:000392105700093,NA,FALSE
+su,2016,2200,10.1007/s11356-016-7991-4,TRUE,Springer,Environmental Science and Pollution Research,0944-1344,0944-1344,1614-7499,0944-1344,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+su,2016,2200,10.1007/s11406-016-9761-4,TRUE,Springer,Philosophia,0048-3893,0048-3893,1574-9274,0048-3893,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000400403700019,NA,FALSE
+su,2016,2200,10.1007/s11625-016-0397-x,TRUE,Springer,Sustainability Science,1862-4065,1862-4065,1862-4057,1862-4057,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000386378100003,NA,FALSE
+su,2016,2200,10.1007/s11625-016-0409-x,TRUE,Springer,Sustainability Science,1862-4065,1862-4065,1862-4057,1862-4057,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000393593200009,NA,FALSE
+su,2016,2200,10.1007/s11698-016-0144-7,TRUE,Springer,Cliometrica,1863-2505,1863-2505,1863-2513,1863-2505,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000400021400004,http://link.springer.com/article/10.1007/s11698-016-0144-7,FALSE
+su,2016,2200,10.1007/s12132-016-9294-8,TRUE,Springer,Urban Forum,1015-3802,1015-3802,1874-6330,1015-3802,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+su,2016,2200,10.1007/s13280-016-0776-7,TRUE,Springer,Ambio,0044-7447,0044-7447,1654-7209,0044-7447,http://creativecommons.org/licenses/by/4.0,TRUE,27098316,PMC5012997,ut:000382860500003,NA,FALSE
+su,2016,2200,10.1007/s13280-016-0847-9,TRUE,Springer,Ambio,0044-7447,0044-7447,1654-7209,0044-7447,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000399228700003,NA,FALSE
+su,2016,2200,10.1007/s13524-016-0498-2,TRUE,Springer,Demography,0070-3370,0070-3370,1533-7790,0070-3370,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000385144600005,NA,FALSE
+su,2016,2200,10.1007/s40675-016-0055-y,TRUE,Springer,Current Sleep Medicine Reports,2198-6401,NA,2198-6401,2198-6401,http://creativecommons.org/licenses/by/4.0,TRUE,28003955,NA,NA,NA,FALSE
 su,2016,2200,10.1007/s40889-016-0026-7,TRUE,Springer,International Journal of Ethics Education,2363-9997,2363-9997,2364-0006,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2231,10.1016/j.jmarsys.2015.10.005,TRUE,Elsevier,Journal of Marine Systems,0924-7963,0924-7963,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2275,10.1093/ije/dyw048,TRUE,Oxford University Press (OUP),International Journal of Epidemiology,0300-5771,0300-5771,1464-3685,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2275,10.1093/rfs/hhw014,TRUE,Oxford University Press (OUP),Review of Financial Studies,0893-9454,0893-9454,1465-7368,NA,NA,TRUE,NA,NA,NA,https://academic.oup.com/rfs/article/29/10/2814/2223352/,FALSE
-su,2016,2276,10.3389/fpsyg.2016.01450,FALSE,Frontiers,Frontiers in Psychology,1664-1078,NA,1664-1078,NA,NA,TRUE,NA,NA,NA,http://journal.frontiersin.org/article/10.3389/fpsyg.2016.01450/full,TRUE
-su,2016,2290,10.3389/fpsyg.2016.01146,FALSE,Frontiers,Frontiers in Psychology,1664-1078,NA,1664-1078,NA,NA,TRUE,27559320,PMC4978721,NA,http://journal.frontiersin.org/article/10.3389/fpsyg.2016.01146/full,TRUE
-su,2016,2313.56,10.1128/mBio.01670-15,FALSE,American Society for Microbiology,mBio,2150-7511,NA,2150-7511,NA,NA,TRUE,26884432,PMC4752598,NA,NA,TRUE
-su,2016,2329,10.1002/2016GL070275,TRUE,Wiley,Geophysical Research Letters,0094-8276,0094-8276,1944-8007,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,http://onlinelibrary.wiley.com/doi/10.1002/2016GL070275/full,FALSE
-su,2016,2330.89,10.1021/acscatal.6b01760,TRUE,American Chemical Society (ACS),ACS Catalysis,2155-5435,2155-5435,2155-5435,NA,http://pubs.acs.org/page/policy/authorchoice_ccby_termsofuse.html,TRUE,NA,NA,NA,http://pubs.acs.org/doi/full/10.1021/acscatal.6b01760,FALSE
-su,2016,2340,10.1088/0031-8949/2015/T166/014063,TRUE,IOP Publishing,Physica Scripta,0031-8949,0031-8949,1402-4896,NA,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2340,10.1093/eurpub/ckw025,TRUE,Oxford University Press (OUP),European Journal of Public Health,1101-1262,1101-1262,1464-360X,NA,NA,TRUE,27032996,PMC4884330,NA,NA,FALSE
-su,2016,2345.1,10.1016/j.jbi.2016.11.006,TRUE,Elsevier,Journal of Biomedical Informatics,1532-0464,1532-0464,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27919732,NA,NA,NA,FALSE
-su,2016,2357,10.3389/fnins.2016.00533,FALSE,Frontiers,Frontiers in Neuroscience,1662-453X,NA,1662-453X,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-su,2016,2367.83,10.3389/fnmol.2016.00097,FALSE,Frontiers,Frontiers in Molecular Neuroscience,1662-5099,NA,1662-5099,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-su,2016,2367.83,10.3389/fphys.2016.00572,FALSE,Frontiers,Frontiers in Physiology,1664-042X,NA,1664-042X,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-su,2016,2400,10.1038/hdy.2016.44,TRUE,Nature Publishing Group,Heredity,0018-067X,0018-067X,1365-2540,NA,NA,TRUE,27328654,PMC5026756,NA,NA,FALSE
-su,2016,2414.89,10.1098/rspb.2015.2857,TRUE,The Royal Society,Proceedings of the Royal Society B: Biological Sciences,0962-8452,0962-8452,1471-2954,NA,NA,TRUE,26962144,PMC4810857,NA,NA,FALSE
-su,2016,2450,10.1093/bjsw/bcw167,TRUE,Oxford University Press (OUP),British Journal of Social Work,0045-3102,0045-3102,1468-263X,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2450,10.1093/esr/jcw053,TRUE,Oxford University Press (OUP),European Sociological Review,0266-7215,0266-7215,1468-2672,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2450,10.1093/ije/dyw295,TRUE,Oxford University Press (OUP),International Journal of Epidemiology,0300-5771,0300-5771,1464-3685,NA,NA,TRUE,28031308,NA,NA,NA,FALSE
-su,2016,2454,10.1016/j.jenvrad.2016.02.007,TRUE,Elsevier,Journal of Environmental Radioactivity,0265-931X,0265-931X,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26913978,NA,NA,http://www.sciencedirect.com/science/article/pii/S0265931X16300303,FALSE
-su,2016,2455,10.1016/j.scitotenv.2016.02.176,TRUE,Elsevier,Science of The Total Environment,0048-9697,0048-9697,1879-1026,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26956179,NA,NA,http://www.sciencedirect.com/science/article/pii/S0048969716303874,FALSE
-su,2016,2500,10.1002/cssc.201601171,TRUE,Wiley,ChemSusChem,1864-5631,1864-5631,1864-564X,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27966290,NA,NA,http://onlinelibrary.wiley.com/doi/10.1002/cssc.201601171/full,FALSE
-su,2016,2513.17,10.1104/pp.15.01531,TRUE,American Society of Plant Biologists (ASPB),Plant Physiology,0032-0889,0032-0889,1532-2548,NA,NA,TRUE,27208263,NA,NA,NA,FALSE
-su,2016,2539.08,10.1088/0953-4075/49/16/162001,TRUE,IOP Publishing,"Journal of Physics B: Atomic, Molecular and Optical Physics",0953-4075,0953-4075,1361-6455,NA,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,NA,http://iopscience.iop.org/article/10.1088/0953-4075/49/16/162001,FALSE
-su,2016,2570.59,10.1016/j.quascirev.2016.07.029,TRUE,Elsevier,Quaternary Science Reviews,0277-3791,0277-3791,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2570.59,10.1016/j.quascirev.2016.07.032,TRUE,Elsevier,Quaternary Science Reviews,0277-3791,0277-3791,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2600,10.1093/bjc/azv114,TRUE,Oxford University Press (OUP),British Journal of Criminology,0007-0955,0007-0955,1464-3529,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2650,10.1093/ntr/ntw188,TRUE,Oxford University Press (OUP),Nicotine & Tobacco Research,1462-2203,1462-2203,1469-994X,NA,NA,TRUE,NA,NA,NA,http://ntr.oxfordjournals.org/content/early/2016/08/18/ntr.ntw188.full,FALSE
-su,2016,2658,10.1017/S1368980016001440,TRUE,Cambridge University Press (CUP),Public Health Nutrition,1368-9800,1368-9800,1475-2727,NA,NA,TRUE,27329947,PMC5217467,NA,https://www.cambridge.org/core/journals/public-health-nutrition/article/div-classtitlesocial-patterning-of-overeating-binge-eating-compensatory-behaviours-and-symptoms-of-bulimia-nervosa-in-young-adult-women-results-from-the-australian-longitudinal-study-on-womens-healthdiv/9FB541DBA5FA92022911FE93700CDBD5,FALSE
-su,2016,2667,10.1017/S2045796016000445,TRUE,Cambridge University Press (CUP),Epidemiology and Psychiatric Sciences,2045-7960,2045-7960,2045-7979,NA,NA,TRUE,NA,NA,NA,https://www.cambridge.org/core/journals/epidemiology-and-psychiatric-sciences/article/div-classtitlethe-use-of-psychiatric-services-by-young-adults-who-came-to-sweden-as-teenage-refugees-a-national-cohort-studydiv/52E7A0AB5F2357F7078D4C5E799DB1CB/core-reader,FALSE
-su,2016,2680.34,10.1073/pnas.1601196113,TRUE,National Academy of Sciences,Proceedings of the National Academy of Sciences,0027-8424,0027-8424,1091-6490,NA,http://www.pnas.org/site/misc/userlicense.xhtml,TRUE,27432958,PMC4978307,NA,NA,FALSE
-su,2016,2700,10.1038/ismej.2016.17,TRUE,Nature Publishing Group,ISME Journal,1751-7362,1751-7362,1751-7370,NA,NA,TRUE,26918665,PMC4989308,NA,NA,FALSE
-su,2016,2706,10.1016/j.ecoser.2016.08.004,TRUE,Elsevier,Ecosystem Services,2212-0416,2212-0416,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S2212041616302170,FALSE
-su,2016,2706,10.1016/j.ecss.2016.10.009,TRUE,Elsevier,"Estuarine, Coastal and Shelf Science",0272-7714,0272-7714,1096-0015,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S0272771416304383,FALSE
-su,2016,2706,10.1016/j.envpol.2016.09.043,TRUE,Elsevier,Environmental Pollution,0269-7491,0269-7491,1873-6424,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27707599,NA,NA,http://www.sciencedirect.com/science/article/pii/S0269749116312969,FALSE
-su,2016,2706,10.1016/j.envpol.2016.11.001,TRUE,Elsevier,Environmental Pollution,0269-7491,0269-7491,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27836476,NA,NA,NA,FALSE
-su,2016,2722.25,10.1016/j.jssc.2016.04.030,TRUE,Elsevier,Journal of Solid State Chemistry,0022-4596,0022-4596,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2750,10.1007/s00148-016-0595-y,TRUE,Springer,Journal of Population Economics,0933-1433,0933-1433,1432-1475,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,http://link.springer.com/article/10.1007/s00148-016-0595-y,FALSE
-su,2016,2750,10.1007/s10021-016-9986-x,TRUE,Springer,Ecosystems,1432-9840,1432-9840,1435-0629,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2750,10.1007/s10021-016-9998-6,TRUE,Springer,Ecosystems,1432-9840,1432-9840,1435-0629,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2750,10.1007/s10433-015-0358-8,TRUE,Springer,European Journal of Ageing,1613-9372,1613-9372,1613-9380,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2750,10.1007/s10964-016-0430-5,TRUE,Springer,Journal of Youth and Adolescence,0047-2891,0047-2891,1573-6601,NA,http://www.springer.com/tdm,TRUE,26847325,PMC4901095,NA,http://link.springer.com/article/10.1007/s10964-016-0430-5,FALSE
-su,2016,2750,10.1007/s11269-016-1363-1,TRUE,Springer,Water Resources Management,0920-4741,0920-4741,1573-1650,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2750,10.1007/s12529-016-9565-8,TRUE,Springer,International Journal of Behavioral Medicine,1070-5503,1070-5503,1532-7558,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2750,10.1007/s13280-016-0777-6,TRUE,Springer,Ambio,0044-7447,0044-7447,1654-7209,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27020688,PMC4980319,NA,NA,FALSE
-su,2016,2751,10.1016/j.jpba.2016.09.029,TRUE,Elsevier,Journal of Pharmaceutical and Biomedical Analysis,0731-7085,0731-7085,1873-264X,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27718394,NA,NA,http://www.sciencedirect.com/science/article/pii/S0731708516307026,FALSE
-su,2016,2760,10.1177/0013164416668950,TRUE,SAGE Publications,Educational and Psychological Measurement,0013-1644,0013-1644,1552-3888,NA,NA,TRUE,NA,NA,NA,http://epm.sagepub.com/content/early/2016/09/01/0013164416668950.full,FALSE
-su,2016,2780,10.1111/jora.12281,TRUE,Wiley,Journal of Research on Adolescence,1050-8392,1050-8392,1532-7795,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,http://onlinelibrary.wiley.com/doi/10.1111/jora.12281/full,FALSE
-su,2016,2792.75,10.1002/jat.3304,TRUE,Wiley,Journal of Applied Toxicology,0260-437X,0260-437X,1099-1263,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,26935862,PMC5069579,NA,http://onlinelibrary.wiley.com/doi/10.1002/jat.3304/full,FALSE
-su,2016,2792.75,10.1111/eff.12308,TRUE,Wiley,Ecology of Freshwater Fish,0906-6691,0906-6691,1600-0633,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,http://onlinelibrary.wiley.com/doi/10.1111/eff.12308/full,FALSE
-su,2016,2794,10.1111/1365-2745.12564,TRUE,Wiley,Journal of Ecology,0022-0477,NA,1365-2745,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,http://onlinelibrary.wiley.com/doi/10.1111/1365-2745.12564/full,FALSE
-su,2016,2804,10.1111/jcpp.12560,TRUE,Wiley,Journal of Child Psychology and Psychiatry,0021-9630,0021-9630,1469-7610,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27058980,NA,NA,http://onlinelibrary.wiley.com/doi/10.1111/jcpp.12560/full,FALSE
-su,2016,2812.12,10.1111/1365-2656.12579,TRUE,Wiley,Journal of Animal Ecology,0021-8790,NA,1365-2656,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27476800,NA,NA,http://onlinelibrary.wiley.com/doi/10.1111/1365-2656.12579/full,FALSE
-su,2016,2830.49,10.1007/s10750-016-2982-5,TRUE,Springer,Hydrobiologia,0018-8158,0018-8158,1573-5117,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2832.88,10.1139/cjfas-2016-0039,TRUE,Canadian Science Publishing,Canadian Journal of Fisheries and Aquatic Sciences,0706-652X,0706-652X,1205-7533,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2834.29,10.1021/acs.est.5b05583,TRUE,American Chemical Society (ACS),Environmental Science & Technology,0013-936X,0013-936X,1520-5851,NA,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,27144960,NA,NA,NA,FALSE
-su,2016,2941.18,10.1002/ange.201511139,TRUE,Wiley,Angewandte Chemie,0044-8249,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2941.18,10.1002/ange.201600696,TRUE,Wiley,Angewandte Chemie,0044-8249,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2941.18,10.1002/ange.201601505,TRUE,Wiley,Angewandte Chemie,0044-8249,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,NA,FALSE
-su,2016,2941.18,10.1002/anie.201602137,TRUE,Wiley,Angewandte Chemie,1433-7851,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27219856,PMC5089581,NA,NA,FALSE
-su,2016,2941.18,10.1002/anie.201606108,TRUE,Wiley,Angewandte Chemie International Edition,1433-7851,1433-7851,1521-3773,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27538999,PMC5113805,NA,http://onlinelibrary.wiley.com/doi/10.1002/anie.201606108/full,FALSE
-su,2016,295.36,10.1016/j.chemosphere.2016.08.082,TRUE,Elsevier,Chemosphere,0045-6535,0045-6535,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27643982,NA,NA,NA,FALSE
-su,2016,3000,10.1002/2016JF004050,TRUE,Wiley,Journal of Geophysical Research: Earth Surface,2169-9003,NA,NA,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,NA,FALSE
-su,2016,3000,10.1242/jeb.129411,TRUE,The Company of Biologists,Journal of Experimental Biology,0022-0949,0022-0949,1477-9145,NA,NA,TRUE,NA,NA,NA,http://jeb.biologists.org/content/219/19/2971,FALSE
-su,2016,3006,10.1111/add.13454,TRUE,Wiley,Addiction,0965-2140,0965-2140,1360-0443,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27178010,PMC5089658,NA,http://onlinelibrary.wiley.com/doi/10.1111/add.13454/full,FALSE
-su,2016,3046.47,10.1088/0143-0807/37/5/055603,TRUE,IOP Publishing,European Journal of Physics,0143-0807,0143-0807,1361-6404,NA,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,NA,http://iopscience.iop.org/article/10.1088/0143-0807/37/5/055603,FALSE
-su,2016,313,10.4172/2375-4427.1000145,FALSE,OMICS Publishing Group,"Journal of Communication Disorders, Deaf Studies & Hearing Aids",2375-4427,NA,2375-4427,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,3139.9,10.1016/j.clay.2016.10.002,TRUE,Elsevier,Applied Clay Science,0169-1317,0169-1317,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-su,2016,3157,10.1016/j.gloenvcha.2016.06.008,TRUE,Elsevier,Global Environmental Change,0959-3780,0959-3780,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S0959378016300826,FALSE
-su,2016,3260,10.1111/1462-2920.13407,TRUE,Wiley,Environmental Microbiology,1462-2912,1462-2912,1462-2920,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27306515,NA,NA,http://onlinelibrary.wiley.com/doi/10.1111/1462-2920.13407/full,FALSE
-su,2016,3300,10.1038/npjqi.2016.10,FALSE,Nature Publishing Group,npj Quantum Information,2056-6387,NA,2056-6387,NA,http://www.springer.com/tdm,TRUE,NA,NA,NA,NA,TRUE
-su,2016,3404,10.1074/jbc.M115.701540,TRUE,American Society for Biochemistry & Molecular Biology (ASBMB),Journal of Biological Chemistry,0021-9258,0021-9258,1083-351X,NA,NA,TRUE,26867577,PMC4817197,NA,NA,FALSE
-su,2016,3500,10.1002/anie.201608605,TRUE,Wiley,Angewandte Chemie International Edition,1433-7851,1433-7851,1521-3773,NA,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27735124,PMC5129484,NA,http://onlinelibrary.wiley.com/doi/10.1002/anie.201608605/full,FALSE
-su,2016,3500,10.1175/JPO-D-15-0219.1,TRUE,American Meteorological Society,Journal of Physical Oceanography,0022-3670,0022-3670,1520-0485,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,3700,10.1038/ncomms12016,FALSE,Nature Publishing Group,Nature Communications,2041-1723,NA,2041-1723,NA,NA,TRUE,27327838,PMC4919534,NA,NA,TRUE
-su,2016,3700,10.1038/ncomms12113,FALSE,Nature Publishing Group,Nature Communications,2041-1723,NA,2041-1723,NA,NA,TRUE,27385026,PMC4941054,NA,NA,TRUE
-su,2016,3700,10.1038/ncomms12776,FALSE,Nature Publishing Group,Nature Communications,2041-1723,NA,2041-1723,NA,NA,TRUE,27627859,PMC5027618,NA,NA,TRUE
-su,2016,3700,10.1038/ncomms13653,FALSE,Nature Publishing Group,Nature Communications,2041-1723,NA,2041-1723,NA,NA,TRUE,27897191,PMC5141343,NA,NA,TRUE
-su,2016,406,10.1080/09553002.2016.1178866,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,NA,NA,TRUE,27160022,NA,NA,NA,FALSE
-su,2016,406,10.1080/09553002.2016.1206228,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,NA,NA,TRUE,27547893,NA,NA,NA,FALSE
-su,2016,406,10.1080/09553002.2016.1206230,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,NA,NA,TRUE,27559844,NA,NA,NA,FALSE
-su,2016,406,10.1080/09553002.2016.1206231,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,NA,NA,TRUE,27673504,NA,NA,NA,FALSE
-su,2016,406,10.1080/09553002.2016.1206232,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,NA,NA,TRUE,27686284,NA,NA,NA,FALSE
-su,2016,406,10.1080/09553002.2016.1206233,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,NA,NA,TRUE,27437830,NA,NA,NA,FALSE
-su,2016,406,10.1080/09553002.2016.1207822,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,NA,NA,TRUE,27686523,NA,NA,NA,FALSE
-su,2016,406,10.1080/09553002.2016.1213455,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,NA,NA,TRUE,27735728,NA,NA,NA,FALSE
-su,2016,406,10.1080/09553002.2016.1221545,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,NA,NA,TRUE,27584947,NA,NA,NA,FALSE
-su,2016,406,10.1080/09553002.2016.1222092,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,NA,NA,TRUE,27705052,NA,NA,NA,FALSE
-su,2016,406,10.1080/09553002.2016.1227105,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,NA,NA,TRUE,27626709,NA,NA,NA,FALSE
-su,2016,406,10.1080/09553002.2016.1227106,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,NA,NA,TRUE,27572921,NA,NA,NA,FALSE
-su,2016,406,10.1080/09553002.2016.1227107,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,NA,NA,TRUE,27557790,NA,NA,NA,FALSE
-su,2016,406,10.1080/09553002.2016.1230239,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,NA,NA,TRUE,27707245,NA,NA,NA,FALSE
-su,2016,406,10.1080/09553002.2016.1233370,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,NA,NA,TRUE,27766931,NA,NA,NA,FALSE
-su,2016,406,10.1080/09553002.2016.1234725,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,NA,NA,TRUE,27813725,NA,NA,NA,FALSE
-su,2016,406,10.1080/09553002.2016.1235296,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,NA,NA,TRUE,27778526,NA,NA,NA,FALSE
-su,2016,450,10.3897/zookeys.574.7002,FALSE,Pensoft Publishers,ZooKeys,1313-2970,1313-2989,1313-2970,NA,http://creativecommons.org/licenses/by/4.0/,TRUE,27110182,PMC4829907,NA,NA,TRUE
-su,2016,5501.96,10.1016/j.cub.2016.07.057,TRUE,Cell Press,Current Biology,0960-9822,0960-9822,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27498567,PMC5069350,NA,NA,FALSE
-su,2016,590,10.15195/v3.a3,FALSE,Society for Sociological Science,Sociological Science,2330-6696,NA,2330-6696,NA,NA,TRUE,NA,NA,NA,https://www.sociologicalscience.com/articles-v3-3-39/,FALSE
-su,2016,667,10.1080/01431161.2016.1249307,TRUE,Taylor & Francis,International Journal of Remote Sensing,0143-1161,0143-1161,1366-5901,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,668,10.17585/njlr.v2.224,FALSE,Taylor & Francis,Nordic Journal of Literacy Research,2464-1596,NA,2464-1596,NA,NA,TRUE,NA,NA,NA,https://nordicliteracy.net/index.php/njlr/article/view/224,TRUE
-su,2016,668,10.3389/fnagi.2016.00203,FALSE,Frontiers,Frontiers in Aging Neuroscience,1663-4365,NA,1663-4365,NA,NA,TRUE,27610082,PMC4997967,NA,http://journal.frontiersin.org/article/10.3389/fnagi.2016.00203/full,TRUE
-su,2016,699.56,10.1021/acs.inorgchem.5b02733,TRUE,American Chemical Society (ACS),Inorganic Chemistry,0020-1669,0020-1669,1520-510X,NA,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,26812142,NA,NA,http://pubs.acs.org/doi/full/10.1021/acs.inorgchem.5b02733,FALSE
-su,2016,708.816,10.1021/acs.jpcc.5b12490,TRUE,American Chemical Society (ACS),The Journal of Physical Chemistry C,1932-7447,1932-7447,1932-7455,NA,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,NA,NA,NA,NA,FALSE
-su,2016,734,10.1080/19491034.2016.1220465,TRUE,Taylor & Francis,Nucleus,1949-1034,1949-1034,1949-1042,NA,NA,TRUE,27541860,PMC5039005,NA,NA,FALSE
-su,2016,892.5,10.5194/gmd-9-1673-2016,TRUE,Copernicus Publications,Geoscientific Model Development,1991-9603,NA,1991-9603,NA,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,NA,TRUE
-su,2016,893,10.1016/j.jmva.2016.02.013,TRUE,Elsevier,Journal of Multivariate Analysis,0047-259X,0047-259X,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S0047259X16000579,FALSE
-su,2016,907.17,10.1107/S160057671601863X,TRUE,International Union of Crystallography (IUCr),Journal of Applied Crystallography,1600-5767,NA,1600-5767,NA,http://creativecommons.org/licenses/by/2.0/uk/legalcode,TRUE,28190994,PMC5294395,NA,NA,FALSE
-su,2016,933.22,10.1021/acs.orglett.6b01132,TRUE,American Chemical Society (ACS),Organic Letters,1523-7060,1523-7060,1523-7052,NA,http://pubs.acs.org/page/policy/authorchoice_ccby_termsofuse.html,TRUE,27166509,NA,NA,http://pubs.acs.org/doi/full/10.1021/acs.orglett.6b01132,FALSE
-su,2016,987.5,10.1080/23746149.2016.1165630,TRUE,Taylor & Francis,Advances in Physics: X,2374-6149,NA,2374-6149,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,992.16,10.1016/j.alcr.2016.11.002,TRUE,Elsevier,Advances in Life Course Research,1040-2608,1040-2608,NA,NA,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
-umu,2008,2660,10.1080/17450120802069109,TRUE,Taylor & Francis,Vulnerable Children and Youth Studies,1745-0128,1745-0128,1745-0136,NA,NA,TRUE,22639678,PMC3357969,NA,NA,FALSE
-umu,2013,2429,10.1080/09644016.2013.835201,TRUE,Taylor & Francis,Environmental Politics,0964-4016,0964-4016,1743-8934,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-umu,2013,2429,10.1080/17542863.2013.800568,TRUE,Taylor & Francis,International Journal of Culture and Mental Health,1754-2863,1754-2863,1754-2871,NA,NA,TRUE,24999370,PMC4066927,NA,NA,FALSE
-umu,2013,2630,10.1080/13607863.2012.758231,TRUE,Taylor & Francis,Aging & Mental Health,1360-7863,1360-7863,1364-6915,NA,NA,TRUE,23339600,PMC3701937,NA,NA,FALSE
-umu,2014,3040,10.3109/0284186X.2014.953258,TRUE,Taylor & Francis,Acta Oncologica,0284-186X,0284-186X,1651-226X,NA,NA,TRUE,25180912,PMC4438349,NA,NA,FALSE
-umu,2014,755,10.1159/000358121,FALSE,Karger,Cerebrovascular Diseases Extra,1664-5456,NA,1664-5456,NA,NA,TRUE,24715896,PMC3975210,NA,NA,TRUE
-umu,2014,755,10.1159/000364816,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,NA,NA,TRUE,25177334,PMC4132238,NA,NA,TRUE
-umu,2015,0,10.3109/03009734.2015.1122687,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,26849806,PMC4812053,NA,NA,FALSE
-umu,2015,1585,10.1159/000369726,FALSE,Karger,Cellular Physiology and Biochemistry,1421-9778,1015-8987,1421-9778,NA,NA,TRUE,25613309,NA,NA,NA,TRUE
-umu,2015,2132,10.1080/13669877.2015.1121905,TRUE,Taylor & Francis,Journal of Risk Research,1366-9877,1366-9877,1466-4461,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-umu,2015,3040,10.3109/02713683.2015.1088954,TRUE,Taylor & Francis,Current Eye Research,0271-3683,0271-3683,1460-2202,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-umu,2015,468,10.1080/15592324.2014.1003753,TRUE,Taylor & Francis,Plant Signaling & Behavior,NA,NA,NA,NA,NA,FALSE,25761224,PMC4622721,NA,NA,NA
-umu,2015,694,10.3109/23320885.2015.1054392,FALSE,Taylor & Francis,Case Reports in Plastic Surgery and Hand Surgery,2332-0885,NA,2332-0885,NA,NA,TRUE,27252972,PMC4793792,NA,NA,FALSE
-umu,2015,702,10.1080/15476286.2014.996099,TRUE,Taylor & Francis,RNA Biology,1547-6286,1547-6286,1555-8584,NA,NA,TRUE,25590644,PMC4615572,NA,NA,FALSE
-umu,2015,702,10.1080/15476286.2015.1017211,TRUE,Taylor & Francis,RNA Biology,1547-6286,1547-6286,1555-8584,NA,NA,TRUE,25826569,PMC4615753,NA,NA,FALSE
-umu,2015,702,10.1080/15476286.2015.1110674,TRUE,Taylor & Francis,RNA Biology,1547-6286,1547-6286,1555-8584,NA,NA,TRUE,26580233,PMC4829319,NA,NA,FALSE
-umu,2015,755,10.1159/000381535,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,NA,NA,TRUE,26078750,PMC4463780,NA,NA,TRUE
-umu,2016,0,10.1080/16549716.2017.1272236,FALSE,Taylor & Francis,Global Health Action,1654-9716,1654-9716,1654-9880,NA,NA,TRUE,28219314,NA,NA,NA,TRUE
-umu,2016,0,10.1080/16549716.2017.1275189,FALSE,Taylor & Francis,Global Health Action,1654-9716,1654-9716,1654-9880,NA,NA,TRUE,28304235,NA,NA,NA,TRUE
-umu,2016,0,10.1080/20004508.2016.1275185,FALSE,Taylor & Francis,Education Inquiry,2000-4508,NA,2000-4508,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-umu,2016,0,10.3109/03009734.2016.1152332,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,27007259,PMC4900065,NA,NA,FALSE
-umu,2016,2074,10.1080/14790718.2016.1155591,TRUE,Taylor & Francis,International Journal of Multilingualism,1479-0718,1479-0718,1747-7530,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2132,10.1080/00313831.2015.1119723,TRUE,Taylor & Francis,Scandinavian Journal of Educational Research,0031-3831,0031-3831,1470-1170,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2132,10.1080/01443410.2016.1143087,TRUE,Taylor & Francis,Educational Psychology,0144-3410,0144-3410,1469-5820,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2132,10.1080/0966369X.2016.1249346,TRUE,Taylor & Francis,"Gender, Place & Culture",0966-369X,0966-369X,1360-0524,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2132,10.1080/0969594X.2016.1142935,TRUE,Taylor & Francis,"Assessment in Education: Principles, Policy & Practice",0969-594X,0969-594X,1465-329X,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2132,10.1080/1088937X.2016.1148794,TRUE,Taylor & Francis,Polar Geography,1088-937X,1088-937X,1939-0513,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2132,10.1080/14623943.2016.1206881,TRUE,Taylor & Francis,Reflective Practice,1462-3943,1462-3943,1470-1103,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2132,10.1080/17441692.2016.1149202,TRUE,Taylor & Francis,Global Public Health,1744-1692,1744-1692,1744-1706,NA,NA,TRUE,26948258,NA,NA,NA,FALSE
-umu,2016,2132,10.3109/08039488.2016.1162846,TRUE,Taylor & Francis,Nordic Journal of Psychiatry,0803-9488,0803-9488,1502-4725,NA,NA,TRUE,27103550,NA,NA,NA,FALSE
-umu,2016,2200,10.1007/s00038-016-0899-4,TRUE,Springer,International Journal of Public Health,1661-8556,1661-8556,1661-8564,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27695901,PMC5348557,NA,NA,FALSE
-umu,2016,2200,10.1007/s00158-016-1553-8,TRUE,Springer,Structural and Multidisciplinary Optimization,1615-147X,1615-147X,1615-1488,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2200,10.1007/s00221-016-4839-6,TRUE,Springer,Experimental Brain Research,0014-4819,0014-4819,1432-1106,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27885405,PMC5315705,NA,NA,FALSE
-umu,2016,2200,10.1007/s00246-016-1507-3,TRUE,Springer,Pediatric Cardiology,0172-0643,0172-0643,1432-1971,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27837301,PMC5331095,NA,NA,FALSE
-umu,2016,2200,10.1007/s00249-016-1158-6,TRUE,Springer,European Biophysics Journal,0175-7571,0175-7571,1432-1017,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27461369,PMC5346443,NA,NA,FALSE
-umu,2016,2200,10.1007/s00345-016-1952-x,TRUE,Springer,World Journal of Urology,0724-4983,0724-4983,1433-8726,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2200,10.1007/s00442-016-3779-y,TRUE,Springer,Oecologia,0029-8549,0029-8549,1432-1939,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27915414,PMC5306166,NA,NA,FALSE
-umu,2016,2200,10.1007/s00484-016-1270-4,TRUE,Springer,International Journal of Biometeorology,0020-7128,0020-7128,1432-1254,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2200,10.1007/s00502-016-0424-8,TRUE,Springer,e & i Elektrotechnik und Informationstechnik,0932-383X,0932-383X,1613-7620,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2200,10.1007/s00590-016-1873-9,TRUE,Springer,European Journal of Orthopaedic Surgery & Traumatology,1633-8065,1633-8065,1432-1068,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2200,10.1007/s10021-016-0020-0,TRUE,Springer,Ecosystems,1432-9840,1432-9840,1435-0629,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2200,10.1007/s10198-016-0851-9,TRUE,Springer,The European Journal of Health Economics,1618-7598,1618-7598,1618-7601,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2200,10.1007/s10433-016-0404-1,TRUE,Springer,European Journal of Ageing,1613-9372,1613-9372,1613-9380,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2200,10.1007/s10804-016-9248-3,TRUE,Springer,Journal of Adult Development,1068-0667,1068-0667,1573-3440,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2200,10.1007/s10805-016-9265-7,TRUE,Springer,Journal of Academic Ethics,1570-1727,1570-1727,1572-8544,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2200,10.1007/s11060-016-2271-1,TRUE,Springer,Journal of Neuro-Oncology,0167-594X,0167-594X,1573-7373,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27664151,PMC5258803,NA,NA,FALSE
-umu,2016,2200,10.1007/s11104-016-3033-8,TRUE,Springer,Plant and Soil,0032-079X,0032-079X,1573-5036,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2200,10.1007/s11104-016-3038-3,TRUE,Springer,Plant and Soil,0032-079X,0032-079X,1573-5036,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2200,10.1007/s11136-016-1367-6,TRUE,Springer,Quality of Life Research,0962-9343,0962-9343,1573-2649,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27444778,PMC5243882,NA,NA,FALSE
-umu,2016,2200,10.1007/s11144-016-1069-7,TRUE,Springer,"Reaction Kinetics, Mechanisms and Catalysis",1878-5190,1878-5190,1878-5204,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2200,10.1007/s11192-016-2097-9,TRUE,Springer,Scientometrics,0138-9130,0138-9130,1588-2861,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27942088,PMC5124050,NA,NA,FALSE
-umu,2016,2200,10.1007/s11239-016-1411-y,TRUE,Springer,Journal of Thrombosis and Thrombolysis,0929-5305,0929-5305,1573-742X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27522504,PMC5233740,NA,NA,FALSE
-umu,2016,2200,10.1007/s11262-016-1416-9,TRUE,Springer,Virus Genes,0920-8569,0920-8569,1572-994X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28000080,PMC5357487,NA,NA,FALSE
-umu,2016,2200,10.1007/s11295-016-1074-z,TRUE,Springer,Tree Genetics & Genomes,1614-2942,1614-2942,1614-2950,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2200,10.1007/s11306-016-1120-8,TRUE,Springer,Metabolomics,1573-3882,1573-3882,1573-3890,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2200,10.1007/s11422-016-9784-y,TRUE,Springer,Cultural Studies of Science Education,1871-1502,1871-1502,1871-1510,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2200,10.1007/s12021-016-9320-y,TRUE,Springer,Neuroinformatics,1539-2791,1539-2791,1559-0089,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27873151,PMC5306162,NA,NA,FALSE
-umu,2016,2200,10.1007/s12076-016-0176-4,TRUE,Springer,Letters in Spatial and Resource Sciences,1864-4031,1864-4031,1864-404X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2200,10.1007/s12350-016-0638-5,TRUE,Springer,Journal of Nuclear Cardiology,1071-3581,1071-3581,1532-6551,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-umu,2016,2200,10.1007/s40266-016-0408-8,TRUE,Springer,Drugs & Aging,1170-229X,1170-229X,1179-1969,NA,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27734278,PMC5122609,NA,NA,FALSE
-umu,2016,248,10.1080/19336934.2016.1182269,TRUE,Taylor & Francis,Fly,1933-6934,1933-6934,1933-6942,NA,NA,TRUE,27116253,PMC4970531,NA,NA,FALSE
-umu,2016,2760,10.1080/21681805.2016.1194460,TRUE,Taylor & Francis,Scandinavian Journal of Urology,2168-1805,2168-1805,2168-1813,NA,NA,TRUE,27333148,PMC5020330,NA,NA,FALSE
-umu,2016,323,10.1080/21681376.2016.1189354,FALSE,Taylor & Francis,"Regional Studies, Regional Science",2168-1376,NA,2168-1376,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-umu,2016,575,10.1080/02673843.2016.1269653,FALSE,Taylor & Francis,International Journal of Adolescence and Youth,0267-3843,0267-3843,2164-4527,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-umu,2016,662,10.1080/14756366.2016.1265520,FALSE,Taylor & Francis,Journal of Enzyme Inhibition and Medicinal Chemistry,1475-6366,1475-6366,1475-6374,NA,NA,TRUE,28114819,NA,NA,NA,FALSE
-uu,2012,2630,10.1080/00958972.2012.701008,TRUE,Taylor & Francis,Journal of Coordination Chemistry,0095-8972,0095-8972,1029-0389,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2012,2630,10.1080/10426507.2012.743145,TRUE,Taylor & Francis,"Phosphorus, Sulfur, and Silicon and the Related Elements",1042-6507,1042-6507,1563-5325,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2013,2429,10.1080/00806765.2013.855350,TRUE,Taylor & Francis,Scando-Slavica,0080-6765,0080-6765,1600-082X,NA,NA,TRUE,NA,NA,NA,NA,FALSE
+su,2016,2231,10.1016/j.jmarsys.2015.10.005,TRUE,Elsevier,Journal of Marine Systems,0924-7963,0924-7963,NA,0924-7963,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000367760500007,NA,FALSE
+su,2016,2275,10.1093/ije/dyw048,TRUE,Oxford University Press (OUP),International Journal of Epidemiology,0300-5771,0300-5771,1464-3685,0300-5771,NA,TRUE,NA,NA,ut:000402724100031,NA,FALSE
+su,2016,2275,10.1093/rfs/hhw014,TRUE,Oxford University Press (OUP),Review of Financial Studies,0893-9454,0893-9454,1465-7368,0893-9454,NA,TRUE,NA,NA,ut:000386207400007,https://academic.oup.com/rfs/article/29/10/2814/2223352/,FALSE
+su,2016,2276,10.3389/fpsyg.2016.01450,FALSE,Frontiers,Frontiers in Psychology,1664-1078,NA,1664-1078,1664-1078,NA,TRUE,NA,NA,ut:000384508200001,http://journal.frontiersin.org/article/10.3389/fpsyg.2016.01450/full,TRUE
+su,2016,2290,10.3389/fpsyg.2016.01146,FALSE,Frontiers,Frontiers in Psychology,1664-1078,NA,1664-1078,1664-1078,NA,TRUE,27559320,PMC4978721,ut:000381093100001,http://journal.frontiersin.org/article/10.3389/fpsyg.2016.01146/full,TRUE
+su,2016,2313.56,10.1128/mBio.01670-15,FALSE,American Society for Microbiology,mBio,2150-7511,NA,2150-7511,2150-7511,NA,TRUE,26884432,PMC4752598,ut:000373933100067,NA,TRUE
+su,2016,2329,10.1002/2016GL070275,TRUE,Wiley,Geophysical Research Letters,0094-8276,0094-8276,1944-8007,0094-8276,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000383290300057,http://onlinelibrary.wiley.com/doi/10.1002/2016GL070275/full,FALSE
+su,2016,2330.89,10.1021/acscatal.6b01760,TRUE,American Chemical Society (ACS),ACS Catalysis,2155-5435,2155-5435,2155-5435,2155-5435,http://pubs.acs.org/page/policy/authorchoice_ccby_termsofuse.html,TRUE,NA,NA,ut:000385057900046,http://pubs.acs.org/doi/full/10.1021/acscatal.6b01760,FALSE
+su,2016,2340,10.1088/0031-8949/2015/T166/014063,TRUE,IOP Publishing,Physica Scripta,0031-8949,0031-8949,1402-4896,0031-8949,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,ut:000368901600064,NA,FALSE
+su,2016,2340,10.1093/eurpub/ckw025,TRUE,Oxford University Press (OUP),European Journal of Public Health,1101-1262,1101-1262,1464-360X,1101-1262,NA,TRUE,27032996,PMC4884330,ut:000377470800024,NA,FALSE
+su,2016,2345.1,10.1016/j.jbi.2016.11.006,TRUE,Elsevier,Journal of Biomedical Informatics,1532-0464,1532-0464,NA,1532-0464,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27919732,NA,ut:000406235200008,NA,FALSE
+su,2016,2357,10.3389/fnins.2016.00533,FALSE,Frontiers,Frontiers in Neuroscience,1662-453X,NA,1662-453X,1662-453X,NA,TRUE,NA,NA,ut:000388649600001,NA,TRUE
+su,2016,2367.83,10.3389/fnmol.2016.00097,FALSE,Frontiers,Frontiers in Molecular Neuroscience,1662-5099,NA,1662-5099,1662-5099,NA,TRUE,NA,NA,ut:000385442500002,NA,TRUE
+su,2016,2367.83,10.3389/fphys.2016.00572,FALSE,Frontiers,Frontiers in Physiology,1664-042X,NA,1664-042X,1664-042X,NA,TRUE,NA,NA,NA,NA,TRUE
+su,2016,2400,10.1038/hdy.2016.44,TRUE,Nature Publishing Group,Heredity,0018-067X,0018-067X,1365-2540,0018-067X,NA,TRUE,27328654,PMC5026756,ut:000383707900011,NA,FALSE
+su,2016,2414.89,10.1098/rspb.2015.2857,TRUE,The Royal Society,Proceedings of the Royal Society B: Biological Sciences,0962-8452,0962-8452,1471-2954,0962-8452,NA,TRUE,26962144,PMC4810857,ut:000374921900015,NA,FALSE
+su,2016,2450,10.1093/bjsw/bcw167,TRUE,Oxford University Press (OUP),British Journal of Social Work,0045-3102,0045-3102,1468-263X,0045-3102,NA,TRUE,NA,NA,NA,NA,FALSE
+su,2016,2450,10.1093/esr/jcw053,TRUE,Oxford University Press (OUP),European Sociological Review,0266-7215,0266-7215,1468-2672,0266-7215,NA,TRUE,NA,NA,ut:000400997800001,NA,FALSE
+su,2016,2450,10.1093/ije/dyw295,TRUE,Oxford University Press (OUP),International Journal of Epidemiology,0300-5771,0300-5771,1464-3685,0300-5771,NA,TRUE,28031308,NA,ut:000406242600034,NA,FALSE
+su,2016,2454,10.1016/j.jenvrad.2016.02.007,TRUE,Elsevier,Journal of Environmental Radioactivity,0265-931X,0265-931X,NA,0265-931X,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26913978,NA,ut:000374358100009,http://www.sciencedirect.com/science/article/pii/S0265931X16300303,FALSE
+su,2016,2455,10.1016/j.scitotenv.2016.02.176,TRUE,Elsevier,Science of The Total Environment,0048-9697,0048-9697,1879-1026,0048-9697,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26956179,NA,ut:000373274700035,http://www.sciencedirect.com/science/article/pii/S0048969716303874,FALSE
+su,2016,2500,10.1002/cssc.201601171,TRUE,Wiley,ChemSusChem,1864-5631,1864-5631,1864-564X,1864-5631,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27966290,NA,ut:000394571500013,http://onlinelibrary.wiley.com/doi/10.1002/cssc.201601171/full,FALSE
+su,2016,2513.17,10.1104/pp.15.01531,TRUE,American Society of Plant Biologists (ASPB),Plant Physiology,0032-0889,0032-0889,1532-2548,0032-0889,NA,TRUE,27208263,NA,ut:000380699200015,NA,FALSE
+su,2016,2539.08,10.1088/0953-4075/49/16/162001,TRUE,IOP Publishing,"Journal of Physics B: Atomic, Molecular and Optical Physics",0953-4075,0953-4075,1361-6455,0953-4075,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,ut:000384107500001,http://iopscience.iop.org/article/10.1088/0953-4075/49/16/162001,FALSE
+su,2016,2570.59,10.1016/j.quascirev.2016.07.029,TRUE,Elsevier,Quaternary Science Reviews,0277-3791,0277-3791,NA,0277-3791,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000389116000007,NA,FALSE
+su,2016,2570.59,10.1016/j.quascirev.2016.07.032,TRUE,Elsevier,Quaternary Science Reviews,0277-3791,0277-3791,NA,0277-3791,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000383825400020,NA,FALSE
+su,2016,2600,10.1093/bjc/azv114,TRUE,Oxford University Press (OUP),British Journal of Criminology,0007-0955,0007-0955,1464-3529,0007-0955,NA,TRUE,NA,NA,ut:000387987800012,NA,FALSE
+su,2016,2650,10.1093/ntr/ntw188,TRUE,Oxford University Press (OUP),Nicotine & Tobacco Research,1462-2203,1462-2203,1469-994X,1462-2203,NA,TRUE,NA,NA,ut:000397273900003,http://ntr.oxfordjournals.org/content/early/2016/08/18/ntr.ntw188.full,FALSE
+su,2016,2658,10.1017/S1368980016001440,TRUE,Cambridge University Press (CUP),Public Health Nutrition,1368-9800,1368-9800,1475-2727,1368-9800,NA,TRUE,27329947,PMC5217467,NA,https://www.cambridge.org/core/journals/public-health-nutrition/article/div-classtitlesocial-patterning-of-overeating-binge-eating-compensatory-behaviours-and-symptoms-of-bulimia-nervosa-in-young-adult-women-results-from-the-australian-longitudinal-study-on-womens-healthdiv/9FB541DBA5FA92022911FE93700CDBD5,FALSE
+su,2016,2667,10.1017/S2045796016000445,TRUE,Cambridge University Press (CUP),Epidemiology and Psychiatric Sciences,2045-7960,2045-7960,2045-7979,2045-7960,NA,TRUE,NA,NA,NA,https://www.cambridge.org/core/journals/epidemiology-and-psychiatric-sciences/article/div-classtitlethe-use-of-psychiatric-services-by-young-adults-who-came-to-sweden-as-teenage-refugees-a-national-cohort-studydiv/52E7A0AB5F2357F7078D4C5E799DB1CB/core-reader,FALSE
+su,2016,2680.34,10.1073/pnas.1601196113,TRUE,National Academy of Sciences,Proceedings of the National Academy of Sciences,0027-8424,0027-8424,1091-6490,0027-8424,http://www.pnas.org/site/misc/userlicense.xhtml,TRUE,27432958,PMC4978307,ut:000380586600010,NA,FALSE
+su,2016,2700,10.1038/ismej.2016.17,TRUE,Nature Publishing Group,ISME Journal,1751-7362,1751-7362,1751-7370,1751-7362,NA,TRUE,26918665,PMC4989308,ut:000386664600011,NA,FALSE
+su,2016,2706,10.1016/j.ecoser.2016.08.004,TRUE,Elsevier,Ecosystem Services,2212-0416,2212-0416,NA,2212-0416,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000385526300015,http://www.sciencedirect.com/science/article/pii/S2212041616302170,FALSE
+su,2016,2706,10.1016/j.ecss.2016.10.009,TRUE,Elsevier,"Estuarine, Coastal and Shelf Science",0272-7714,0272-7714,1096-0015,0272-7714,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000408787800011,http://www.sciencedirect.com/science/article/pii/S0272771416304383,FALSE
+su,2016,2706,10.1016/j.envpol.2016.09.043,TRUE,Elsevier,Environmental Pollution,0269-7491,0269-7491,1873-6424,0269-7491,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27707599,NA,ut:000390734100103,http://www.sciencedirect.com/science/article/pii/S0269749116312969,FALSE
+su,2016,2706,10.1016/j.envpol.2016.11.001,TRUE,Elsevier,Environmental Pollution,0269-7491,0269-7491,NA,0269-7491,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27836476,NA,ut:000390732300061,NA,FALSE
+su,2016,2722.25,10.1016/j.jssc.2016.04.030,TRUE,Elsevier,Journal of Solid State Chemistry,0022-4596,0022-4596,NA,0022-4596,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000377422000030,NA,FALSE
+su,2016,2750,10.1007/s00148-016-0595-y,TRUE,Springer,Journal of Population Economics,0933-1433,0933-1433,1432-1475,0933-1433,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000380271300007,http://link.springer.com/article/10.1007/s00148-016-0595-y,FALSE
+su,2016,2750,10.1007/s10021-016-9986-x,TRUE,Springer,Ecosystems,1432-9840,1432-9840,1435-0629,1432-9840,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000386710000008,NA,FALSE
+su,2016,2750,10.1007/s10021-016-9998-6,TRUE,Springer,Ecosystems,1432-9840,1432-9840,1435-0629,1432-9840,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392317000008,NA,FALSE
+su,2016,2750,10.1007/s10433-015-0358-8,TRUE,Springer,European Journal of Ageing,1613-9372,1613-9372,1613-9380,1613-9372,NA,TRUE,NA,NA,ut:000371261900008,NA,FALSE
+su,2016,2750,10.1007/s10964-016-0430-5,TRUE,Springer,Journal of Youth and Adolescence,0047-2891,0047-2891,1573-6601,0047-2891,http://www.springer.com/tdm,TRUE,26847325,PMC4901095,ut:000377915700003,http://link.springer.com/article/10.1007/s10964-016-0430-5,FALSE
+su,2016,2750,10.1007/s11269-016-1363-1,TRUE,Springer,Water Resources Management,0920-4741,0920-4741,1573-1650,0920-4741,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000381377700002,NA,FALSE
+su,2016,2750,10.1007/s12529-016-9565-8,TRUE,Springer,International Journal of Behavioral Medicine,1070-5503,1070-5503,1532-7558,1070-5503,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388938600003,NA,FALSE
+su,2016,2750,10.1007/s13280-016-0777-6,TRUE,Springer,Ambio,0044-7447,0044-7447,1654-7209,0044-7447,http://creativecommons.org/licenses/by/4.0,TRUE,27020688,PMC4980319,ut:000381580800001,NA,FALSE
+su,2016,2751,10.1016/j.jpba.2016.09.029,TRUE,Elsevier,Journal of Pharmaceutical and Biomedical Analysis,0731-7085,0731-7085,1873-264X,0731-7085,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27718394,NA,ut:000389015700017,http://www.sciencedirect.com/science/article/pii/S0731708516307026,FALSE
+su,2016,2760,10.1177/0013164416668950,TRUE,SAGE Publications,Educational and Psychological Measurement,0013-1644,0013-1644,1552-3888,0013-1644,NA,TRUE,NA,NA,ut:000405849500009,http://epm.sagepub.com/content/early/2016/09/01/0013164416668950.full,FALSE
+su,2016,2780,10.1111/jora.12281,TRUE,Wiley,Journal of Research on Adolescence,1050-8392,1050-8392,1532-7795,1050-8392,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000401163500015,http://onlinelibrary.wiley.com/doi/10.1111/jora.12281/full,FALSE
+su,2016,2792.75,10.1002/jat.3304,TRUE,Wiley,Journal of Applied Toxicology,0260-437X,0260-437X,1099-1263,0260-437X,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,26935862,PMC5069579,ut:000382699000006,http://onlinelibrary.wiley.com/doi/10.1002/jat.3304/full,FALSE
+su,2016,2792.75,10.1111/eff.12308,TRUE,Wiley,Ecology of Freshwater Fish,0906-6691,0906-6691,1600-0633,0906-6691,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,http://onlinelibrary.wiley.com/doi/10.1111/eff.12308/full,FALSE
+su,2016,2794,10.1111/1365-2745.12564,TRUE,Wiley,Journal of Ecology,0022-0477,NA,1365-2745,0022-0477,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000379014900005,http://onlinelibrary.wiley.com/doi/10.1111/1365-2745.12564/full,FALSE
+su,2016,2804,10.1111/jcpp.12560,TRUE,Wiley,Journal of Child Psychology and Psychiatry,0021-9630,0021-9630,1469-7610,0021-9630,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27058980,NA,ut:000383399300013,http://onlinelibrary.wiley.com/doi/10.1111/jcpp.12560/full,FALSE
+su,2016,2812.12,10.1111/1365-2656.12579,TRUE,Wiley,Journal of Animal Ecology,0021-8790,NA,1365-2656,0021-8790,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27476800,NA,ut:000388354200018,http://onlinelibrary.wiley.com/doi/10.1111/1365-2656.12579/full,FALSE
+su,2016,2830.49,10.1007/s10750-016-2982-5,TRUE,Springer,Hydrobiologia,0018-8158,0018-8158,1573-5117,0018-8158,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000390139200026,NA,FALSE
+su,2016,2832.88,10.1139/cjfas-2016-0039,TRUE,Canadian Science Publishing,Canadian Journal of Fisheries and Aquatic Sciences,0706-652X,0706-652X,1205-7533,0706-652X,NA,TRUE,NA,NA,ut:000398836600014,NA,FALSE
+su,2016,2834.29,10.1021/acs.est.5b05583,TRUE,American Chemical Society (ACS),Environmental Science & Technology,0013-936X,0013-936X,1520-5851,0013-936X,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,27144960,NA,ut:000377629900007,NA,FALSE
+su,2016,2941.18,10.1002/ange.201511139,TRUE,Wiley,Angewandte Chemie,0044-8249,NA,NA,0044-8249,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,NA,FALSE
+su,2016,2941.18,10.1002/ange.201600696,TRUE,Wiley,Angewandte Chemie,0044-8249,NA,NA,0044-8249,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,NA,FALSE
+su,2016,2941.18,10.1002/ange.201601505,TRUE,Wiley,Angewandte Chemie,0044-8249,NA,NA,0044-8249,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,NA,FALSE
+su,2016,2941.18,10.1002/anie.201602137,TRUE,Wiley,Angewandte Chemie,1433-7851,NA,NA,1433-7851,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27219856,PMC5089581,ut:000383253300041,NA,FALSE
+su,2016,2941.18,10.1002/anie.201606108,TRUE,Wiley,Angewandte Chemie International Edition,1433-7851,1433-7851,1521-3773,1433-7851,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27538999,PMC5113805,ut:000384713100026,http://onlinelibrary.wiley.com/doi/10.1002/anie.201606108/full,FALSE
+su,2016,295.36,10.1016/j.chemosphere.2016.08.082,TRUE,Elsevier,Chemosphere,0045-6535,0045-6535,NA,0045-6535,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27643982,NA,ut:000385318200080,NA,FALSE
+su,2016,3000,10.1002/2016JF004050,TRUE,Wiley,Journal of Geophysical Research: Earth Surface,2169-9003,NA,NA,2169-9003,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000392831800012,NA,FALSE
+su,2016,3000,10.1242/jeb.129411,TRUE,The Company of Biologists,Journal of Experimental Biology,0022-0949,0022-0949,1477-9145,0022-0949,NA,TRUE,NA,NA,NA,http://jeb.biologists.org/content/219/19/2971,FALSE
+su,2016,3006,10.1111/add.13454,TRUE,Wiley,Addiction,0965-2140,0965-2140,1360-0443,0965-2140,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27178010,PMC5089658,ut:000383713500022,http://onlinelibrary.wiley.com/doi/10.1111/add.13454/full,FALSE
+su,2016,3046.47,10.1088/0143-0807/37/5/055603,TRUE,IOP Publishing,European Journal of Physics,0143-0807,0143-0807,1361-6404,0143-0807,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,ut:000381819000040,http://iopscience.iop.org/article/10.1088/0143-0807/37/5/055603,FALSE
+su,2016,313,10.4172/2375-4427.1000145,FALSE,OMICS Publishing Group,"Journal of Communication Disorders, Deaf Studies & Hearing Aids",2375-4427,NA,2375-4427,2375-4427,NA,TRUE,NA,NA,NA,NA,FALSE
+su,2016,3139.9,10.1016/j.clay.2016.10.002,TRUE,Elsevier,Applied Clay Science,0169-1317,0169-1317,NA,0169-1317,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000405048000016,NA,FALSE
+su,2016,3157,10.1016/j.gloenvcha.2016.06.008,TRUE,Elsevier,Global Environmental Change,0959-3780,0959-3780,NA,0959-3780,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000383297200006,http://www.sciencedirect.com/science/article/pii/S0959378016300826,FALSE
+su,2016,3260,10.1111/1462-2920.13407,TRUE,Wiley,Environmental Microbiology,1462-2912,1462-2912,1462-2920,1462-2912,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27306515,NA,ut:000392946900012,http://onlinelibrary.wiley.com/doi/10.1111/1462-2920.13407/full,FALSE
+su,2016,3300,10.1038/npjqi.2016.10,FALSE,Nature Publishing Group,npj Quantum Information,2056-6387,NA,2056-6387,2056-6387,http://www.springer.com/tdm,TRUE,NA,NA,ut:000392279900001,NA,TRUE
+su,2016,3404,10.1074/jbc.M115.701540,TRUE,American Society for Biochemistry & Molecular Biology (ASBMB),Journal of Biological Chemistry,0021-9258,0021-9258,1083-351X,0021-9258,NA,TRUE,26867577,PMC4817197,ut:000383447600042,NA,FALSE
+su,2016,3500,10.1002/anie.201608605,TRUE,Wiley,Angewandte Chemie International Edition,1433-7851,1433-7851,1521-3773,1433-7851,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27735124,PMC5129484,ut:000387028000040,http://onlinelibrary.wiley.com/doi/10.1002/anie.201608605/full,FALSE
+su,2016,3500,10.1175/JPO-D-15-0219.1,TRUE,American Meteorological Society,Journal of Physical Oceanography,0022-3670,0022-3670,1520-0485,0022-3670,NA,TRUE,NA,NA,ut:000380799200011,NA,FALSE
+su,2016,3700,10.1038/ncomms12016,FALSE,Nature Publishing Group,Nature Communications,2041-1723,NA,2041-1723,2041-1723,NA,TRUE,27327838,PMC4919534,ut:000379091000001,NA,TRUE
+su,2016,3700,10.1038/ncomms12113,FALSE,Nature Publishing Group,Nature Communications,2041-1723,NA,2041-1723,2041-1723,NA,TRUE,27385026,PMC4941054,ut:000380303100001,NA,TRUE
+su,2016,3700,10.1038/ncomms12776,FALSE,Nature Publishing Group,Nature Communications,2041-1723,NA,2041-1723,2041-1723,NA,TRUE,27627859,PMC5027618,ut:000385256500006,NA,TRUE
+su,2016,3700,10.1038/ncomms13653,FALSE,Nature Publishing Group,Nature Communications,2041-1723,NA,2041-1723,2041-1723,NA,TRUE,27897191,PMC5141343,ut:000388661300001,NA,TRUE
+su,2016,406,10.1080/09553002.2016.1178866,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,0955-3002,NA,TRUE,27160022,NA,ut:000392891400018,NA,FALSE
+su,2016,406,10.1080/09553002.2016.1206228,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,0955-3002,NA,TRUE,27547893,NA,ut:000392891400014,NA,FALSE
+su,2016,406,10.1080/09553002.2016.1206230,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,0955-3002,NA,TRUE,27559844,NA,ut:000392891400010,NA,FALSE
+su,2016,406,10.1080/09553002.2016.1206231,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,0955-3002,NA,TRUE,27673504,NA,ut:000392891400006,NA,FALSE
+su,2016,406,10.1080/09553002.2016.1206232,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,0955-3002,NA,TRUE,27686284,NA,ut:000392891400011,NA,FALSE
+su,2016,406,10.1080/09553002.2016.1206233,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,0955-3002,NA,TRUE,27437830,NA,ut:000392891400013,NA,FALSE
+su,2016,406,10.1080/09553002.2016.1207822,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,0955-3002,NA,TRUE,27686523,NA,ut:000392891400008,NA,FALSE
+su,2016,406,10.1080/09553002.2016.1213455,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,0955-3002,NA,TRUE,27735728,NA,ut:000392891400015,NA,FALSE
+su,2016,406,10.1080/09553002.2016.1221545,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,0955-3002,NA,TRUE,27584947,NA,ut:000392891400009,NA,FALSE
+su,2016,406,10.1080/09553002.2016.1222092,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,0955-3002,NA,TRUE,27705052,NA,ut:000392891400005,NA,FALSE
+su,2016,406,10.1080/09553002.2016.1227105,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,0955-3002,NA,TRUE,27626709,NA,ut:000392891400012,NA,FALSE
+su,2016,406,10.1080/09553002.2016.1227106,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,0955-3002,NA,TRUE,27572921,NA,ut:000392891400016,NA,FALSE
+su,2016,406,10.1080/09553002.2016.1227107,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,0955-3002,NA,TRUE,27557790,NA,ut:000392891400017,NA,FALSE
+su,2016,406,10.1080/09553002.2016.1230239,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,0955-3002,NA,TRUE,27707245,NA,ut:000392891400002,NA,FALSE
+su,2016,406,10.1080/09553002.2016.1233370,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,0955-3002,NA,TRUE,27766931,NA,ut:000392891400004,NA,FALSE
+su,2016,406,10.1080/09553002.2016.1234725,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,0955-3002,NA,TRUE,27813725,NA,ut:000392891400007,NA,FALSE
+su,2016,406,10.1080/09553002.2016.1235296,TRUE,Taylor & Francis,International Journal of Radiation Biology,0955-3002,0955-3002,1362-3095,0955-3002,NA,TRUE,27778526,NA,ut:000392891400003,NA,FALSE
+su,2016,450,10.3897/zookeys.574.7002,FALSE,Pensoft Publishers,ZooKeys,1313-2970,1313-2989,1313-2970,1313-2970,http://creativecommons.org/licenses/by/4.0/,TRUE,27110182,PMC4829907,ut:000372802600008,NA,TRUE
+su,2016,5501.96,10.1016/j.cub.2016.07.057,TRUE,Cell Press,Current Biology,0960-9822,0960-9822,NA,0960-9822,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27498567,PMC5069350,ut:000385690800028,NA,FALSE
+su,2016,590,10.15195/v3.a3,FALSE,Society for Sociological Science,Sociological Science,2330-6696,NA,2330-6696,2330-6696,NA,TRUE,NA,NA,NA,https://www.sociologicalscience.com/articles-v3-3-39/,FALSE
+su,2016,667,10.1080/01431161.2016.1249307,TRUE,Taylor & Francis,International Journal of Remote Sensing,0143-1161,0143-1161,1366-5901,0143-1161,NA,TRUE,NA,NA,ut:000394652900013,NA,FALSE
+su,2016,668,10.17585/njlr.v2.224,FALSE,Taylor & Francis,Nordic Journal of Literacy Research,2464-1596,NA,2464-1596,2464-1596,NA,TRUE,NA,NA,NA,https://nordicliteracy.net/index.php/njlr/article/view/224,TRUE
+su,2016,668,10.3389/fnagi.2016.00203,FALSE,Frontiers,Frontiers in Aging Neuroscience,1663-4365,NA,1663-4365,1663-4365,NA,TRUE,27610082,PMC4997967,ut:000381942100001,http://journal.frontiersin.org/article/10.3389/fnagi.2016.00203/full,TRUE
+su,2016,699.56,10.1021/acs.inorgchem.5b02733,TRUE,American Chemical Society (ACS),Inorganic Chemistry,0020-1669,0020-1669,1520-510X,0020-1669,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,26812142,NA,ut:000370395000060,http://pubs.acs.org/doi/full/10.1021/acs.inorgchem.5b02733,FALSE
+su,2016,708.816,10.1021/acs.jpcc.5b12490,TRUE,American Chemical Society (ACS),The Journal of Physical Chemistry C,1932-7447,1932-7447,1932-7455,1932-7447,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,NA,NA,ut:000372042600028,NA,FALSE
+su,2016,734,10.1080/19491034.2016.1220465,TRUE,Taylor & Francis,Nucleus,1949-1034,1949-1034,1949-1042,1949-1042,NA,TRUE,27541860,PMC5039005,ut:000384442800010,NA,FALSE
+su,2016,892.5,10.5194/gmd-9-1673-2016,TRUE,Copernicus Publications,Geoscientific Model Development,1991-9603,NA,1991-9603,1991-959X,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000376937800002,NA,TRUE
+su,2016,893,10.1016/j.jmva.2016.02.013,TRUE,Elsevier,Journal of Multivariate Analysis,0047-259X,0047-259X,NA,0047-259X,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000375826400004,http://www.sciencedirect.com/science/article/pii/S0047259X16000579,FALSE
+su,2016,907.17,10.1107/S160057671601863X,TRUE,International Union of Crystallography (IUCr),Journal of Applied Crystallography,1600-5767,NA,1600-5767,0021-8898,http://creativecommons.org/licenses/by/2.0/uk/legalcode,TRUE,28190994,PMC5294395,ut:000394289400030,NA,FALSE
+su,2016,933.22,10.1021/acs.orglett.6b01132,TRUE,American Chemical Society (ACS),Organic Letters,1523-7060,1523-7060,1523-7052,1523-7052,http://pubs.acs.org/page/policy/authorchoice_ccby_termsofuse.html,TRUE,27166509,NA,ut:000376476300045,http://pubs.acs.org/doi/full/10.1021/acs.orglett.6b01132,FALSE
+su,2016,987.5,10.1080/23746149.2016.1165630,TRUE,Taylor & Francis,Advances in Physics: X,2374-6149,NA,2374-6149,2374-6149,NA,TRUE,NA,NA,ut:000398353500004,NA,FALSE
+su,2016,992.16,10.1016/j.alcr.2016.11.002,TRUE,Elsevier,Advances in Life Course Research,1040-2608,1040-2608,NA,1040-2608,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000403857600001,NA,FALSE
+umu,2008,2660,10.1080/17450120802069109,TRUE,Taylor & Francis,Vulnerable Children and Youth Studies,1745-0128,1745-0128,1745-0136,1745-0128,NA,TRUE,22639678,PMC3357969,NA,NA,FALSE
+umu,2013,2429,10.1080/09644016.2013.835201,TRUE,Taylor & Francis,Environmental Politics,0964-4016,0964-4016,1743-8934,0964-4016,NA,TRUE,NA,NA,ut:000334661300009,NA,FALSE
+umu,2013,2429,10.1080/17542863.2013.800568,TRUE,Taylor & Francis,International Journal of Culture and Mental Health,1754-2863,1754-2863,1754-2871,1754-2871,NA,TRUE,24999370,PMC4066927,NA,NA,FALSE
+umu,2013,2630,10.1080/13607863.2012.758231,TRUE,Taylor & Francis,Aging & Mental Health,1360-7863,1360-7863,1364-6915,1360-7863,NA,TRUE,23339600,PMC3701937,ut:000320913300015,NA,FALSE
+umu,2014,3040,10.3109/0284186X.2014.953258,TRUE,Taylor & Francis,Acta Oncologica,0284-186X,0284-186X,1651-226X,0284-186X,NA,TRUE,25180912,PMC4438349,ut:000342282100001,NA,FALSE
+umu,2014,755,10.1159/000358121,FALSE,Karger,Cerebrovascular Diseases Extra,1664-5456,NA,1664-5456,1664-5456,NA,TRUE,24715896,PMC3975210,NA,NA,TRUE
+umu,2014,755,10.1159/000364816,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,1664-5464,NA,TRUE,25177334,PMC4132238,NA,NA,TRUE
+umu,2015,0,10.3109/03009734.2015.1122687,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,26849806,PMC4812053,ut:000372123700003,NA,FALSE
+umu,2015,1585,10.1159/000369726,FALSE,Karger,Cellular Physiology and Biochemistry,1421-9778,1015-8987,1421-9778,1015-8987,NA,TRUE,25613309,NA,ut:000349032700019,NA,TRUE
+umu,2015,2132,10.1080/13669877.2015.1121905,TRUE,Taylor & Francis,Journal of Risk Research,1366-9877,1366-9877,1466-4461,1366-9877,NA,TRUE,NA,NA,ut:000402412100003,NA,FALSE
+umu,2015,3040,10.3109/02713683.2015.1088954,TRUE,Taylor & Francis,Current Eye Research,0271-3683,0271-3683,1460-2202,0271-3683,NA,TRUE,NA,NA,ut:000382771600005,NA,FALSE
+umu,2015,468,10.1080/15592324.2014.1003753,TRUE,Taylor & Francis,Plant Signaling & Behavior,NA,NA,NA,NA,NA,FALSE,25761224,PMC4622721,ut:000362317900003,NA,NA
+umu,2015,694,10.3109/23320885.2015.1054392,FALSE,Taylor & Francis,Case Reports in Plastic Surgery and Hand Surgery,2332-0885,NA,2332-0885,2332-0885,NA,TRUE,27252972,PMC4793792,NA,NA,FALSE
+umu,2015,702,10.1080/15476286.2014.996099,TRUE,Taylor & Francis,RNA Biology,1547-6286,1547-6286,1555-8584,1547-6286,NA,TRUE,25590644,PMC4615572,ut:000350024000014,NA,FALSE
+umu,2015,702,10.1080/15476286.2015.1017211,TRUE,Taylor & Francis,RNA Biology,1547-6286,1547-6286,1555-8584,1547-6286,NA,TRUE,25826569,PMC4615753,ut:000352238900009,NA,FALSE
+umu,2015,702,10.1080/15476286.2015.1110674,TRUE,Taylor & Francis,RNA Biology,1547-6286,1547-6286,1555-8584,1547-6286,NA,TRUE,26580233,PMC4829319,ut:000371745100010,NA,FALSE
+umu,2015,755,10.1159/000381535,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,1664-5464,NA,TRUE,26078750,PMC4463780,ut:000367324000001,NA,TRUE
+umu,2016,0,10.1080/16549716.2017.1272236,FALSE,Taylor & Francis,Global Health Action,1654-9716,1654-9716,1654-9880,1654-9880,NA,TRUE,28219314,NA,NA,NA,TRUE
+umu,2016,0,10.1080/16549716.2017.1275189,FALSE,Taylor & Francis,Global Health Action,1654-9716,1654-9716,1654-9880,1654-9880,NA,TRUE,28304235,NA,ut:000397603900001,NA,TRUE
+umu,2016,0,10.1080/20004508.2016.1275185,FALSE,Taylor & Francis,Education Inquiry,2000-4508,NA,2000-4508,2000-4508,NA,TRUE,NA,NA,NA,NA,TRUE
+umu,2016,0,10.3109/03009734.2016.1152332,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,27007259,PMC4900065,ut:000376695600002,NA,FALSE
+umu,2016,2074,10.1080/14790718.2016.1155591,TRUE,Taylor & Francis,International Journal of Multilingualism,1479-0718,1479-0718,1747-7530,1479-0718,NA,TRUE,NA,NA,ut:000399550200006,NA,FALSE
+umu,2016,2132,10.1080/00313831.2015.1119723,TRUE,Taylor & Francis,Scandinavian Journal of Educational Research,0031-3831,0031-3831,1470-1170,0031-3831,NA,TRUE,NA,NA,ut:000393802200007,NA,FALSE
+umu,2016,2132,10.1080/01443410.2016.1143087,TRUE,Taylor & Francis,Educational Psychology,0144-3410,0144-3410,1469-5820,0144-3410,NA,TRUE,NA,NA,ut:000395093000005,NA,FALSE
+umu,2016,2132,10.1080/0966369X.2016.1249346,TRUE,Taylor & Francis,"Gender, Place & Culture",0966-369X,0966-369X,1360-0524,0966-369X,NA,TRUE,NA,NA,ut:000392834200009,NA,FALSE
+umu,2016,2132,10.1080/0969594X.2016.1142935,TRUE,Taylor & Francis,"Assessment in Education: Principles, Policy & Practice",0969-594X,0969-594X,1465-329X,0969-594X,NA,TRUE,NA,NA,ut:000400610000002,NA,FALSE
+umu,2016,2132,10.1080/1088937X.2016.1148794,TRUE,Taylor & Francis,Polar Geography,1088-937X,1088-937X,1939-0513,1088-937X,NA,TRUE,NA,NA,ut:000386442200003,NA,FALSE
+umu,2016,2132,10.1080/14623943.2016.1206881,TRUE,Taylor & Francis,Reflective Practice,1462-3943,1462-3943,1470-1103,1462-3943,NA,TRUE,NA,NA,ut:000384681300005,NA,FALSE
+umu,2016,2132,10.1080/17441692.2016.1149202,TRUE,Taylor & Francis,Global Public Health,1744-1692,1744-1692,1744-1706,1744-1692,NA,TRUE,26948258,NA,NA,NA,FALSE
+umu,2016,2132,10.3109/08039488.2016.1162846,TRUE,Taylor & Francis,Nordic Journal of Psychiatry,0803-9488,0803-9488,1502-4725,0803-9488,NA,TRUE,27103550,NA,ut:000383037300001,NA,FALSE
+umu,2016,2200,10.1007/s00038-016-0899-4,TRUE,Springer,International Journal of Public Health,1661-8556,1661-8556,1661-8564,1661-8556,http://creativecommons.org/licenses/by/4.0,TRUE,27695901,PMC5348557,ut:000396886800007,NA,FALSE
+umu,2016,2200,10.1007/s00158-016-1553-8,TRUE,Springer,Structural and Multidisciplinary Optimization,1615-147X,1615-147X,1615-1488,1615-147X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000398114200019,NA,FALSE
+umu,2016,2200,10.1007/s00221-016-4839-6,TRUE,Springer,Experimental Brain Research,0014-4819,0014-4819,1432-1106,0014-4819,http://creativecommons.org/licenses/by/4.0,TRUE,27885405,PMC5315705,ut:000395068900013,NA,FALSE
+umu,2016,2200,10.1007/s00246-016-1507-3,TRUE,Springer,Pediatric Cardiology,0172-0643,0172-0643,1432-1971,0172-0643,http://creativecommons.org/licenses/by/4.0,TRUE,27837301,PMC5331095,ut:000395096700007,NA,FALSE
+umu,2016,2200,10.1007/s00249-016-1158-6,TRUE,Springer,European Biophysics Journal,0175-7571,0175-7571,1432-1017,0175-7571,http://creativecommons.org/licenses/by/4.0,TRUE,27461369,PMC5346443,ut:000397496200002,NA,FALSE
+umu,2016,2200,10.1007/s00345-016-1952-x,TRUE,Springer,World Journal of Urology,0724-4983,0724-4983,1433-8726,0724-4983,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000402462900011,NA,FALSE
+umu,2016,2200,10.1007/s00442-016-3779-y,TRUE,Springer,Oecologia,0029-8549,0029-8549,1432-1939,0029-8549,http://creativecommons.org/licenses/by/4.0,TRUE,27915414,PMC5306166,ut:000394254500023,NA,FALSE
+umu,2016,2200,10.1007/s00484-016-1270-4,TRUE,Springer,International Journal of Biometeorology,0020-7128,0020-7128,1432-1254,0020-7128,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000400545400018,NA,FALSE
+umu,2016,2200,10.1007/s00502-016-0424-8,TRUE,Springer,e & i Elektrotechnik und Informationstechnik,0932-383X,0932-383X,1613-7620,0932-383X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000384882400003,NA,FALSE
+umu,2016,2200,10.1007/s00590-016-1873-9,TRUE,Springer,European Journal of Orthopaedic Surgery & Traumatology,1633-8065,1633-8065,1432-1068,1633-8065,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+umu,2016,2200,10.1007/s10021-016-0020-0,TRUE,Springer,Ecosystems,1432-9840,1432-9840,1435-0629,1432-9840,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392317000015,NA,FALSE
+umu,2016,2200,10.1007/s10198-016-0851-9,TRUE,Springer,The European Journal of Health Economics,1618-7598,1618-7598,1618-7601,1618-7598,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000406690000009,NA,FALSE
+umu,2016,2200,10.1007/s10433-016-0404-1,TRUE,Springer,European Journal of Ageing,1613-9372,1613-9372,1613-9380,1613-9372,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+umu,2016,2200,10.1007/s10804-016-9248-3,TRUE,Springer,Journal of Adult Development,1068-0667,1068-0667,1573-3440,1068-0667,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000399825300001,NA,FALSE
+umu,2016,2200,10.1007/s10805-016-9265-7,TRUE,Springer,Journal of Academic Ethics,1570-1727,1570-1727,1572-8544,1570-1727,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+umu,2016,2200,10.1007/s11060-016-2271-1,TRUE,Springer,Journal of Neuro-Oncology,0167-594X,0167-594X,1573-7373,0167-594X,http://creativecommons.org/licenses/by/4.0,TRUE,27664151,PMC5258803,ut:000393065400010,NA,FALSE
+umu,2016,2200,10.1007/s11104-016-3033-8,TRUE,Springer,Plant and Soil,0032-079X,0032-079X,1573-5036,0032-079X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392392200035,NA,FALSE
+umu,2016,2200,10.1007/s11104-016-3038-3,TRUE,Springer,Plant and Soil,0032-079X,0032-079X,1573-5036,0032-079X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392392200032,NA,FALSE
+umu,2016,2200,10.1007/s11136-016-1367-6,TRUE,Springer,Quality of Life Research,0962-9343,0962-9343,1573-2649,0962-9343,http://creativecommons.org/licenses/by/4.0,TRUE,27444778,PMC5243882,ut:000393571300005,NA,FALSE
+umu,2016,2200,10.1007/s11144-016-1069-7,TRUE,Springer,"Reaction Kinetics, Mechanisms and Catalysis",1878-5190,1878-5190,1878-5204,1878-5190,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388189000004,NA,FALSE
+umu,2016,2200,10.1007/s11192-016-2097-9,TRUE,Springer,Scientometrics,0138-9130,0138-9130,1588-2861,0138-9130,http://creativecommons.org/licenses/by/4.0,TRUE,27942088,PMC5124050,ut:000389336100046,NA,FALSE
+umu,2016,2200,10.1007/s11239-016-1411-y,TRUE,Springer,Journal of Thrombosis and Thrombolysis,0929-5305,0929-5305,1573-742X,0929-5305,http://creativecommons.org/licenses/by/4.0,TRUE,27522504,PMC5233740,ut:000392304500011,NA,FALSE
+umu,2016,2200,10.1007/s11262-016-1416-9,TRUE,Springer,Virus Genes,0920-8569,0920-8569,1572-994X,0920-8569,http://creativecommons.org/licenses/by/4.0,TRUE,28000080,PMC5357487,ut:000398473700003,NA,FALSE
+umu,2016,2200,10.1007/s11295-016-1074-z,TRUE,Springer,Tree Genetics & Genomes,1614-2942,1614-2942,1614-2950,1614-2942,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000397238800012,NA,FALSE
+umu,2016,2200,10.1007/s11306-016-1120-8,TRUE,Springer,Metabolomics,1573-3882,1573-3882,1573-3890,1573-3882,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000389604300002,NA,FALSE
+umu,2016,2200,10.1007/s11422-016-9784-y,TRUE,Springer,Cultural Studies of Science Education,1871-1502,1871-1502,1871-1510,1871-1502,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+umu,2016,2200,10.1007/s12021-016-9320-y,TRUE,Springer,Neuroinformatics,1539-2791,1539-2791,1559-0089,1539-2791,http://creativecommons.org/licenses/by/4.0,TRUE,27873151,PMC5306162,ut:000394260000009,NA,FALSE
+umu,2016,2200,10.1007/s12076-016-0176-4,TRUE,Springer,Letters in Spatial and Resource Sciences,1864-4031,1864-4031,1864-404X,1864-4031,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+umu,2016,2200,10.1007/s12350-016-0638-5,TRUE,Springer,Journal of Nuclear Cardiology,1071-3581,1071-3581,1532-6551,1071-3581,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+umu,2016,2200,10.1007/s40266-016-0408-8,TRUE,Springer,Drugs & Aging,1170-229X,1170-229X,1179-1969,1170-229X,http://creativecommons.org/licenses/by-nc/4.0,TRUE,27734278,PMC5122609,ut:000388987000004,NA,FALSE
+umu,2016,248,10.1080/19336934.2016.1182269,TRUE,Taylor & Francis,Fly,1933-6934,1933-6934,1933-6942,1933-6934,NA,TRUE,27116253,PMC4970531,ut:000381307600003,NA,FALSE
+umu,2016,2760,10.1080/21681805.2016.1194460,TRUE,Taylor & Francis,Scandinavian Journal of Urology,2168-1805,2168-1805,2168-1813,2168-1805,NA,TRUE,27333148,PMC5020330,ut:000384068000003,NA,FALSE
+umu,2016,323,10.1080/21681376.2016.1189354,FALSE,Taylor & Francis,"Regional Studies, Regional Science",2168-1376,NA,2168-1376,2168-1376,NA,TRUE,NA,NA,NA,NA,TRUE
+umu,2016,575,10.1080/02673843.2016.1269653,FALSE,Taylor & Francis,International Journal of Adolescence and Youth,0267-3843,0267-3843,2164-4527,0267-3843,NA,TRUE,NA,NA,NA,NA,TRUE
+umu,2016,662,10.1080/14756366.2016.1265520,FALSE,Taylor & Francis,Journal of Enzyme Inhibition and Medicinal Chemistry,1475-6366,1475-6366,1475-6374,1475-6366,NA,TRUE,28114819,NA,ut:000392591100045,NA,FALSE
+uu,2012,2630,10.1080/00958972.2012.701008,TRUE,Taylor & Francis,Journal of Coordination Chemistry,0095-8972,0095-8972,1029-0389,0095-8972,NA,TRUE,NA,NA,ut:000305759500011,NA,FALSE
+uu,2012,2630,10.1080/10426507.2012.743145,TRUE,Taylor & Francis,"Phosphorus, Sulfur, and Silicon and the Related Elements",1042-6507,1042-6507,1563-5325,1026-7719,NA,TRUE,NA,NA,ut:000319042300042,NA,FALSE
+uu,2013,2429,10.1080/00806765.2013.855350,TRUE,Taylor & Francis,Scando-Slavica,0080-6765,0080-6765,1600-082X,0080-6765,NA,TRUE,NA,NA,NA,NA,FALSE
 uu,2013,2429,10.1080/21647259.2013.813179,TRUE,Taylor & Francis,Peacebuilding,2164-7259,2164-7259,2164-7267,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2013,413,10.1080/21663831.2013.802262,FALSE,Taylor & Francis,Materials Research Letters,2166-3831,NA,2166-3831,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2014,0,10.1159/000365274,FALSE,Karger,Audiology and Neurotology Extra,1664-5537,NA,1664-5537,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2014,2132,10.1080/00393274.2012.751670,TRUE,Taylor & Francis,Studia Neophilologica,0039-3274,0039-3274,1651-2308,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2014,2132,10.1080/00393274.2013.822742,TRUE,Taylor & Francis,Studia Neophilologica,0039-3274,0039-3274,1651-2308,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2014,2132,10.1080/00393274.2013.871975,TRUE,Taylor & Francis,Studia Neophilologica,0039-3274,0039-3274,1651-2308,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2014,2429,10.1080/1070289X.2013.868351,TRUE,Taylor & Francis,Identities,1070-289X,1070-289X,1547-3384,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2014,321,10.1159/000362868,FALSE,Karger,Case Reports in Neurology,1662-680X,NA,1662-680X,NA,NA,TRUE,24987361,PMC4067733,NA,NA,TRUE
-uu,2014,935,10.4161/15384101.2014.964985,TRUE,Taylor & Francis,Cell Cycle,1538-4101,1538-4101,1551-4005,NA,NA,TRUE,25483080,PMC4615048,NA,NA,FALSE
-uu,2015,0,10.3109/03009734.2015.1037031,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,25951045,PMC4526876,NA,NA,FALSE
-uu,2015,0,10.3109/03009734.2015.1044055,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,NA,NA,NA,NA,NA,FALSE,25941864,PMC4463487,NA,NA,NA
-uu,2015,0,10.3109/03009734.2015.1049388,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,26074171,PMC4816890,NA,NA,FALSE
-uu,2015,0,10.3109/03009734.2015.1075630,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,26482657,PMC4816889,NA,NA,FALSE
-uu,2015,0,10.3109/03009734.2015.1091522,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,26479863,PMC4812051,NA,NA,FALSE
-uu,2015,0,10.3109/03009734.2015.1093568,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,26489857,PMC4812057,NA,NA,FALSE
-uu,2015,0,10.3109/03009734.2015.1109012,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,27181825,PMC4900071,NA,NA,FALSE
-uu,2015,0,10.3109/03009734.2015.1109569,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,26610050,PMC4812054,NA,NA,FALSE
-uu,2015,2132,10.3109/03009734.2015.1037032,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,25903284,PMC4463485,NA,NA,FALSE
-uu,2015,2429,10.1080/23269995.2014.992119,TRUE,Taylor & Francis,Global Discourse,2326-9995,2326-9995,2043-7897,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2015,347,10.3109/23320885.2015.1102067,FALSE,Taylor & Francis,Case Reports in Plastic Surgery and Hand Surgery,2332-0885,NA,2332-0885,NA,NA,TRUE,27252976,PMC4793796,NA,NA,FALSE
-uu,2015,935,10.4161/15384101.2014.967094,TRUE,Taylor & Francis,Cell Cycle,1538-4101,1538-4101,1551-4005,NA,NA,TRUE,25483050,PMC4934077,NA,NA,FALSE
-uu,2015,935,10.4161/15384101.2014.990302,TRUE,Taylor & Francis,Cell Cycle,1538-4101,1538-4101,1551-4005,NA,NA,TRUE,25622187,PMC4347693,NA,NA,FALSE
-uu,2016,0,10.1080/03009734.2016.1176094,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,27216564,PMC4967265,NA,NA,FALSE
-uu,2016,0,10.1080/03009734.2016.1189470,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,0,10.1080/03009734.2016.1191564,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,0,10.1080/03009734.2016.1195900,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,27416324,PMC4967260,NA,NA,FALSE
-uu,2016,0,10.1080/03009734.2016.1198441,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,27356590,PMC4967264,NA,NA,FALSE
-uu,2016,0,10.1080/03009734.2016.1201177,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,27379448,PMC4967261,NA,NA,FALSE
-uu,2016,0,10.1080/03009734.2016.1210267,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,0,10.1080/03009734.2016.1211776,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,0,10.1080/03009734.2016.1218575,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,0,10.1080/03009734.2016.1225870,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,27622962,NA,NA,NA,FALSE
-uu,2016,0,10.1080/03009734.2016.1228721,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,27690722,NA,NA,NA,FALSE
-uu,2016,0,10.1080/03009734.2016.1230157,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,27658527,NA,NA,NA,FALSE
-uu,2016,0,10.1080/03009734.2016.1238426,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,0,10.1080/03009734.2016.1271843,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,28145795,NA,NA,NA,FALSE
-uu,2016,0,10.1080/17453674.2016.1248315,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,NA,NA,TRUE,27892748,PMC5251262,NA,NA,TRUE
-uu,2016,0,10.1080/19420889.2016.1216740,FALSE,Taylor & Francis,Communicative & Integrative Biology,1942-0889,NA,1942-0889,NA,NA,TRUE,27829980,PMC5100654,NA,NA,TRUE
-uu,2016,0,10.3109/03009734.2016.1141810,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,26915921,PMC4812058,NA,NA,FALSE
-uu,2016,0,10.3109/03009734.2016.1144663,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,26959327,PMC4812060,NA,NA,FALSE
-uu,2016,0,10.3109/03009734.2016.1144664,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,26933994,PMC4812052,NA,NA,FALSE
-uu,2016,0,10.3109/03009734.2016.1154905,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,27044660,PMC4900067,NA,NA,FALSE
-uu,2016,0,10.3109/03009734.2016.1164769,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,27124642,PMC4900068,NA,NA,FALSE
-uu,2016,0,10.3109/03009734.2016.1164770,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,27181824,PMC4900074,NA,NA,FALSE
-uu,2016,0,10.3109/03009734.2016.1165317,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,27117607,PMC4900070,NA,NA,FALSE
-uu,2016,0,10.3109/03009734.2016.1173746,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,27460605,PMC4967268,NA,NA,FALSE
-uu,2016,0,10.3109/17453674.2016.1146511,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,NA,NA,TRUE,26854321,PMC4812089,NA,NA,TRUE
-uu,2016,2132,10.1080/00016489.2016.1193894,TRUE,Taylor & Francis,Acta Oto-Laryngologica,0001-6489,0001-6489,1651-2251,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2132,10.1080/02673037.2016.1219332,TRUE,Taylor & Francis,Housing Studies,0267-3037,0267-3037,1466-1810,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2132,10.1080/09638288.2016.1236405,TRUE,Taylor & Francis,Disability and Rehabilitation,0963-8288,0963-8288,1464-5165,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2132,10.1080/13183222.2016.1149760,TRUE,Taylor & Francis,Javnost - The Public,1318-3222,1318-3222,1854-8377,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2132,10.1080/13501763.2016.1170192,TRUE,Taylor & Francis,Journal of European Public Policy,1350-1763,1350-1763,1466-4429,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2132,10.1080/13504509.2016.1235624,TRUE,Taylor & Francis,International Journal of Sustainable Development & World Ecology,1350-4509,1350-4509,1745-2627,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2132,10.1080/13607863.2016.1232364,TRUE,Taylor & Francis,Aging & Mental Health,1360-7863,1360-7863,1364-6915,NA,NA,TRUE,27657536,NA,NA,NA,FALSE
-uu,2016,2132,10.1080/13688804.2016.1161503,TRUE,Taylor & Francis,Media History,1368-8804,1368-8804,1469-9729,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2132,10.1080/13691058.2016.1214746,TRUE,Taylor & Francis,"Culture, Health & Sexuality",1369-1058,1369-1058,1464-5351,NA,NA,TRUE,27684388,NA,NA,NA,FALSE
-uu,2016,2132,10.1080/13691457.2016.1256869,TRUE,Taylor & Francis,European Journal of Social Work,1369-1457,1369-1457,1468-2664,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2132,10.3109/00365521.2016.1166519,TRUE,Taylor & Francis,Scandinavian Journal of Gastroenterology,0036-5521,0036-5521,1502-7708,NA,NA,TRUE,27181159,PMC4926774,NA,NA,FALSE
-uu,2016,2200,10.1007/s00035-016-0176-4,TRUE,Springer,Alpine Botany,1664-2201,1664-2201,1664-221X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s00125-016-4140-z,TRUE,Springer,Diabetologia,0012-186X,0012-186X,1432-0428,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27796420,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s00153-016-0507-6,TRUE,Springer,Archive for Mathematical Logic,0933-5846,0933-5846,1432-0665,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s00181-016-1133-1,TRUE,Springer,Empirical Economics,0377-7332,0377-7332,1435-8921,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s00181-016-1175-4,TRUE,Springer,Empirical Economics,0377-7332,0377-7332,1435-8921,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s00204-016-1905-6,TRUE,Springer,Archives of Toxicology,0340-5761,0340-5761,1432-0738,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s00208-016-1447-5,TRUE,Springer,Mathematische Annalen,0025-5831,0025-5831,1432-1807,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s00294-016-0644-9,TRUE,Springer,Current Genetics,0172-8083,0172-8083,1432-0983,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27613427,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s00383-016-4032-9,TRUE,Springer,Pediatric Surgery International,0179-0358,0179-0358,1437-9813,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27986977,PMC5310566,NA,NA,FALSE
-uu,2016,2200,10.1007/s00424-016-1864-z,TRUE,Springer,Pflügers Archiv - European Journal of Physiology,0031-6768,0031-6768,1432-2013,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27539300,PMC5026721,NA,NA,FALSE
-uu,2016,2200,10.1007/s00439-016-1729-8,TRUE,Springer,Human Genetics,0340-6717,0340-6717,1432-1203,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s00445-016-1080-x,TRUE,Springer,Bulletin of Volcanology,0258-8900,0258-8900,1432-0819,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s00526-016-1058-8,TRUE,Springer,Calculus of Variations and Partial Differential Equations,0944-2669,0944-2669,1432-0835,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s00526-016-1088-2,TRUE,Springer,Calculus of Variations and Partial Differential Equations,0944-2669,0944-2669,1432-0835,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s00701-016-3039-2,TRUE,Springer,Acta Neurochirurgica,0001-6268,0001-6268,0942-0940,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27928632,PMC5241344,NA,NA,FALSE
-uu,2016,2200,10.1007/s10040-016-1513-9,TRUE,Springer,Hydrogeology Journal,1431-2174,1431-2174,1435-0157,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10549-016-3928-3,TRUE,Springer,Breast Cancer Research and Treatment,0167-6806,0167-6806,1573-7217,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27492739,PMC5012147,NA,NA,FALSE
-uu,2016,2200,10.1007/s10571-016-0454-0,TRUE,Springer,Cellular and Molecular Neurobiology,0272-4340,0272-4340,1573-6830,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28028735,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10592-016-0908-4,TRUE,Springer,Conservation Genetics,1566-0621,1566-0621,1572-9737,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10633-016-9564-8,TRUE,Springer,Documenta Ophthalmologica,0012-4486,0012-4486,1573-2622,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10687-016-0269-x,TRUE,Springer,Extremes,1386-1999,1386-1999,1572-915X,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10726-016-9509-3,TRUE,Springer,Group Decision and Negotiation,0926-2644,0926-2644,1572-9907,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10797-016-9427-y,TRUE,Springer,International Tax and Public Finance,0927-5940,0927-5940,1573-6970,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10800-016-1026-1,TRUE,Springer,Journal of Applied Electrochemistry,0021-891X,0021-891X,1572-8838,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10803-016-2955-6,TRUE,Springer,Journal of Autism and Developmental Disorders,0162-3257,0162-3257,1573-3432,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27987062,PMC5352793,NA,NA,FALSE
-uu,2016,2200,10.1007/s10803-016-2978-z,TRUE,Springer,Journal of Autism and Developmental Disorders,0162-3257,0162-3257,1573-3432,NA,http://creativecommons.org/licenses/by/4.0,TRUE,28000078,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10817-016-9393-1,TRUE,Springer,Journal of Automated Reasoning,0168-7433,0168-7433,1573-0670,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10844-016-0427-2,TRUE,Springer,Journal of Intelligent Information Systems,0925-9902,0925-9902,1573-7675,NA,NA,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10854-016-5387-3,TRUE,Springer,Journal of Materials Science: Materials in Electronics,0957-4522,0957-4522,1573-482X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10854-016-6140-7,TRUE,Springer,Journal of Materials Science: Materials in Electronics,0957-4522,0957-4522,1573-482X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10856-016-5785-3,TRUE,Springer,Journal of Materials Science: Materials in Medicine,0957-4530,0957-4530,1573-4838,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10892-016-9238-5,TRUE,Springer,The Journal of Ethics,1382-4554,1382-4554,1572-8609,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10915-016-0297-3,TRUE,Springer,Journal of Scientific Computing,0885-7474,0885-7474,1573-7691,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10928-016-9486-9,TRUE,Springer,Journal of Pharmacokinetics and Pharmacodynamics,1567-567X,1567-567X,1573-8744,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27578330,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10928-016-9487-8,TRUE,Springer,Journal of Pharmacokinetics and Pharmacodynamics,1567-567X,1567-567X,1573-8744,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10928-016-9496-7,TRUE,Springer,Journal of Pharmacokinetics and Pharmacodynamics,1567-567X,1567-567X,1573-8744,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10928-016-9499-4,TRUE,Springer,Journal of Pharmacokinetics and Pharmacodynamics,1567-567X,1567-567X,1573-8744,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10955-016-1604-y,TRUE,Springer,Journal of Statistical Physics,0022-4715,0022-4715,1572-9613,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s10959-016-0723-3,TRUE,Springer,Journal of Theoretical Probability,0894-9840,0894-9840,1572-9230,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s11019-016-9740-3,TRUE,Springer,"Medicine, Health Care and Philosophy",1386-7423,1386-7423,1572-8633,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s11090-016-9766-6,TRUE,Springer,Plasma Chemistry and Plasma Processing,0272-4324,0272-4324,1572-8986,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s11121-016-0696-6,TRUE,Springer,Prevention Science,1389-4986,1389-4986,1573-6695,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27638427,PMC5236081,NA,NA,FALSE
-uu,2016,2200,10.1007/s11229-016-1155-4,TRUE,Springer,Synthese,0039-7857,0039-7857,1573-0964,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s11244-016-0690-z,TRUE,Springer,Topics in Catalysis,1022-5528,1022-5528,1572-9028,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s11336-016-9512-2,TRUE,Springer,Psychometrika,0033-3123,0033-3123,1860-0980,NA,NA,TRUE,27660261,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s11422-016-9790-0,TRUE,Springer,Cultural Studies of Science Education,1871-1502,1871-1502,1871-1510,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s11695-016-2476-6,TRUE,Springer,Obesity Surgery,0960-8923,0960-8923,1708-0428,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s11899-016-0335-0,TRUE,Springer,Current Hematologic Malignancy Reports,1558-8211,1558-8211,1558-822X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27497846,PMC5031713,NA,NA,FALSE
-uu,2016,2200,10.1007/s12020-016-1172-6,TRUE,Springer,Endocrine,1355-008X,1355-008X,1559-0100,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27858284,PMC5316391,NA,NA,FALSE
-uu,2016,2200,10.1007/s12031-016-0867-8,TRUE,Springer,Journal of Molecular Neuroscience,0895-8696,0895-8696,1559-1166,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27981419,PMC5321710,NA,NA,FALSE
-uu,2016,2200,10.1007/s12035-016-0157-z,TRUE,Springer,Molecular Neurobiology,0893-7648,0893-7648,1559-1182,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s13366-016-0320-8,TRUE,Springer,Beiträge zur Algebra und Geometrie / Contributions to Algebra and Geometry,0138-4821,0138-4821,2191-0383,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1007/s40072-016-0080-3,TRUE,Springer,Stochastics and Partial Differential Equations: Analysis and Computations,2194-0401,2194-0401,2194-041X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
-uu,2016,2200,10.1208/s12248-016-9977-z,TRUE,Springer,The AAPS Journal,1550-7416,NA,1550-7416,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27634384,NA,NA,NA,FALSE
-uu,2016,2200,10.1245/s10434-016-5703-4,TRUE,Springer,Annals of Surgical Oncology,1068-9265,1068-9265,1534-4681,NA,http://creativecommons.org/licenses/by/4.0,TRUE,27904972,NA,NA,NA,FALSE
-uu,2016,321,10.1159/000444874,FALSE,Karger,Case Reports in Neurology,1662-680X,NA,1662-680X,NA,NA,TRUE,27065427,PMC4821142,NA,NA,TRUE
-uu,2016,969,10.1080/2331186X.2016.1247610,FALSE,Taylor & Francis,Cogent Education,2331-186X,NA,2331-186X,NA,NA,TRUE,NA,NA,NA,NA,TRUE
-uu,2016,982,10.1080/21592535.2015.1123842,FALSE,Taylor & Francis,Biomatter,2159-2535,NA,2159-2535,NA,NA,TRUE,26787304,PMC5055208,NA,NA,FALSE
-uu,2016,982,10.1080/21592535.2015.1133394,FALSE,Taylor & Francis,Biomatter,2159-2535,NA,2159-2535,NA,NA,TRUE,26727581,PMC4927199,NA,NA,FALSE
-uu,2017,0,10.1080/03009734.2016.1274806,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,NA,NA,TRUE,28256956,NA,NA,NA,FALSE
-uu,2017,0,10.1080/03009734.2017.1285374,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,NA,NA,NA,NA,NA,FALSE,28276779,NA,NA,NA,NA
-uu,2017,0,10.1080/03009734.2017.1285836,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,NA,NA,NA,NA,NA,FALSE,28276782,NA,NA,NA,NA
-vti,2016,2200,10.1007/s11116-016-9750-2,TRUE,Springer,Transportation,0049-4488,0049-4488,1572-9435,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+uu,2013,413,10.1080/21663831.2013.802262,FALSE,Taylor & Francis,Materials Research Letters,2166-3831,NA,2166-3831,2166-3831,NA,TRUE,NA,NA,ut:000209767500005,NA,FALSE
+uu,2014,0,10.1159/000365274,FALSE,Karger,Audiology and Neurotology Extra,1664-5537,NA,1664-5537,1664-5537,NA,TRUE,NA,NA,NA,NA,FALSE
+uu,2014,2132,10.1080/00393274.2012.751670,TRUE,Taylor & Francis,Studia Neophilologica,0039-3274,0039-3274,1651-2308,0039-3274,NA,TRUE,NA,NA,ut:000319199300008,NA,FALSE
+uu,2014,2132,10.1080/00393274.2013.822742,TRUE,Taylor & Francis,Studia Neophilologica,0039-3274,0039-3274,1651-2308,0039-3274,NA,TRUE,NA,NA,ut:000335850200002,NA,FALSE
+uu,2014,2132,10.1080/00393274.2013.871975,TRUE,Taylor & Francis,Studia Neophilologica,0039-3274,0039-3274,1651-2308,0039-3274,NA,TRUE,NA,NA,ut:000335850200012,NA,FALSE
+uu,2014,2429,10.1080/1070289X.2013.868351,TRUE,Taylor & Francis,Identities,1070-289X,1070-289X,1547-3384,1070-289X,NA,TRUE,NA,NA,ut:000343216200007,NA,FALSE
+uu,2014,321,10.1159/000362868,FALSE,Karger,Case Reports in Neurology,1662-680X,NA,1662-680X,1662-680X,NA,TRUE,24987361,PMC4067733,NA,NA,TRUE
+uu,2014,935,10.4161/15384101.2014.964985,TRUE,Taylor & Francis,Cell Cycle,1538-4101,1538-4101,1551-4005,1551-4005,NA,TRUE,25483080,PMC4615048,ut:000348329200013,NA,FALSE
+uu,2015,0,10.3109/03009734.2015.1037031,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,25951045,PMC4526876,ut:000359819800008,NA,FALSE
+uu,2015,0,10.3109/03009734.2015.1044055,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,NA,NA,NA,NA,NA,FALSE,25941864,PMC4463487,ut:000353920500011,NA,NA
+uu,2015,0,10.3109/03009734.2015.1049388,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,26074171,PMC4816890,ut:000365684900009,NA,FALSE
+uu,2015,0,10.3109/03009734.2015.1075630,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,26482657,PMC4816889,ut:000365684900008,NA,FALSE
+uu,2015,0,10.3109/03009734.2015.1091522,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,26479863,PMC4812051,ut:000372123700001,NA,FALSE
+uu,2015,0,10.3109/03009734.2015.1093568,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,26489857,PMC4812057,ut:000372123700007,NA,FALSE
+uu,2015,0,10.3109/03009734.2015.1109012,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,27181825,PMC4900071,ut:000376695600003,NA,FALSE
+uu,2015,0,10.3109/03009734.2015.1109569,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,26610050,PMC4812054,ut:000372123700004,NA,FALSE
+uu,2015,2132,10.3109/03009734.2015.1037032,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,25903284,PMC4463485,ut:000353920500009,NA,FALSE
+uu,2015,2429,10.1080/23269995.2014.992119,TRUE,Taylor & Francis,Global Discourse,2326-9995,2326-9995,2043-7897,2043-7897,NA,TRUE,NA,NA,NA,NA,FALSE
+uu,2015,347,10.3109/23320885.2015.1102067,FALSE,Taylor & Francis,Case Reports in Plastic Surgery and Hand Surgery,2332-0885,NA,2332-0885,2332-0885,NA,TRUE,27252976,PMC4793796,NA,NA,FALSE
+uu,2015,935,10.4161/15384101.2014.967094,TRUE,Taylor & Francis,Cell Cycle,1538-4101,1538-4101,1551-4005,1551-4005,NA,TRUE,25483050,PMC4934077,ut:000379743800011,NA,FALSE
+uu,2015,935,10.4161/15384101.2014.990302,TRUE,Taylor & Francis,Cell Cycle,1538-4101,1538-4101,1551-4005,1551-4005,NA,TRUE,25622187,PMC4347693,ut:000350137700018,NA,FALSE
+uu,2016,0,10.1080/03009734.2016.1176094,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,27216564,PMC4967265,ut:000381958400006,NA,FALSE
+uu,2016,0,10.1080/03009734.2016.1189470,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,NA,NA,ut:000387292600017,NA,FALSE
+uu,2016,0,10.1080/03009734.2016.1191564,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,NA,NA,ut:000387292600005,NA,FALSE
+uu,2016,0,10.1080/03009734.2016.1195900,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,27416324,PMC4967260,ut:000381958400001,NA,FALSE
+uu,2016,0,10.1080/03009734.2016.1198441,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,27356590,PMC4967264,ut:000381958400005,NA,FALSE
+uu,2016,0,10.1080/03009734.2016.1201177,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,27379448,PMC4967261,ut:000381958400002,NA,FALSE
+uu,2016,0,10.1080/03009734.2016.1210267,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,NA,NA,ut:000387292600018,NA,FALSE
+uu,2016,0,10.1080/03009734.2016.1211776,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,NA,NA,ut:000387292600002,NA,FALSE
+uu,2016,0,10.1080/03009734.2016.1218575,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,NA,NA,ut:000387292600016,NA,FALSE
+uu,2016,0,10.1080/03009734.2016.1225870,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,27622962,NA,ut:000396476600003,NA,FALSE
+uu,2016,0,10.1080/03009734.2016.1228721,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,27690722,NA,ut:000396476600005,NA,FALSE
+uu,2016,0,10.1080/03009734.2016.1230157,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,27658527,NA,ut:000396476600004,NA,FALSE
+uu,2016,0,10.1080/03009734.2016.1238426,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,NA,NA,ut:000387292600001,NA,FALSE
+uu,2016,0,10.1080/03009734.2016.1271843,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,28145795,NA,ut:000396476600002,NA,FALSE
+uu,2016,0,10.1080/17453674.2016.1248315,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,1745-3674,NA,TRUE,27892748,PMC5251262,ut:000392736200007,NA,TRUE
+uu,2016,0,10.1080/19420889.2016.1216740,FALSE,Taylor & Francis,Communicative & Integrative Biology,1942-0889,NA,1942-0889,1942-0889,NA,TRUE,27829980,PMC5100654,NA,NA,TRUE
+uu,2016,0,10.3109/03009734.2016.1141810,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,26915921,PMC4812058,ut:000372123700008,NA,FALSE
+uu,2016,0,10.3109/03009734.2016.1144663,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,26959327,PMC4812060,ut:000372123700010,NA,FALSE
+uu,2016,0,10.3109/03009734.2016.1144664,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,26933994,PMC4812052,ut:000372123700002,NA,FALSE
+uu,2016,0,10.3109/03009734.2016.1154905,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,27044660,PMC4900067,ut:000376695600007,NA,FALSE
+uu,2016,0,10.3109/03009734.2016.1164769,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,27124642,PMC4900068,ut:000376695600004,NA,FALSE
+uu,2016,0,10.3109/03009734.2016.1164770,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,27181824,PMC4900074,NA,NA,FALSE
+uu,2016,0,10.3109/03009734.2016.1165317,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,27117607,PMC4900070,ut:000376695600005,NA,FALSE
+uu,2016,0,10.3109/03009734.2016.1173746,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,27460605,PMC4967268,ut:000381958400009,NA,FALSE
+uu,2016,0,10.3109/17453674.2016.1146511,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,1745-3674,NA,TRUE,26854321,PMC4812089,ut:000372447400001,NA,TRUE
+uu,2016,2132,10.1080/00016489.2016.1193894,TRUE,Taylor & Francis,Acta Oto-Laryngologica,0001-6489,0001-6489,1651-2251,0001-6489,NA,TRUE,NA,NA,ut:000386069300014,NA,FALSE
+uu,2016,2132,10.1080/02673037.2016.1219332,TRUE,Taylor & Francis,Housing Studies,0267-3037,0267-3037,1466-1810,0267-3037,NA,TRUE,NA,NA,ut:000398538500006,NA,FALSE
+uu,2016,2132,10.1080/09638288.2016.1236405,TRUE,Taylor & Francis,Disability and Rehabilitation,0963-8288,0963-8288,1464-5165,0963-8288,NA,TRUE,NA,NA,NA,NA,FALSE
+uu,2016,2132,10.1080/13183222.2016.1149760,TRUE,Taylor & Francis,Javnost - The Public,1318-3222,1318-3222,1854-8377,1318-3222,NA,TRUE,NA,NA,ut:000373495000005,NA,FALSE
+uu,2016,2132,10.1080/13501763.2016.1170192,TRUE,Taylor & Francis,Journal of European Public Policy,1350-1763,1350-1763,1466-4429,1350-1763,NA,TRUE,NA,NA,ut:000402015800005,NA,FALSE
+uu,2016,2132,10.1080/13504509.2016.1235624,TRUE,Taylor & Francis,International Journal of Sustainable Development & World Ecology,1350-4509,1350-4509,1745-2627,1350-4509,NA,TRUE,NA,NA,NA,NA,FALSE
+uu,2016,2132,10.1080/13607863.2016.1232364,TRUE,Taylor & Francis,Aging & Mental Health,1360-7863,1360-7863,1364-6915,1360-7863,NA,TRUE,27657536,NA,NA,NA,FALSE
+uu,2016,2132,10.1080/13688804.2016.1161503,TRUE,Taylor & Francis,Media History,1368-8804,1368-8804,1469-9729,1368-8804,NA,TRUE,NA,NA,ut:000374341700004,NA,FALSE
+uu,2016,2132,10.1080/13691058.2016.1214746,TRUE,Taylor & Francis,"Culture, Health & Sexuality",1369-1058,1369-1058,1464-5351,1369-1058,NA,TRUE,27684388,NA,ut:000393781500004,NA,FALSE
+uu,2016,2132,10.1080/13691457.2016.1256869,TRUE,Taylor & Francis,European Journal of Social Work,1369-1457,1369-1457,1468-2664,1369-1457,NA,TRUE,NA,NA,NA,NA,FALSE
+uu,2016,2132,10.3109/00365521.2016.1166519,TRUE,Taylor & Francis,Scandinavian Journal of Gastroenterology,0036-5521,0036-5521,1502-7708,0036-5521,NA,TRUE,27181159,PMC4926774,ut:000381406800006,NA,FALSE
+uu,2016,2200,10.1007/s00035-016-0176-4,TRUE,Springer,Alpine Botany,1664-2201,1664-2201,1664-221X,1664-221X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000398467800004,NA,FALSE
+uu,2016,2200,10.1007/s00125-016-4140-z,TRUE,Springer,Diabetologia,0012-186X,0012-186X,1432-0428,0012-186X,http://creativecommons.org/licenses/by/4.0,TRUE,27796420,NA,ut:000391359800016,NA,FALSE
+uu,2016,2200,10.1007/s00153-016-0507-6,TRUE,Springer,Archive for Mathematical Logic,0933-5846,0933-5846,1432-0665,0933-5846,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000385155700010,NA,FALSE
+uu,2016,2200,10.1007/s00181-016-1133-1,TRUE,Springer,Empirical Economics,0377-7332,0377-7332,1435-8921,0377-7332,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000407847400017,NA,FALSE
+uu,2016,2200,10.1007/s00181-016-1175-4,TRUE,Springer,Empirical Economics,0377-7332,0377-7332,1435-8921,0377-7332,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+uu,2016,2200,10.1007/s00204-016-1905-6,TRUE,Springer,Archives of Toxicology,0340-5761,0340-5761,1432-0738,0340-5761,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000401338100001,NA,FALSE
+uu,2016,2200,10.1007/s00208-016-1447-5,TRUE,Springer,Mathematische Annalen,0025-5831,0025-5831,1432-1807,0025-5831,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000406037300004,NA,FALSE
+uu,2016,2200,10.1007/s00294-016-0644-9,TRUE,Springer,Current Genetics,0172-8083,0172-8083,1432-0983,0172-8083,http://creativecommons.org/licenses/by/4.0,TRUE,27613427,NA,ut:000399176400018,NA,FALSE
+uu,2016,2200,10.1007/s00383-016-4032-9,TRUE,Springer,Pediatric Surgery International,0179-0358,0179-0358,1437-9813,0179-0358,http://creativecommons.org/licenses/by/4.0,TRUE,27986977,PMC5310566,ut:000394435900005,NA,FALSE
+uu,2016,2200,10.1007/s00424-016-1864-z,TRUE,Springer,Pflügers Archiv - European Journal of Physiology,0031-6768,0031-6768,1432-2013,0031-6768,http://creativecommons.org/licenses/by/4.0,TRUE,27539300,PMC5026721,ut:000384425500011,NA,FALSE
+uu,2016,2200,10.1007/s00439-016-1729-8,TRUE,Springer,Human Genetics,0340-6717,0340-6717,1432-1203,0340-6717,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000385345900005,NA,FALSE
+uu,2016,2200,10.1007/s00445-016-1080-x,TRUE,Springer,Bulletin of Volcanology,0258-8900,0258-8900,1432-0819,0258-8900,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000394130700001,NA,FALSE
+uu,2016,2200,10.1007/s00526-016-1058-8,TRUE,Springer,Calculus of Variations and Partial Differential Equations,0944-2669,0944-2669,1432-0835,0944-2669,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000386708700016,NA,FALSE
+uu,2016,2200,10.1007/s00526-016-1088-2,TRUE,Springer,Calculus of Variations and Partial Differential Equations,0944-2669,0944-2669,1432-0835,0944-2669,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000390043500009,NA,FALSE
+uu,2016,2200,10.1007/s00701-016-3039-2,TRUE,Springer,Acta Neurochirurgica,0001-6268,0001-6268,0942-0940,0001-6268,http://creativecommons.org/licenses/by/4.0,TRUE,27928632,PMC5241344,ut:000393022200018,NA,FALSE
+uu,2016,2200,10.1007/s10040-016-1513-9,TRUE,Springer,Hydrogeology Journal,1431-2174,1431-2174,1435-0157,1431-2174,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000400755400015,NA,FALSE
+uu,2016,2200,10.1007/s10549-016-3928-3,TRUE,Springer,Breast Cancer Research and Treatment,0167-6806,0167-6806,1573-7217,0167-6806,http://creativecommons.org/licenses/by/4.0,TRUE,27492739,PMC5012147,ut:000382991500009,NA,FALSE
+uu,2016,2200,10.1007/s10571-016-0454-0,TRUE,Springer,Cellular and Molecular Neurobiology,0272-4340,0272-4340,1573-6830,0272-4340,http://creativecommons.org/licenses/by/4.0,TRUE,28028735,NA,ut:000409352200007,NA,FALSE
+uu,2016,2200,10.1007/s10592-016-0908-4,TRUE,Springer,Conservation Genetics,1566-0621,1566-0621,1572-9737,1566-0621,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000396341900007,NA,FALSE
+uu,2016,2200,10.1007/s10633-016-9564-8,TRUE,Springer,Documenta Ophthalmologica,0012-4486,0012-4486,1573-2622,0012-4486,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388974900001,NA,FALSE
+uu,2016,2200,10.1007/s10687-016-0269-x,TRUE,Springer,Extremes,1386-1999,1386-1999,1572-915X,1386-1999,NA,TRUE,NA,NA,ut:000394354400002,NA,FALSE
+uu,2016,2200,10.1007/s10726-016-9509-3,TRUE,Springer,Group Decision and Negotiation,0926-2644,0926-2644,1572-9907,0926-2644,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392417600007,NA,FALSE
+uu,2016,2200,10.1007/s10797-016-9427-y,TRUE,Springer,International Tax and Public Finance,0927-5940,0927-5940,1573-6970,0927-5940,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000400197100004,NA,FALSE
+uu,2016,2200,10.1007/s10800-016-1026-1,TRUE,Springer,Journal of Applied Electrochemistry,0021-891X,0021-891X,1572-8838,0021-891X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000394149900009,NA,FALSE
+uu,2016,2200,10.1007/s10803-016-2955-6,TRUE,Springer,Journal of Autism and Developmental Disorders,0162-3257,0162-3257,1573-3432,0162-3257,http://creativecommons.org/licenses/by/4.0,TRUE,27987062,PMC5352793,ut:000396815400011,NA,FALSE
+uu,2016,2200,10.1007/s10803-016-2978-z,TRUE,Springer,Journal of Autism and Developmental Disorders,0162-3257,0162-3257,1573-3432,0162-3257,http://creativecommons.org/licenses/by/4.0,TRUE,28000078,NA,NA,NA,FALSE
+uu,2016,2200,10.1007/s10817-016-9393-1,TRUE,Springer,Journal of Automated Reasoning,0168-7433,0168-7433,1573-0670,0168-7433,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392387400006,NA,FALSE
+uu,2016,2200,10.1007/s10844-016-0427-2,TRUE,Springer,Journal of Intelligent Information Systems,0925-9902,0925-9902,1573-7675,0925-9902,NA,TRUE,NA,NA,ut:000401468300004,NA,FALSE
+uu,2016,2200,10.1007/s10854-016-5387-3,TRUE,Springer,Journal of Materials Science: Materials in Electronics,0957-4522,0957-4522,1573-482X,0957-4522,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000389231000040,NA,FALSE
+uu,2016,2200,10.1007/s10854-016-6140-7,TRUE,Springer,Journal of Materials Science: Materials in Electronics,0957-4522,0957-4522,1573-482X,0957-4522,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000395072700052,NA,FALSE
+uu,2016,2200,10.1007/s10856-016-5785-3,TRUE,Springer,Journal of Materials Science: Materials in Medicine,0957-4530,0957-4530,1573-4838,0957-4530,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000386564000001,NA,FALSE
+uu,2016,2200,10.1007/s10892-016-9238-5,TRUE,Springer,The Journal of Ethics,1382-4554,1382-4554,1572-8609,1382-4554,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+uu,2016,2200,10.1007/s10915-016-0297-3,TRUE,Springer,Journal of Scientific Computing,0885-7474,0885-7474,1573-7691,0885-7474,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000398062500009,NA,FALSE
+uu,2016,2200,10.1007/s10928-016-9486-9,TRUE,Springer,Journal of Pharmacokinetics and Pharmacodynamics,1567-567X,1567-567X,1573-8744,1567-567X,http://creativecommons.org/licenses/by/4.0,TRUE,27578330,NA,ut:000399036400002,NA,FALSE
+uu,2016,2200,10.1007/s10928-016-9487-8,TRUE,Springer,Journal of Pharmacokinetics and Pharmacodynamics,1567-567X,1567-567X,1573-8744,1567-567X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388634800003,NA,FALSE
+uu,2016,2200,10.1007/s10928-016-9496-7,TRUE,Springer,Journal of Pharmacokinetics and Pharmacodynamics,1567-567X,1567-567X,1573-8744,1567-567X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388634800004,NA,FALSE
+uu,2016,2200,10.1007/s10928-016-9499-4,TRUE,Springer,Journal of Pharmacokinetics and Pharmacodynamics,1567-567X,1567-567X,1573-8744,1567-567X,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388634800005,NA,FALSE
+uu,2016,2200,10.1007/s10955-016-1604-y,TRUE,Springer,Journal of Statistical Physics,0022-4715,0022-4715,1572-9613,0022-4715,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000394366800014,NA,FALSE
+uu,2016,2200,10.1007/s10959-016-0723-3,TRUE,Springer,Journal of Theoretical Probability,0894-9840,0894-9840,1572-9230,0894-9840,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+uu,2016,2200,10.1007/s11019-016-9740-3,TRUE,Springer,"Medicine, Health Care and Philosophy",1386-7423,1386-7423,1572-8633,1386-7423,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000402455900002,NA,FALSE
+uu,2016,2200,10.1007/s11090-016-9766-6,TRUE,Springer,Plasma Chemistry and Plasma Processing,0272-4324,0272-4324,1572-8986,0272-4324,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000393053800008,NA,FALSE
+uu,2016,2200,10.1007/s11121-016-0696-6,TRUE,Springer,Prevention Science,1389-4986,1389-4986,1573-6695,1389-4986,http://creativecommons.org/licenses/by/4.0,TRUE,27638427,PMC5236081,ut:000392394600009,NA,FALSE
+uu,2016,2200,10.1007/s11229-016-1155-4,TRUE,Springer,Synthese,0039-7857,0039-7857,1573-0964,0039-7857,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+uu,2016,2200,10.1007/s11244-016-0690-z,TRUE,Springer,Topics in Catalysis,1022-5528,1022-5528,1572-9028,1022-5528,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000388825800005,NA,FALSE
+uu,2016,2200,10.1007/s11336-016-9512-2,TRUE,Springer,Psychometrika,0033-3123,0033-3123,1860-0980,0033-3123,NA,TRUE,27660261,NA,ut:000394985400004,NA,FALSE
+uu,2016,2200,10.1007/s11422-016-9790-0,TRUE,Springer,Cultural Studies of Science Education,1871-1502,1871-1502,1871-1510,1871-1502,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000405854300012,NA,FALSE
+uu,2016,2200,10.1007/s11695-016-2476-6,TRUE,Springer,Obesity Surgery,0960-8923,0960-8923,1708-0428,0960-8923,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000404529600016,NA,FALSE
+uu,2016,2200,10.1007/s11899-016-0335-0,TRUE,Springer,Current Hematologic Malignancy Reports,1558-8211,1558-8211,1558-822X,1558-8211,http://creativecommons.org/licenses/by/4.0,TRUE,27497846,PMC5031713,ut:000384583100004,NA,FALSE
+uu,2016,2200,10.1007/s12020-016-1172-6,TRUE,Springer,Endocrine,1355-008X,1355-008X,1559-0100,1355-008X,http://creativecommons.org/licenses/by/4.0,TRUE,27858284,PMC5316391,ut:000394966900021,NA,FALSE
+uu,2016,2200,10.1007/s12031-016-0867-8,TRUE,Springer,Journal of Molecular Neuroscience,0895-8696,0895-8696,1559-1166,0895-8696,http://creativecommons.org/licenses/by/4.0,TRUE,27981419,PMC5321710,ut:000396263800008,NA,FALSE
+uu,2016,2200,10.1007/s12035-016-0157-z,TRUE,Springer,Molecular Neurobiology,0893-7648,0893-7648,1559-1182,0893-7648,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000409039000040,NA,FALSE
+uu,2016,2200,10.1007/s13366-016-0320-8,TRUE,Springer,Beiträge zur Algebra und Geometrie / Contributions to Algebra and Geometry,0138-4821,0138-4821,2191-0383,0138-4821,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
+uu,2016,2200,10.1007/s40072-016-0080-3,TRUE,Springer,Stochastics and Partial Differential Equations: Analysis and Computations,2194-0401,2194-0401,2194-041X,NA,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000406353300002,NA,FALSE
+uu,2016,2200,10.1208/s12248-016-9977-z,TRUE,Springer,The AAPS Journal,1550-7416,NA,1550-7416,1550-7416,http://creativecommons.org/licenses/by/4.0,TRUE,27634384,NA,ut:000392210900017,NA,FALSE
+uu,2016,2200,10.1245/s10434-016-5703-4,TRUE,Springer,Annals of Surgical Oncology,1068-9265,1068-9265,1534-4681,1068-9265,http://creativecommons.org/licenses/by/4.0,TRUE,27904972,NA,ut:000399013200012,NA,FALSE
+uu,2016,321,10.1159/000444874,FALSE,Karger,Case Reports in Neurology,1662-680X,NA,1662-680X,1662-680X,NA,TRUE,27065427,PMC4821142,ut:000378535900010,NA,TRUE
+uu,2016,969,10.1080/2331186X.2016.1247610,FALSE,Taylor & Francis,Cogent Education,2331-186X,NA,2331-186X,2331-186X,NA,TRUE,NA,NA,ut:000387266300001,NA,TRUE
+uu,2016,982,10.1080/21592535.2015.1123842,FALSE,Taylor & Francis,Biomatter,2159-2535,NA,2159-2535,2159-2527,NA,TRUE,26787304,PMC5055208,NA,NA,FALSE
+uu,2016,982,10.1080/21592535.2015.1133394,FALSE,Taylor & Francis,Biomatter,2159-2535,NA,2159-2535,2159-2527,NA,TRUE,26727581,PMC4927199,NA,NA,FALSE
+uu,2017,0,10.1080/03009734.2016.1274806,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,28256956,NA,ut:000396476600001,NA,FALSE
+uu,2017,0,10.1080/03009734.2017.1285374,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,NA,NA,NA,NA,NA,FALSE,28276779,NA,ut:000401756500001,NA,NA
+uu,2017,0,10.1080/03009734.2017.1285836,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,NA,NA,NA,NA,NA,FALSE,28276782,NA,ut:000401756500002,NA,NA
+vti,2016,2200,10.1007/s11116-016-9750-2,TRUE,Springer,Transportation,0049-4488,0049-4488,1572-9435,0049-4488,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE


### PR DESCRIPTION
WoS identifers (ut) and ISSN-L values (issn_l) were added + some DOIs corrected (they contained [zero-width spaces](https://en.wikipedia.org/wiki/Zero-width_space) which made them unresolvable). Aside from that, the file (including format) was left unchanged.