### PR TITLE
DOIs normalised to lower case in core data file

### DIFF
--- a/data/apc_se.csv
+++ b/data/apc_se.csv
@@ -58,8 +58,8 @@ du,2015,747,10.2174/1874434601610010026,TRUE,Bentham Open,The Open Nursing Journ
 du,2015,926,10.1186/s13104-015-1597-7,FALSE,BioMed Central,BMC Research Notes,1756-0500,NA,1756-0500,1756-0500,NA,TRUE,26517989,PMC4627617,NA,http://bmcresnotes.biomedcentral.com/articles/10.1186/s13104-015-1597-7,TRUE
 du,2016,1051,10.4236/ojn.2017.72013,FALSE,Scientific Research Publishing,Open Journal of Nursing,2162-5336,2162-5336,2162-5344,2162-5336,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,NA,http://www.scirp.org/Journal/PaperInformation.aspx?PaperID=73974,FALSE
 du,2016,1429,10.1186/s12884-016-0955-3,FALSE,BioMed Central,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,1471-2393,NA,TRUE,27430590,PMC4949764,ut:000379781400003,https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-016-0955-3,TRUE
-du,2016,1614,10.2147/OAJSM.S101995,FALSE,Dove Medical Press,Open Access Journal of Sports Medicine,1179-1543,NA,1179-1543,1179-1543,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,26937207,PMC4762471,ut:000399933100002,https://www.dovepress.com/the-influence-of-sex-age-and-race-experience-on-pacing-profiles-during-peer-reviewed-article-OAJSM,TRUE
-du,2016,1636,10.2147/OAJSM.S93174,FALSE,Dove Medical Press,Open Access Journal of Sports Medicine,1179-1543,NA,1179-1543,1179-1543,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,26719730,PMC4689292,NA,https://www.dovepress.com/optimal-vo2max-to-mass-ratio-for-predicting-15-km-performance-among-el-peer-reviewed-article-OAJSM,TRUE
+du,2016,1614,10.2147/oajsm.s101995,FALSE,Dove Medical Press,Open Access Journal of Sports Medicine,1179-1543,NA,1179-1543,1179-1543,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,26937207,PMC4762471,ut:000399933100002,https://www.dovepress.com/the-influence-of-sex-age-and-race-experience-on-pacing-profiles-during-peer-reviewed-article-OAJSM,TRUE
+du,2016,1636,10.2147/oajsm.s93174,FALSE,Dove Medical Press,Open Access Journal of Sports Medicine,1179-1543,NA,1179-1543,1179-1543,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,26719730,PMC4689292,NA,https://www.dovepress.com/optimal-vo2max-to-mass-ratio-for-predicting-15-km-performance-among-el-peer-reviewed-article-OAJSM,TRUE
 du,2016,1650,10.1136/acupmed-2016-011164,TRUE,BMJ,Acupuncture in Medicine,0964-5284,0964-5284,1759-9873,0964-5284,NA,TRUE,27986648,NA,ut:000407905400003,http://aim.bmj.com/content/early/2016/12/16/acupmed-2016-011164,FALSE
 du,2016,1698,10.1002/ece3.2449,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,2045-7758,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000385626100026,http://onlinelibrary.wiley.com/doi/10.1002/ece3.2449/full,TRUE
 du,2016,1724,10.1186/s12889-016-3726-1,FALSE,BioMed Central,BMC Public Health,1471-2458,NA,1471-2458,1471-2458,http://www.springer.com/tdm,TRUE,27745552,PMC5066281,ut:000385307700001,https://bmcpublichealth.biomedcentral.com/articles/10.1186/s12889-016-3726-1,TRUE
@@ -70,7 +70,7 @@ du,2016,1980,10.1186/s12914-016-0082-2,FALSE,BioMed Central,BMC International He
 du,2016,2271,10.1186/s12913-016-1957-6,FALSE,BioMed Central,BMC Health Services Research,1472-6963,NA,1472-6963,1472-6963,NA,TRUE,28077130,PMC5225615,ut:000391924100001,http://bmchealthservres.biomedcentral.com/articles/10.1186/s12913-016-1957-6,TRUE
 du,2016,2519,10.1016/j.midw.2016.05.009,TRUE,Elsevier,Midwifery,0266-6138,0266-6138,NA,0266-6138,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27428093,NA,ut:000382308900003,http://www.sciencedirect.com/science/article/pii/S0266613816300614,FALSE
 du,2016,2690,10.1111/apa.13417,TRUE,Wiley,Acta Paediatrica,0803-5253,NA,1651-2227,0803-5253,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27059114,PMC5074324,ut:000382742900020,http://onlinelibrary.wiley.com/doi/10.1111/apa.13417/full,FALSE
-du,2016,2764,10.1111/2041-210X.12535,TRUE,Wiley,Methods in Ecology and Evolution,2041-210X,NA,2041-210X,2041-210X,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27478587,PMC4950150,ut:000379957400004,http://onlinelibrary.wiley.com/doi/10.1111/2041-210X.12535/full,FALSE
+du,2016,2764,10.1111/2041-210x.12535,TRUE,Wiley,Methods in Ecology and Evolution,2041-210X,NA,2041-210X,2041-210X,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27478587,PMC4950150,ut:000379957400004,http://onlinelibrary.wiley.com/doi/10.1111/2041-210X.12535/full,FALSE
 du,2016,2794,10.1111/scs.12391,TRUE,Wiley,Scandinavian Journal of Caring Sciences,0283-9318,NA,1471-6712,0283-9318,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27862156,NA,NA,http://onlinelibrary.wiley.com/doi/10.1111/scs.12391/full,FALSE
 du,2016,2852,10.1016/j.diabres.2016.09.015,TRUE,Elsevier,Diabetes Research and Clinical Practice,0168-8227,0168-8227,NA,0168-8227,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27718374,NA,ut:000390460100020,http://www.sciencedirect.com/science/article/pii/S0168822716306064,FALSE
 du,2016,3428,10.1016/j.matchar.2016.10.017,TRUE,Elsevier,Materials Characterization,1044-5803,1044-5803,NA,1044-5803,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000390728300003,http://www.sciencedirect.com/science/article/pii/S1044580316306131,FALSE
@@ -83,7 +83,7 @@ gu,2013,2429,10.1080/10439463.2013.817995,TRUE,Taylor & Francis,Policing and Soc
 gu,2013,2429,10.1080/10439463.2013.817996,TRUE,Taylor & Francis,Policing and Society,1043-9463,1043-9463,1477-2728,1043-9463,NA,TRUE,NA,NA,ut:000347523700002,NA,FALSE
 gu,2014,0,10.1159/000369918,FALSE,Karger,Audiology and Neurotology Extra,1664-5537,NA,1664-5537,1664-5537,NA,TRUE,NA,NA,NA,NA,FALSE
 gu,2014,2132,10.1080/16506073.2014.921834,TRUE,Taylor & Francis,Cognitive Behaviour Therapy,1650-6073,1650-6073,1651-2316,1650-6073,NA,TRUE,24911260,PMC4260664,ut:000344862500002,NA,FALSE
-gu,2014,2429,10.1080/2158379X.2014.963381,TRUE,Taylor & Francis,Journal of Political Power,2158-379X,2158-379X,2158-3803,2158-379X,NA,TRUE,NA,NA,NA,NA,FALSE
+gu,2014,2429,10.1080/2158379x.2014.963381,TRUE,Taylor & Francis,Journal of Political Power,2158-379X,2158-379X,2158-3803,2158-379X,NA,TRUE,NA,NA,NA,NA,FALSE
 gu,2014,2779,10.1111/adb.12202,TRUE,Wiley,Addiction Biology,1355-6215,NA,NA,1355-6215,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25475101,NA,ut:000371148700012,NA,FALSE
 gu,2014,755,10.1159/000362164,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,1664-5464,NA,TRUE,25254036,PMC4164083,NA,NA,TRUE
 gu,2014,755,10.1159/000366119,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,1664-5464,NA,TRUE,25493088,PMC4255994,NA,NA,TRUE
@@ -105,12 +105,12 @@ gu,2015,2779,10.1111/jch.12682,TRUE,Wiley,The Journal of Clinical Hypertension,1
 gu,2015,2779,10.1111/jvh.12464,TRUE,Wiley,Journal of Viral Hepatitis,1352-0504,NA,NA,1352-0504,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26353843,NA,ut:000368945700002,NA,FALSE
 gu,2015,397,10.3109/02813432.2015.1067515,FALSE,Taylor & Francis,Scandinavian Journal of Primary Health Care,0281-3432,0281-3432,1502-7724,0281-3432,NA,TRUE,26194171,PMC4750718,ut:000369749200002,NA,TRUE
 gu,2015,702,10.1080/15476286.2015.1056975,TRUE,Taylor & Francis,RNA Biology,1547-6286,1547-6286,1555-8584,1547-6286,NA,TRUE,26176991,PMC4615768,ut:000359659700006,NA,FALSE
-gu,2015,702,10.1080/2162402X.2015.1041701,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,2162-4011,NA,TRUE,26942055,PMC4760300,ut:000373383600040,NA,FALSE
+gu,2015,702,10.1080/2162402x.2015.1041701,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,2162-4011,NA,TRUE,26942055,PMC4760300,ut:000373383600040,NA,FALSE
 gu,2015,702,10.1080/21624054.2015.1096490,TRUE,Taylor & Francis,Worm,2162-4054,NA,2162-4054,2162-4046,NA,TRUE,27123370,PMC4826155,NA,NA,FALSE
 gu,2016,0,10.1080/20004508.2016.1275177,FALSE,Taylor & Francis,Education Inquiry,2000-4508,NA,2000-4508,2000-4508,NA,TRUE,NA,NA,NA,NA,TRUE
 gu,2016,0,10.1080/20004508.2016.1275182,FALSE,Taylor & Francis,Education Inquiry,2000-4508,NA,2000-4508,2000-4508,NA,TRUE,NA,NA,NA,NA,TRUE
 gu,2016,0,10.1093/ckj/sfv152,FALSE,Oxford University Press (OUP),Clinical Kidney Journal,2048-8505,2048-8505,2048-8513,2048-8505,NA,TRUE,26985373,PMC4792626,ut:000386129600009,NA,TRUE
-gu,2016,0,10.1107/S1600576715023444,TRUE,International Union of Crystallography (IUCr),Journal of Applied Crystallography,1600-5767,NA,1600-5767,0021-8898,http://creativecommons.org/licenses/by/2.0/uk/legalcode,TRUE,NA,NA,ut:000369389300006,NA,FALSE
+gu,2016,0,10.1107/s1600576715023444,TRUE,International Union of Crystallography (IUCr),Journal of Applied Crystallography,1600-5767,NA,1600-5767,0021-8898,http://creativecommons.org/licenses/by/2.0/uk/legalcode,TRUE,NA,NA,ut:000369389300006,NA,FALSE
 gu,2016,0,10.1111/eva.12277,FALSE,Wiley,Evolutionary Applications,1752-4571,NA,NA,1752-4571,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27087845,PMC4780386,ut:000368250500010,NA,TRUE
 gu,2016,0,10.1111/pbi.12479,FALSE,Wiley,Plant Biotechnology Journal,1467-7644,NA,NA,1467-7644,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26403330,NA,ut:000373069400006,NA,FALSE
 gu,2016,0,10.1177/2056305115624528,FALSE,SAGE Publications,Social Media + Society,2056-3051,2056-3051,2056-3051,2056-3051,NA,TRUE,NA,NA,NA,NA,TRUE
@@ -226,7 +226,7 @@ gu,2016,1482,10.1186/s12898-016-0067-y,FALSE,Springer,BMC Ecology,1472-6785,NA,1
 gu,2016,1482,10.1186/s12944-016-0342-0,FALSE,Springer,Lipids in Health and Disease,1476-511X,NA,1476-511X,1476-511X,NA,TRUE,27671740,PMC5037885,ut:000384581400001,NA,TRUE
 gu,2016,1482,10.1186/s12947-016-0091-2,FALSE,Springer,Cardiovascular Ultrasound,1476-7120,NA,1476-7120,1476-7120,http://www.springer.com/tdm,TRUE,27919286,PMC5139021,ut:000389300700001,NA,TRUE
 gu,2016,1482,10.1186/s40795-016-0094-2,FALSE,Springer,BMC Nutrition,2055-0928,NA,2055-0928,2055-0928,http://www.springer.com/tdm,TRUE,NA,NA,NA,NA,TRUE
-gu,2016,1490.9,10.1039/C6SM00580B,TRUE,Royal Society of Chemistry (RSC),Soft Matter,1744-683X,1744-683X,1744-6848,1744-683X,NA,TRUE,27112965,NA,ut:000379676800011,NA,FALSE
+gu,2016,1490.9,10.1039/c6sm00580b,TRUE,Royal Society of Chemistry (RSC),Soft Matter,1744-683X,1744-683X,1744-6848,1744-683X,NA,TRUE,27112965,NA,ut:000379676800011,NA,FALSE
 gu,2016,1490.9,10.3390/ijerph13080836,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,NA,1660-4601,1660-4601,NA,TRUE,27556476,PMC4997522,ut:000382462900091,NA,TRUE
 gu,2016,1503,10.1186/s13195-016-0208-8,FALSE,Springer,Alzheimer's Research & Therapy,1758-9193,NA,1758-9193,1758-9193,NA,TRUE,NA,NA,ut:000384844800001,NA,TRUE
 gu,2016,1503.8,10.1186/s13601-016-0112-0,FALSE,Springer,Clinical and Translational Allergy,2045-7022,NA,2045-7022,2045-7022,NA,TRUE,27493721,PMC4973051,ut:000390119200001,NA,TRUE
@@ -246,7 +246,7 @@ gu,2016,1646.2,10.1186/s12868-015-0221-z,FALSE,Springer,BMC Neuroscience,1471-22
 gu,2016,1686.6,10.1186/s12891-016-0947-5,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,1471-2474,NA,TRUE,26932181,PMC4774121,ut:000371387600001,NA,TRUE
 gu,2016,1692,10.1186/s40168-016-0199-5,FALSE,Springer,Microbiome,2049-2618,NA,2049-2618,2049-2618,NA,TRUE,NA,NA,ut:000385047800002,NA,TRUE
 gu,2016,1701.3,10.1080/00219266.2016.1233130,TRUE,Taylor & Francis,Journal of Biological Education,0021-9266,0021-9266,2157-6009,0021-9266,NA,TRUE,NA,NA,NA,NA,FALSE
-gu,2016,1705,10.1161/JAHA.115.003071,FALSE,Wolters Kluwer,Journal of the American Heart Association,2047-9980,2047-9980,2047-9980,2047-9980,NA,TRUE,26908411,PMC4802444,ut:000378131100032,NA,TRUE
+gu,2016,1705,10.1161/jaha.115.003071,FALSE,Wolters Kluwer,Journal of the American Heart Association,2047-9980,2047-9980,2047-9980,2047-9980,NA,TRUE,26908411,PMC4802444,ut:000378131100032,NA,TRUE
 gu,2016,1710,10.5194/hess-20-3719-2016,FALSE,Copernicus Publications,Hydrology and Earth System Sciences,1607-7938,NA,1607-7938,1027-5606,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000384116700001,NA,TRUE
 gu,2016,1740.45,10.1016/j.vaccine.2016.04.055,TRUE,Elsevier,Vaccine,0264-410X,0264-410X,NA,0264-410X,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27133878,NA,ut:000378667900019,NA,FALSE
 gu,2016,1743,10.1186/s12884-016-0836-9,FALSE,Springer,BMC Pregnancy and Childbirth,1471-2393,NA,1471-2393,1471-2393,NA,TRUE,26951777,PMC4782290,ut:000371575400001,NA,TRUE
@@ -355,13 +355,13 @@ gu,2016,246.2,10.1080/23723556.2015.1124174,TRUE,Taylor & Francis,Molecular & Ce
 gu,2016,2550,10.1093/eurheartj/ehw221,TRUE,Oxford University Press (OUP),European Heart Journal,0195-668X,0195-668X,1522-9645,0195-668X,NA,TRUE,NA,NA,ut:000403828700017,NA,FALSE
 gu,2016,2597,10.1093/nar/gkw224,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,0305-1048,NA,TRUE,27060140,PMC4914102,ut:000379753100005,NA,TRUE
 gu,2016,2610,10.1371/journal.pmed.1002156,FALSE,Public Library of Science (PLoS),PLOS Medicine,1549-1676,NA,1549-1676,1549-1277,http://creativecommons.org/licenses/by/4.0/,TRUE,27727282,PMC5058554,ut:000387656000020,NA,TRUE
-gu,2016,2627,10.1017/S0007123416000508,TRUE,Cambridge University Press (CUP),British Journal of Political Science,0007-1234,0007-1234,1469-2112,0007-1234,NA,TRUE,NA,NA,NA,NA,FALSE
+gu,2016,2627,10.1017/s0007123416000508,TRUE,Cambridge University Press (CUP),British Journal of Political Science,0007-1234,0007-1234,1469-2112,0007-1234,NA,TRUE,NA,NA,NA,NA,FALSE
 gu,2016,2641,10.18632/oncotarget.8508,FALSE,Impact Journals,OncoTarget,1949-2553,NA,1949-2553,1949-2553,NA,TRUE,27049722,PMC5045374,ut:000377742600021,NA,FALSE
 gu,2016,2705.88,10.1016/j.csr.2016.09.005,TRUE,Elsevier,Continental Shelf Research,0278-4343,0278-4343,NA,0278-4343,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000393005500005,NA,FALSE
 gu,2016,2750,10.1007/s00198-015-3445-y,TRUE,Springer,Osteoporosis International,0937-941X,0937-941X,1433-2965,0937-941X,http://creativecommons.org/licenses/by-nc/4.0,TRUE,26659067,PMC4839051,ut:000374564800007,NA,FALSE
 gu,2016,2750,10.1007/s00198-016-3643-2,TRUE,Springer,Osteoporosis International,0937-941X,0937-941X,1433-2965,0937-941X,http://creativecommons.org/licenses/by-nc/4.0,TRUE,NA,NA,ut:000388954600006,NA,FALSE
 gu,2016,2750,10.1007/s12678-016-0310-5,TRUE,Springer,Electrocatalysis,1868-2529,1868-2529,1868-5994,1868-2529,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000378805400008,NA,FALSE
-gu,2016,2779,10.1002/2015JC011451,TRUE,Wiley,Journal of Geophysical Research: Oceans,2169-9275,NA,NA,2169-9275,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000378072700031,NA,FALSE
+gu,2016,2779,10.1002/2015jc011451,TRUE,Wiley,Journal of Geophysical Research: Oceans,2169-9275,NA,NA,2169-9275,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000378072700031,NA,FALSE
 gu,2016,2779,10.1002/acr.22868,TRUE,Wiley,Arthritis Care & Research,2151-464X,NA,NA,2151-464X,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26881821,PMC5129496,ut:000387058800007,NA,FALSE
 gu,2016,2779,10.1002/jbmr.2743,TRUE,Wiley,Journal of Bone and Mineral Research,0884-0431,NA,NA,0884-0431,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26572678,PMC4832374,ut:000374008200005,NA,FALSE
 gu,2016,2779,10.1002/jbmr.3006,TRUE,Wiley,Journal of Bone and Mineral Research,0884-0431,NA,NA,0884-0431,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27676223,NA,ut:000398055900008,NA,FALSE
@@ -389,7 +389,7 @@ gu,2016,2976.47,10.1016/j.ijcard.2016.07.060,TRUE,Elsevier,International Journal
 gu,2016,3123.89,10.1016/j.biomaterials.2016.01.034,TRUE,Elsevier,Biomaterials,0142-9612,0142-9612,NA,0142-9612,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26828682,NA,ut:000371367500015,NA,FALSE
 gu,2016,3201.96,10.1016/j.bbadis.2016.11.033,TRUE,Elsevier,Biochimica et Biophysica Acta (BBA) - Molecular Basis of Disease,0925-4439,0925-4439,NA,0925-4439,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27915033,NA,ut:000394190300004,NA,FALSE
 gu,2016,3242,10.1002/jbm.a.35935,TRUE,Wiley,Journal of Biomedical Materials Research Part A,1549-3296,NA,NA,1549-3296,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27750392,PMC5216444,ut:000392506300023,NA,FALSE
-gu,2016,3256,10.1002/2015JC011112,TRUE,Wiley,Journal of Geophysical Research: Oceans,2169-9275,NA,NA,2169-9275,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000373134600022,NA,FALSE
+gu,2016,3256,10.1002/2015jc011112,TRUE,Wiley,Journal of Geophysical Research: Oceans,2169-9275,NA,NA,2169-9275,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000373134600022,NA,FALSE
 gu,2016,3256,10.1111/1462-2920.13557,TRUE,Wiley,Environmental Microbiology,1462-2912,NA,NA,1462-2912,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,27696654,NA,ut:000392946900023,NA,FALSE
 gu,2016,3300,10.1038/npjpcrm.2015.82,FALSE,Springer,npj Primary Care Respiratory Medicine,2055-1010,NA,2055-1010,2055-1010,http://www.springer.com/tdm,TRUE,26845513,PMC4741287,ut:000369423300001,NA,TRUE
 gu,2016,3355.3,10.1016/j.apergo.2016.06.012,TRUE,Elsevier,Applied Ergonomics,0003-6870,0003-6870,NA,0003-6870,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27633215,NA,ut:000384776100024,NA,FALSE
@@ -419,7 +419,7 @@ gu,2016,4462.7,10.1016/j.cmet.2016.05.001,TRUE,Elsevier,Cell Metabolism,1550-413
 gu,2016,521.5,10.1177/2058460116686392,FALSE,SAGE Publications,Acta Radiologica Open,2058-4601,2058-4601,2058-4601,2058-4601,NA,TRUE,28286672,PMC5330413,ut:000390871400006,NA,TRUE
 gu,2016,541.18,10.1016/j.amper.2016.10.001,FALSE,Elsevier,Ampersand,2215-0390,2215-0390,NA,2215-0390,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,TRUE
 gu,2016,580,10.1080/02673843.2015.1137777,FALSE,Taylor & Francis,International Journal of Adolescence and Youth,0267-3843,0267-3843,2164-4527,0267-3843,NA,TRUE,NA,NA,ut:000407699400009,NA,TRUE
-gu,2016,697,10.1080/2162402X.2015.1091147,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,2162-4011,NA,TRUE,27141351,PMC4839365,ut:000373385700025,NA,FALSE
+gu,2016,697,10.1080/2162402x.2015.1091147,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,2162-4011,NA,TRUE,27141351,PMC4839365,ut:000373385700025,NA,FALSE
 gu,2016,713.63,10.1080/15548627.2015.1132134,TRUE,Taylor & Francis,Autophagy,1554-8627,1554-8627,1554-8635,1554-8627,NA,TRUE,26727396,PMC4835980,ut:000373982600015,NA,FALSE
 gu,2016,713.63,10.1080/15592294.2016.1138195,TRUE,Taylor & Francis,Epigenetics,1559-2294,1559-2294,1559-2308,1559-2294,NA,TRUE,26786290,PMC4846113,ut:000372742300007,NA,FALSE
 gu,2016,730,10.1080/15476286.2016.1249092,TRUE,Taylor & Francis,RNA Biology,1547-6286,1547-6286,1555-8584,1547-6286,NA,TRUE,27791479,PMC5270547,ut:000392612000009,NA,FALSE
@@ -428,7 +428,7 @@ gu,2016,752,10.1186/s40064-016-2015-x,FALSE,Springer,SpringerPlus,2193-1801,NA,2
 gu,2016,931.3,10.1177/2325967116667920,FALSE,SAGE Publications,Orthopaedic Journal of Sports Medicine,2325-9671,2325-9671,2325-9671,2325-9671,NA,TRUE,NA,NA,ut:000385550100007,NA,TRUE
 gu,2016,931.3,10.1177/2325967116669708,FALSE,SAGE Publications,Orthopaedic Journal of Sports Medicine,2325-9671,2325-9671,2325-9671,2325-9671,NA,TRUE,NA,NA,NA,NA,TRUE
 gu,2016,932,10.1038/srep28490,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,27329824,PMC4916408,ut:000379997400001,NA,TRUE
-gu,2016,947,10.1002/2015WR018375,TRUE,Wiley,Water Resources Research,0043-1397,NA,NA,0043-1397,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000380100200034,NA,FALSE
+gu,2016,947,10.1002/2015wr018375,TRUE,Wiley,Water Resources Research,0043-1397,NA,NA,0043-1397,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000380100200034,NA,FALSE
 gu,2016,960,10.1093/jhps/hnw023,FALSE,Oxford University Press (OUP),Journal of Hip Preservation Surgery,2054-8397,NA,2054-8397,2054-8397,NA,TRUE,NA,NA,ut:000389764900011,NA,TRUE
 gu,2016,981.79,10.1016/j.giq.2016.01.010,TRUE,Elsevier,Government Information Quarterly,0740-624X,0740-624X,NA,0740-624X,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000372774300002,NA,FALSE
 gu,2017,1345.5,10.1371/journal.pone.0169759,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,28061507,PMC5218734,ut:000391641500135,NA,TRUE
@@ -481,14 +481,14 @@ ki,2015,3040,10.3109/10408444.2015.1092498,TRUE,Taylor & Francis,Critical Review
 ki,2015,702,10.1080/15476286.2015.1110675,TRUE,Taylor & Francis,RNA Biology,1547-6286,1547-6286,1555-8584,1547-6286,NA,TRUE,26669816,PMC4829308,ut:000370963300003,NA,FALSE
 ki,2015,702,10.1080/15548627.2015.1068489,TRUE,Taylor & Francis,Autophagy,1554-8627,1554-8627,1554-8635,1554-8627,NA,TRUE,26259639,PMC4590675,ut:000361629400011,NA,FALSE
 ki,2015,702,10.1080/19491034.2015.1106675,TRUE,Taylor & Francis,Nucleus,1949-1034,1949-1034,1949-1042,1949-1042,NA,TRUE,26734725,PMC4915514,ut:000367800700010,NA,FALSE
-ki,2015,702,10.1080/2162402X.2015.1052213,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,2162-4011,NA,TRUE,26942060,PMC4760332,ut:000373383600033,NA,FALSE
+ki,2015,702,10.1080/2162402x.2015.1052213,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,2162-4011,NA,TRUE,26942060,PMC4760332,ut:000373383600033,NA,FALSE
 ki,2015,755,10.1159/000441942,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,1664-5464,NA,TRUE,26955384,PMC4777933,ut:000367324900024,NA,TRUE
 ki,2016,0,10.1080/03009734.2016.1201553,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,NA,NA,ut:000387292600008,NA,FALSE
 ki,2016,0,10.1080/03009734.2016.1208310,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,NA,NA,ut:000387292600010,NA,FALSE
 ki,2016,0,10.1080/03009734.2016.1219432,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,NA,NA,ut:000387292600003,NA,FALSE
 ki,2016,0,10.1080/17453674.2016.1202013,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,1745-3674,NA,TRUE,27331243,PMC5016913,ut:000387526300015,NA,TRUE
 ki,2016,0,10.3109/03009734.2016.1158756,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,27064303,PMC4967266,ut:000381958400007,NA,FALSE
-ki,2016,1473,10.1080/2162402X.2016.1232222,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,2162-4011,NA,TRUE,28123870,PMC5214950,ut:000392846200005,NA,FALSE
+ki,2016,1473,10.1080/2162402x.2016.1232222,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,2162-4011,NA,TRUE,28123870,PMC5214950,ut:000392846200005,NA,FALSE
 ki,2016,199,10.3109/23320885.2016.1153974,FALSE,Taylor & Francis,Case Reports in Plastic Surgery and Hand Surgery,2332-0885,NA,2332-0885,2332-0885,NA,TRUE,27583262,PMC4996062,ut:000406332200003,NA,FALSE
 ki,2016,2074,10.1080/00016357.2016.1206211,TRUE,Taylor & Francis,Acta Odontologica Scandinavica,0001-6357,0001-6357,1502-3850,0001-6357,NA,TRUE,27409593,PMC4960510,ut:000381408200011,NA,FALSE
 ki,2016,2074,10.1080/10400419.2017.1263507,TRUE,Taylor & Francis,Creativity Research Journal,1040-0419,1040-0419,1532-6934,1040-0419,NA,TRUE,NA,NA,ut:000395125800004,NA,FALSE
@@ -569,13 +569,13 @@ ki,2016,2200,10.1007/s40618-016-0546-1,TRUE,Springer,Journal of Endocrinological
 ki,2016,2200,10.1245/s10434-016-5661-x,TRUE,Springer,Annals of Surgical Oncology,1068-9265,1068-9265,1534-4681,1068-9265,http://creativecommons.org/licenses/by/4.0,TRUE,27822633,PMC5339331,ut:000398047600041,NA,FALSE
 ki,2016,234,10.1080/19490976.2015.1127480,TRUE,Taylor & Francis,Gut Microbes,1949-0976,1949-0976,1949-0984,1949-0976,NA,TRUE,26939855,PMC4856455,NA,NA,FALSE
 ki,2016,397,10.3109/02813432.2015.1132892,FALSE,Taylor & Francis,Scandinavian Journal of Primary Health Care,0281-3432,0281-3432,1502-7724,0281-3432,NA,TRUE,26849465,PMC4911027,ut:000372023200009,NA,TRUE
-ki,2016,468,10.1080/2162402X.2015.1093722,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,2162-4011,NA,TRUE,27467926,PMC4910721,ut:000379162200004,NA,FALSE
+ki,2016,468,10.1080/2162402x.2015.1093722,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,2162-4011,NA,TRUE,27467926,PMC4910721,ut:000379162200004,NA,FALSE
 ki,2016,734,10.1080/15476286.2016.1243647,TRUE,Taylor & Francis,RNA Biology,1547-6286,1547-6286,1555-8584,1547-6286,NA,TRUE,27715493,NA,ut:000406139300013,NA,FALSE
-ki,2016,734,10.1080/2162402X.2015.1128613,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,2162-4011,NA,TRUE,27467944,PMC4910727,ut:000379162200036,NA,FALSE
+ki,2016,734,10.1080/2162402x.2015.1128613,TRUE,Taylor & Francis,OncoImmunology,2162-402X,NA,2162-402X,2162-4011,NA,TRUE,27467944,PMC4910727,ut:000379162200036,NA,FALSE
 ki,2016,870,10.1080/09699260.2015.1103497,TRUE,Taylor & Francis,Progress in Palliative Care,0969-9260,0969-9260,1743-291X,0969-9260,NA,TRUE,NA,NA,ut:000376256700006,NA,FALSE
 ki,2017,0,10.1080/16512235.2017.1281946,FALSE,Taylor & Francis,Microbial Ecology in Health and Disease,NA,NA,NA,NA,NA,FALSE,NA,NA,NA,NA,NA
 ki,2017,0,10.1080/16512235.2017.1281963,FALSE,Taylor & Francis,Microbial Ecology in Health and Disease,NA,NA,NA,NA,NA,FALSE,NA,NA,NA,NA,NA
-kth,2015,0,10.1007/JHEP09(2015)096,FALSE,Springer,Journal of High Energy Physics,1029-8479,NA,1029-8479,1029-8479,NA,TRUE,NA,NA,ut:000363539300002,http://link.springer.com/article/10.1007/JHEP09(2015)096,TRUE
+kth,2015,0,10.1007/jhep09(2015)096,FALSE,Springer,Journal of High Energy Physics,1029-8479,NA,1029-8479,1029-8479,NA,TRUE,NA,NA,ut:000363539300002,http://link.springer.com/article/10.1007/JHEP09(2015)096,TRUE
 kth,2015,0,10.1007/s13373-015-0067-9,FALSE,Springer,Bulletin of Mathematical Sciences,1664-3607,1664-3607,1664-3615,1664-3615,NA,TRUE,NA,NA,ut:000372286800001,http://link.springer.com/article/10.1007/s13373-015-0067-9,TRUE
 kth,2015,0,10.1186/s40294-015-0009-0,FALSE,Springer Open,Complex Adaptive Systems Modeling,2194-3206,NA,2194-3206,2194-3206,NA,TRUE,NA,NA,ut:000376148700001,https://casmodeling.springeropen.com/articles/10.1186/s40294-015-0009-0,TRUE
 kth,2015,0,10.3390/catal5041737,FALSE,MDPI,Catalysts,2073-4344,NA,2073-4344,2073-4344,NA,TRUE,NA,NA,ut:000367535300008,http://www.mdpi.com/2073-4344/5/4/1737,TRUE
@@ -588,21 +588,21 @@ kth,2015,1166,10.1016/j.segan.2015.09.001,TRUE,Elsevier,"Sustainable Energy, Gri
 kth,2015,1191,10.3390/ma8020751,FALSE,MDPI,Materials,1996-1944,NA,1996-1944,1996-1944,NA,TRUE,NA,NA,ut:000352052600026,http://www.mdpi.com/1996-1944/8/2/751,TRUE
 kth,2015,1258,10.1186/s12934-015-0227-3,FALSE,BioMed Central,Microbial Cell Factories,1475-2859,NA,1475-2859,1475-2859,NA,TRUE,25889453,PMC4415288,ut:000353617100001,https://microbialcellfactories.biomedcentral.com/articles/10.1186/s12934-015-0227-3,TRUE
 kth,2015,1258,10.1186/s12934-015-0236-2,FALSE,BioMed Central,Microbial Cell Factories,1475-2859,NA,1475-2859,1475-2859,NA,TRUE,25889969,PMC4405896,ut:000353259300001,https://microbialcellfactories.biomedcentral.com/articles/10.1186/s12934-015-0236-2,TRUE
-kth,2015,1280,10.1109/JPETS.2015.2445296,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Power and Energy Technology Systems Journal,2332-7707,NA,2332-7707,2332-7707,NA,TRUE,NA,NA,NA,http://ieeexplore.ieee.org/document/7234831/,FALSE
-kth,2015,1280,10.1109/PESGM.2016.7741306,TRUE,Institute of Electrical & Electronics Engineers (IEEE),Power and Energy Society General Meeting,NA,NA,1944-9933,1944-9925,NA,FALSE,NA,NA,NA,http://ieeexplore.ieee.org/document/7741306/,FALSE
-kth,2015,1280,10.1109/TAFFC.2015.2457417,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Affective Computing,1949-3045,1949-3045,NA,1949-3045,NA,TRUE,NA,NA,ut:000383995300007,http://ieeexplore.ieee.org/document/7160715/,FALSE
+kth,2015,1280,10.1109/jpets.2015.2445296,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Power and Energy Technology Systems Journal,2332-7707,NA,2332-7707,2332-7707,NA,TRUE,NA,NA,NA,http://ieeexplore.ieee.org/document/7234831/,FALSE
+kth,2015,1280,10.1109/pesgm.2016.7741306,TRUE,Institute of Electrical & Electronics Engineers (IEEE),Power and Energy Society General Meeting,NA,NA,1944-9933,1944-9925,NA,FALSE,NA,NA,NA,http://ieeexplore.ieee.org/document/7741306/,FALSE
+kth,2015,1280,10.1109/taffc.2015.2457417,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Affective Computing,1949-3045,1949-3045,NA,1949-3045,NA,TRUE,NA,NA,ut:000383995300007,http://ieeexplore.ieee.org/document/7160715/,FALSE
 kth,2015,1345,10.1016/j.ultrasmedbio.2015.08.012,TRUE,Elsevier,Ultrasound in Medicine & Biology,0301-5629,0301-5629,NA,0301-5629,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26454623,NA,ut:000367733800032,http://www.sciencedirect.com/science/article/pii/S0301-5629(15)00522-0,FALSE
 kth,2015,1360,10.1186/s12880-015-0086-8,FALSE,BioMed Central,BMC Medical Imaging,1471-2342,NA,1471-2342,1471-2342,http://www.springer.com/tdm,TRUE,26459634,PMC4601150,ut:000362535400001,https://bmcmedimaging.biomedcentral.com/articles/10.1186/s12880-015-0086-8,TRUE
-kth,2015,1383,10.1371/JOURNAL.PONE.0119032,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25822973,PMC4379182,ut:000352134700031,http://dx.doi.org/10.1371/journal.pone.0119032,TRUE
-kth,2015,1383,10.1371/JOURNAL.PONE.0130169,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26090859,PMC4474965,ut:000356835000093,http://dx.doi.org/10.1371/journal.pone.0130169,TRUE
-kth,2015,1383,10.1371/JOURNAL.PONE.0140644,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,https://creativecommons.org/publicdomain/zero/1.0/,TRUE,26496191,PMC4619776,ut:000363309200025,http://dx.doi.org/10.1371/journal.pone.0140644,TRUE
+kth,2015,1383,10.1371/journal.pone.0119032,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,25822973,PMC4379182,ut:000352134700031,http://dx.doi.org/10.1371/journal.pone.0119032,TRUE
+kth,2015,1383,10.1371/journal.pone.0130169,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26090859,PMC4474965,ut:000356835000093,http://dx.doi.org/10.1371/journal.pone.0130169,TRUE
+kth,2015,1383,10.1371/journal.pone.0140644,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,https://creativecommons.org/publicdomain/zero/1.0/,TRUE,26496191,PMC4619776,ut:000363309200025,http://dx.doi.org/10.1371/journal.pone.0140644,TRUE
 kth,2015,1423.75,10.1186/s12864-015-1686-y,FALSE,BioMed Central,BMC Genomics,1471-2164,NA,1471-2164,1471-2164,NA,TRUE,26109061,PMC4479346,ut:000356761400001,http://bmcgenomics.biomedcentral.com/articles/10.1186/s12864-015-1686-y,TRUE
-kth,2015,1430,10.1109/ACCESS.2015.2414815,FALSE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Access,2169-3536,NA,2169-3536,2169-3536,NA,TRUE,NA,NA,ut:000371388200033,http://ieeexplore.ieee.org/document/7072470/,TRUE
+kth,2015,1430,10.1109/access.2015.2414815,FALSE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Access,2169-3536,NA,2169-3536,2169-3536,NA,TRUE,NA,NA,ut:000371388200033,http://ieeexplore.ieee.org/document/7072470/,TRUE
 kth,2015,1483.25,10.1186/s12880-015-0083-y,FALSE,BioMed Central,BMC Medical Imaging,1471-2342,NA,1471-2342,1471-2342,http://www.springer.com/tdm,TRUE,26515510,PMC4627379,ut:000363921400001,http://bmcmedimaging.biomedcentral.com/articles/10.1186/s12880-015-0083-y,TRUE
-kth,2015,1505,10.1109/TASE.2015.2471305,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Automation Science and Engineering,1545-5955,1545-5955,1558-3783,1545-5955,NA,TRUE,NA,NA,ut:000362358500002,http://ieeexplore.ieee.org/document/7254252/,FALSE
-kth,2015,1505,10.1109/TIM.2015.2427731,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Instrumentation and Measurement,0018-9456,0018-9456,1557-9662,0018-9456,NA,TRUE,NA,NA,ut:000361487500019,http://ieeexplore.ieee.org/document/7104121/,FALSE
-kth,2015,1505,10.1109/TITS.2015.2431293,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Intelligent Transportation Systems,1524-9050,1524-9050,1558-0016,1524-9050,NA,TRUE,NA,NA,ut:000365958500009,http://ieeexplore.ieee.org/document/7116534/,FALSE
-kth,2015,1505,10.1109/TVT.2015.2434497,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Vehicular Technology,0018-9545,0018-9545,1939-9359,0018-9545,NA,TRUE,NA,NA,ut:000376094500004,http://ieeexplore.ieee.org/document/7109926/,FALSE
+kth,2015,1505,10.1109/tase.2015.2471305,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Automation Science and Engineering,1545-5955,1545-5955,1558-3783,1545-5955,NA,TRUE,NA,NA,ut:000362358500002,http://ieeexplore.ieee.org/document/7254252/,FALSE
+kth,2015,1505,10.1109/tim.2015.2427731,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Instrumentation and Measurement,0018-9456,0018-9456,1557-9662,0018-9456,NA,TRUE,NA,NA,ut:000361487500019,http://ieeexplore.ieee.org/document/7104121/,FALSE
+kth,2015,1505,10.1109/tits.2015.2431293,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Intelligent Transportation Systems,1524-9050,1524-9050,1558-0016,1524-9050,NA,TRUE,NA,NA,ut:000365958500009,http://ieeexplore.ieee.org/document/7116534/,FALSE
+kth,2015,1505,10.1109/tvt.2015.2434497,TRUE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Transactions on Vehicular Technology,0018-9545,0018-9545,1939-9359,0018-9545,NA,TRUE,NA,NA,ut:000376094500004,http://ieeexplore.ieee.org/document/7109926/,FALSE
 kth,2015,1595,10.1016/j.visres.2015.03.009,TRUE,Elsevier,Vision Research,0042-6989,0042-6989,NA,0042-6989,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25817716,NA,ut:000354149100012,http://www.sciencedirect.com/science/article/pii/S0042-6989(15)00108-X,FALSE
 kth,2015,1614,10.1016/j.jbiotec.2015.07.006,TRUE,Elsevier,Journal of Biotechnology,0168-1656,0168-1656,NA,0168-1656,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26211737,NA,NA,http://www.sciencedirect.com/science/article/pii/S0168-1656(15)30063-8,FALSE
 kth,2015,1695.75,10.1186/s13068-015-0380-2,FALSE,BioMed Central,Biotechnology for Biofuels,1754-6834,NA,1754-6834,1754-6834,NA,TRUE,26613003,PMC4660834,ut:000365784000009,https://biotechnologyforbiofuels.biomedcentral.com/articles/10.1186/s13068-015-0380-2,TRUE
@@ -638,24 +638,24 @@ kth,2015,185,10.1155/2015/921903,FALSE,Hindawi Publishing Corporation,Journal of
 kth,2015,185,10.1155/2015/935309,FALSE,Hindawi Publishing Corporation,Advances in Optical Technologies,1687-6393,1687-6393,1687-6407,1687-6393,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,http://dx.doi.org/10.1155/2015/935309,TRUE
 kth,2015,185,10.1155/2015/974530,FALSE,Hindawi Publishing Corporation,BioMed Research International,2314-6133,2314-6133,2314-6141,2314-6133,http://creativecommons.org/licenses/by/3.0/,TRUE,26421308,PMC4569783,ut:000361248100001,http://dx.doi.org/10.1155/2015/974530,TRUE
 kth,2015,185,10.1155/2015/981759,FALSE,Hindawi Publishing Corporation,Scientific Programming,1058-9244,1058-9244,1875-919X,1058-9244,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000364899300001,http://dx.doi.org/10.1155/2015/981759,TRUE
-kth,2015,1905,10.1039/C4TA06362G,TRUE,Royal Society of Chemistry (RSC),Journal of Materials Chemistry A,2050-7488,2050-7488,2050-7496,2050-7496,NA,TRUE,NA,NA,ut:000351845400042,http://pubs.rsc.org/en/Content/ArticleLanding/2015/TA/C4TA06362G#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5CC02907D,TRUE,Royal Society of Chemistry (RSC),Chemical Communications,1359-7345,1359-7345,1364-548X,1359-7345,NA,TRUE,25989158,PMC4456355,ut:000355631700017,http://pubs.rsc.org/en/Content/ArticleLanding/2015/CC/C5CC02907D#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5CC04822B,TRUE,Royal Society of Chemistry (RSC),Chemical Communications,1359-7345,1359-7345,1364-548X,1359-7345,NA,TRUE,26291876,NA,ut:000361540200024,http://pubs.rsc.org/en/Content/ArticleLanding/2015/CC/C5CC04822B#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5CP02306H,TRUE,Royal Society of Chemistry (RSC),Physical Chemistry Chemical Physics,1463-9076,1463-9076,1463-9084,1463-9076,NA,TRUE,26111372,NA,ut:000357808500034,http://pubs.rsc.org/en/Content/ArticleLanding/2015/CP/C5CP02306H#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5LC00436E,TRUE,Royal Society of Chemistry (RSC),Lab Chip,1473-0197,1473-0197,1473-0189,1473-0189,NA,TRUE,26126574,NA,ut:000358022900015,http://pubs.rsc.org/en/Content/ArticleLanding/2015/LC/C5LC00436E#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5LC00490J,TRUE,Royal Society of Chemistry (RSC),Lab Chip,1473-0197,1473-0197,1473-0189,1473-0189,NA,TRUE,26156858,NA,ut:000358609500011,http://pubs.rsc.org/en/Content/ArticleLanding/2015/LC/C5LC00490J#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5NR03002A,TRUE,Royal Society of Chemistry (RSC),Nanoscale,2040-3364,2040-3364,2040-3372,2040-3364,NA,TRUE,26176739,NA,ut:000358615200036,http://pubs.rsc.org/en/Content/ArticleLanding/2015/NR/C5NR03002A#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5NR03965G,TRUE,Royal Society of Chemistry (RSC),Nanoscale,2040-3364,2040-3364,2040-3372,2040-3364,NA,TRUE,26370450,NA,ut:000361834100058,http://pubs.rsc.org/en/Content/ArticleLanding/2015/NR/C5NR03965G#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5PY00136F,TRUE,Royal Society of Chemistry (RSC),Polymer Chemistry,1759-9954,1759-9954,1759-9962,1759-9954,NA,TRUE,NA,NA,ut:000353348700010,http://pubs.rsc.org/en/Content/ArticleLanding/2015/PY/C5PY00136F#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5RA01805F,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000351556800015,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA01805F#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5RA04452A,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000355703700096,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA04452A#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5RA06424D,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000356865500076,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA06424D#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5RA09704E,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000357805500021,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA09704E#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5RA16865A,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000361116500020,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA16865A#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5RA18569F,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000364073700059,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA18569F#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5SC03569D,FALSE,Royal Society of Chemistry (RSC),Chemical Science,2041-6520,2041-6520,2041-6539,2041-6520,NA,TRUE,NA,NA,ut:000372614800020,http://pubs.rsc.org/en/content/articlelanding/2016/sc/c5sc03569d#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5TA03120F,TRUE,Royal Society of Chemistry (RSC),Journal of Materials Chemistry A,2050-7488,2050-7488,2050-7496,2050-7496,NA,TRUE,NA,NA,ut:000359459900033,http://pubs.rsc.org/en/Content/ArticleLanding/2015/TA/C5TA03120F#!divAbstract,FALSE
-kth,2015,1905,10.1039/C5TA03646A,TRUE,Royal Society of Chemistry (RSC),Journal of Materials Chemistry A,2050-7488,2050-7488,2050-7496,2050-7496,NA,TRUE,NA,NA,ut:000358211700048,http://pubs.rsc.org/en/Content/ArticleLanding/2015/TA/C5TA03646A#!divAbstract,FALSE
+kth,2015,1905,10.1039/c4ta06362g,TRUE,Royal Society of Chemistry (RSC),Journal of Materials Chemistry A,2050-7488,2050-7488,2050-7496,2050-7496,NA,TRUE,NA,NA,ut:000351845400042,http://pubs.rsc.org/en/Content/ArticleLanding/2015/TA/C4TA06362G#!divAbstract,FALSE
+kth,2015,1905,10.1039/c5cc02907d,TRUE,Royal Society of Chemistry (RSC),Chemical Communications,1359-7345,1359-7345,1364-548X,1359-7345,NA,TRUE,25989158,PMC4456355,ut:000355631700017,http://pubs.rsc.org/en/Content/ArticleLanding/2015/CC/C5CC02907D#!divAbstract,FALSE
+kth,2015,1905,10.1039/c5cc04822b,TRUE,Royal Society of Chemistry (RSC),Chemical Communications,1359-7345,1359-7345,1364-548X,1359-7345,NA,TRUE,26291876,NA,ut:000361540200024,http://pubs.rsc.org/en/Content/ArticleLanding/2015/CC/C5CC04822B#!divAbstract,FALSE
+kth,2015,1905,10.1039/c5cp02306h,TRUE,Royal Society of Chemistry (RSC),Physical Chemistry Chemical Physics,1463-9076,1463-9076,1463-9084,1463-9076,NA,TRUE,26111372,NA,ut:000357808500034,http://pubs.rsc.org/en/Content/ArticleLanding/2015/CP/C5CP02306H#!divAbstract,FALSE
+kth,2015,1905,10.1039/c5lc00436e,TRUE,Royal Society of Chemistry (RSC),Lab Chip,1473-0197,1473-0197,1473-0189,1473-0189,NA,TRUE,26126574,NA,ut:000358022900015,http://pubs.rsc.org/en/Content/ArticleLanding/2015/LC/C5LC00436E#!divAbstract,FALSE
+kth,2015,1905,10.1039/c5lc00490j,TRUE,Royal Society of Chemistry (RSC),Lab Chip,1473-0197,1473-0197,1473-0189,1473-0189,NA,TRUE,26156858,NA,ut:000358609500011,http://pubs.rsc.org/en/Content/ArticleLanding/2015/LC/C5LC00490J#!divAbstract,FALSE
+kth,2015,1905,10.1039/c5nr03002a,TRUE,Royal Society of Chemistry (RSC),Nanoscale,2040-3364,2040-3364,2040-3372,2040-3364,NA,TRUE,26176739,NA,ut:000358615200036,http://pubs.rsc.org/en/Content/ArticleLanding/2015/NR/C5NR03002A#!divAbstract,FALSE
+kth,2015,1905,10.1039/c5nr03965g,TRUE,Royal Society of Chemistry (RSC),Nanoscale,2040-3364,2040-3364,2040-3372,2040-3364,NA,TRUE,26370450,NA,ut:000361834100058,http://pubs.rsc.org/en/Content/ArticleLanding/2015/NR/C5NR03965G#!divAbstract,FALSE
+kth,2015,1905,10.1039/c5py00136f,TRUE,Royal Society of Chemistry (RSC),Polymer Chemistry,1759-9954,1759-9954,1759-9962,1759-9954,NA,TRUE,NA,NA,ut:000353348700010,http://pubs.rsc.org/en/Content/ArticleLanding/2015/PY/C5PY00136F#!divAbstract,FALSE
+kth,2015,1905,10.1039/c5ra01805f,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000351556800015,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA01805F#!divAbstract,FALSE
+kth,2015,1905,10.1039/c5ra04452a,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000355703700096,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA04452A#!divAbstract,FALSE
+kth,2015,1905,10.1039/c5ra06424d,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000356865500076,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA06424D#!divAbstract,FALSE
+kth,2015,1905,10.1039/c5ra09704e,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000357805500021,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA09704E#!divAbstract,FALSE
+kth,2015,1905,10.1039/c5ra16865a,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000361116500020,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA16865A#!divAbstract,FALSE
+kth,2015,1905,10.1039/c5ra18569f,TRUE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000364073700059,http://pubs.rsc.org/en/Content/ArticleLanding/2015/RA/C5RA18569F#!divAbstract,FALSE
+kth,2015,1905,10.1039/c5sc03569d,FALSE,Royal Society of Chemistry (RSC),Chemical Science,2041-6520,2041-6520,2041-6539,2041-6520,NA,TRUE,NA,NA,ut:000372614800020,http://pubs.rsc.org/en/content/articlelanding/2016/sc/c5sc03569d#!divAbstract,FALSE
+kth,2015,1905,10.1039/c5ta03120f,TRUE,Royal Society of Chemistry (RSC),Journal of Materials Chemistry A,2050-7488,2050-7488,2050-7496,2050-7496,NA,TRUE,NA,NA,ut:000359459900033,http://pubs.rsc.org/en/Content/ArticleLanding/2015/TA/C5TA03120F#!divAbstract,FALSE
+kth,2015,1905,10.1039/c5ta03646a,TRUE,Royal Society of Chemistry (RSC),Journal of Materials Chemistry A,2050-7488,2050-7488,2050-7496,2050-7496,NA,TRUE,NA,NA,ut:000358211700048,http://pubs.rsc.org/en/Content/ArticleLanding/2015/TA/C5TA03646A#!divAbstract,FALSE
 kth,2015,1916.75,10.1186/s13059-015-0834-7,FALSE,BioMed Central,Genome Biology,1474-760X,NA,1474-760X,1474-7596,NA,TRUE,26667648,PMC4699468,ut:000366898100001,http://genomebiology.biomedcentral.com/articles/10.1186/s13059-015-0834-7,TRUE
 kth,2015,1949,10.1016/j.carbpol.2015.02.059,TRUE,Elsevier,Carbohydrate Polymers,0144-8617,0144-8617,NA,0144-8617,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,25857964,NA,ut:000353604200012,http://www.sciencedirect.com/science/article/pii/S0144861715001757,FALSE
 kth,2015,1949,10.1016/j.yrtph.2015.05.027,TRUE,Elsevier,Regulatory Toxicology and Pharmacology,0273-2300,0273-2300,NA,0273-2300,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26032492,NA,ut:000360255700003,http://www.sciencedirect.com/science/article/pii/S0273-2300(15)00142-7,FALSE
@@ -715,8 +715,8 @@ kth,2015,923,10.3390/su7043637,FALSE,MDPI,Sustainability,2071-1050,NA,2071-1050,
 kth,2015,930,10.1186/s40163-015-0027-4,FALSE,Springer,Crime Science,2193-7680,NA,2193-7680,2193-7680,NA,TRUE,NA,NA,NA,https://crimesciencejournal.springeropen.com/articles/10.1186/s40163-015-0027-4,TRUE
 kth,2015,935,10.1186/s13638-015-0480-5,FALSE,Springer Open,EURASIP Journal on Wireless Communications and Networking,1687-1499,NA,1687-1499,1687-1472,NA,TRUE,NA,NA,ut:000365807800002,http://link.springer.com/article/10.1186/s13638-015-0480-5,TRUE
 kth,2015,981.75,10.1186/s13634-015-0215-0,FALSE,Springer,EURASIP Journal on Advances in Signal Processing,1687-6180,NA,1687-6180,1687-6172,NA,TRUE,NA,NA,ut:000360573500001,http://asp.eurasipjournals.springeropen.com/articles/10.1186/s13634-015-0215-0,TRUE
-kth,2015,990,10.1109/JEDS.2015.2443172,FALSE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Journal of the Electron Devices Society,2168-6734,NA,2168-6734,2168-6734,NA,TRUE,NA,NA,ut:000369885000002,http://ieeexplore.ieee.org/document/7120903/,TRUE
-kth,2015,990,10.1109/JPHOT.2015.2428245,FALSE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Photonics Journal,1943-0655,NA,1943-0655,1943-0647,NA,TRUE,NA,NA,ut:000360358300035,http://ieeexplore.ieee.org/document/7098342/,TRUE
+kth,2015,990,10.1109/jeds.2015.2443172,FALSE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Journal of the Electron Devices Society,2168-6734,NA,2168-6734,2168-6734,NA,TRUE,NA,NA,ut:000369885000002,http://ieeexplore.ieee.org/document/7120903/,TRUE
+kth,2015,990,10.1109/jphot.2015.2428245,FALSE,Institute of Electrical & Electronics Engineers (IEEE),IEEE Photonics Journal,1943-0655,NA,1943-0655,1943-0647,NA,TRUE,NA,NA,ut:000360358300035,http://ieeexplore.ieee.org/document/7098342/,TRUE
 kth,2016,0,10.3390/ma9030127,FALSE,MDPI,Materials,1996-1944,NA,1996-1944,1996-1944,NA,TRUE,NA,NA,ut:000373805400072,http://www.mdpi.com/1996-1944/9/3/127,TRUE
 kth,2016,0,10.3390/ma9050313,FALSE,MDPI,Materials,1996-1944,NA,1996-1944,1996-1944,NA,TRUE,NA,NA,ut:000378628500008,http://www.mdpi.com/1996-1944/9/5/313,TRUE
 kth,2016,0,10.3390/mi7100192,FALSE,MDPI,Micromachines,2072-666X,NA,2072-666X,2072-666X,NA,TRUE,NA,NA,ut:000389131300022,http://www.mdpi.com/2072-666X/7/10/192,TRUE
@@ -724,7 +724,7 @@ kth,2016,0,10.3390/molecules21030366,FALSE,MDPI,Molecules,1420-3049,NA,1420-3049
 kth,2016,0,10.3390/w8020059,FALSE,MDPI,Water,2073-4441,NA,2073-4441,2073-4441,NA,TRUE,NA,NA,ut:000371828400020,http://www.mdpi.com/2073-4441/8/2/59,TRUE
 kth,2016,1072,10.3390/en9121080,FALSE,MDPI,Energies,1996-1073,NA,1996-1073,1996-1073,NA,TRUE,NA,NA,ut:000392402700081,http://www.mdpi.com/1996-1073/9/12/1080,TRUE
 kth,2016,1072,10.3390/ma10010057,FALSE,MDPI,Materials,1996-1944,NA,1996-1944,1996-1944,NA,TRUE,NA,NA,ut:000394838800057,http://www.mdpi.com/1996-1944/10/1/57,TRUE
-kth,2016,1267,10.1371/JOURNAL.PONE.0166149,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27870854,PMC5117611,ut:000388846400006,http://dx.doi.org/10.1371/journal.pone.0166149,TRUE
+kth,2016,1267,10.1371/journal.pone.0166149,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27870854,PMC5117611,ut:000388846400006,http://dx.doi.org/10.1371/journal.pone.0166149,TRUE
 kth,2016,1527,10.3390/s16030344,FALSE,MDPI,Sensors,1424-8220,NA,1424-8220,1424-8220,NA,TRUE,27005623,PMC4813919,ut:000373713600015,http://www.mdpi.com/1424-8220/16/3/344,TRUE
 kth,2016,1707,10.1155/2016/6279571,FALSE,Hindawi Publishing Corporation,Advances in Materials Science and Engineering,1687-8434,1687-8434,1687-8442,1687-8434,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,ut:000380314700001,http://dx.doi.org/10.1155/2016/6279571,TRUE
 kth,2016,2142.1,10.1016/j.apacoust.2016.04.004,TRUE,Elsevier,Applied Acoustics,0003-682X,0003-682X,NA,0003-682X,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000377837700008,http://dx.doi.org/10.1016/j.apacoust.2016.04.004,FALSE
@@ -788,7 +788,7 @@ liu,2012,468,10.1080/21663831.2012.749814,FALSE,Taylor & Francis,Materials Resea
 liu,2013,2429,10.1080/08351813.2013.753710,TRUE,Taylor & Francis,Research on Language & Social Interaction,0835-1813,0835-1813,1532-7973,0835-1813,NA,TRUE,NA,NA,ut:000322633100001,NA,FALSE
 liu,2013,413,10.1080/21663831.2013.865105,FALSE,Taylor & Francis,Materials Research Letters,2166-3831,NA,2166-3831,2166-3831,NA,TRUE,NA,NA,ut:000209767800006,NA,FALSE
 liu,2014,1239,10.1080/21693277.2014.898219,FALSE,Taylor & Francis,Production & Manufacturing Research,NA,NA,NA,NA,NA,FALSE,NA,NA,NA,NA,NA
-liu,2014,2429,10.1080/1943815X.2014.921629,FALSE,Taylor & Francis,Journal of Integrative Environmental Sciences,1943-815X,1943-815X,1943-8168,1943-815X,NA,TRUE,NA,NA,ut:000337948900003,NA,FALSE
+liu,2014,2429,10.1080/1943815x.2014.921629,FALSE,Taylor & Francis,Journal of Integrative Environmental Sciences,1943-815X,1943-815X,1943-8168,1943-815X,NA,TRUE,NA,NA,ut:000337948900003,NA,FALSE
 liu,2014,372,10.1080/21663831.2014.944676,FALSE,Taylor & Francis,Materials Research Letters,2166-3831,NA,2166-3831,2166-3831,NA,TRUE,NA,NA,ut:000372215500003,NA,FALSE
 liu,2014,702,10.4161/pri.29239,TRUE,Taylor & Francis,Prion,1933-6896,1933-6896,1933-690X,1933-6896,NA,TRUE,25495506,PMC4601348,ut:000348376000006,NA,FALSE
 liu,2015,2132,10.1080/10400435.2015.1092182,TRUE,Taylor & Francis,Assistive Technology,1040-0435,1040-0435,1949-3614,1040-0435,NA,TRUE,26496529,PMC4867850,ut:000376031400004,NA,FALSE
@@ -798,7 +798,7 @@ liu,2015,755,10.1159/000440816,FALSE,Karger,Nephron Extra,1664-5529,NA,1664-5529
 liu,2016,0,10.1080/17453674.2016.1205172,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,1745-3674,NA,TRUE,27357416,PMC5016903,ut:000387526300005,NA,TRUE
 liu,2016,0,10.1080/17453674.2016.1269273,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,1745-3674,NA,TRUE,27998203,PMC5251253,ut:000392736200001,NA,TRUE
 liu,2016,0,10.1080/17453674.2016.1274587,FALSE,Taylor & Francis,Acta Orthopaedica,1745-3674,1745-3674,1745-3682,1745-3674,NA,TRUE,28128005,NA,ut:000399484400018,NA,TRUE
-liu,2016,1169,10.1080/2331205X.2016.1239796,FALSE,Taylor & Francis,Cogent Medicine,2331-205X,NA,2331-205X,2331-205X,NA,TRUE,NA,NA,NA,NA,TRUE
+liu,2016,1169,10.1080/2331205x.2016.1239796,FALSE,Taylor & Francis,Cogent Medicine,2331-205X,NA,2331-205X,2331-205X,NA,TRUE,NA,NA,NA,NA,TRUE
 liu,2016,2074,10.3109/17518423.2015.1132281,TRUE,Taylor & Francis,Developmental Neurorehabilitation,1751-8423,1751-8423,1751-8431,1751-8423,NA,TRUE,26930111,NA,ut:000399489800003,NA,FALSE
 liu,2016,2132,10.1080/08856257.2016.1187878,TRUE,Taylor & Francis,European Journal of Special Needs Education,0885-6257,0885-6257,1469-591X,0885-6257,NA,TRUE,NA,NA,ut:000385511800006,NA,FALSE
 liu,2016,2132,10.1080/09537287.2016.1220649,TRUE,Taylor & Francis,Production Planning & Control,0953-7287,0953-7287,1366-5871,0953-7287,NA,TRUE,NA,NA,ut:000384468200004,NA,FALSE
@@ -845,7 +845,7 @@ liu,2016,413,10.1080/21663831.2016.1245682,FALSE,Taylor & Francis,Materials Rese
 liu,2016,421,10.1080/21693277.2016.1200502,FALSE,Taylor & Francis,Production & Manufacturing Research,2169-3277,NA,2169-3277,2169-3277,NA,TRUE,NA,NA,ut:000379824300001,NA,TRUE
 liu,2017,1016.8,NA,FALSE,Taylor & Francis,International Journal of Burns and Trauma,2160-2026,NA,NA,2160-2026,NA,FALSE,NA,NA,NA,http://www.ijbt.org/IJBT_V7N1.html  Int J Burn Trauma 2017;7(1):6-11,FALSE
 liu,2017,1045,10.1038/s41598-017-06457-9,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://creativecommons.org/licenses/by/4.0,TRUE,28765593,PMC5539109,ut:000406764200045,NA,TRUE
-liu,2017,1109.7,10.1108/JKM-10-2016-0438,TRUE,NA,NA,NA,NA,NA,NA,NA,FALSE,NA,NA,NA,NA,NA
+liu,2017,1109.7,10.1108/jkm-10-2016-0438,TRUE,NA,NA,NA,NA,NA,NA,NA,FALSE,NA,NA,NA,NA,NA
 liu,2017,1121,10.1016/j.invent.2017.01.001,FALSE,Elsevier,Internet Interventions,2214-7829,2214-7829,NA,2214-7829,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,TRUE
 liu,2017,1121,10.1016/j.invent.2017.03.002,FALSE,Elsevier,Internet Interventions,2214-7829,2214-7829,NA,2214-7829,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,TRUE
 liu,2017,1163.3,10.1063/1.4974461,FALSE,AIP Publishing,AIP Advances,2158-3226,NA,2158-3226,2158-3226,NA,TRUE,NA,NA,ut:000395789900073,NA,TRUE
@@ -888,7 +888,7 @@ liu,2017,1516,10.1186/s12864-017-3488-x,FALSE,Springer,BMC Genomics,1471-2164,NA
 liu,2017,1519.5,10.1186/s12906-017-1844-7,FALSE,Springer,BMC Complementary and Alternative Medicine,1472-6882,NA,1472-6882,1472-6882,NA,TRUE,28693538,PMC5504801,ut:000405065800001,NA,TRUE
 liu,2017,1522.6,10.1186/s12891-017-1581-6,FALSE,Springer,BMC Musculoskeletal Disorders,1471-2474,NA,1471-2474,1471-2474,NA,TRUE,28623897,PMC5474047,ut:000403494900001,NA,TRUE
 liu,2017,1537.5,10.1186/s12944-017-0505-7,FALSE,Springer,Lipids in Health and Disease,1476-511X,NA,1476-511X,1476-511X,NA,TRUE,28606089,PMC5469054,ut:000403043600002,NA,TRUE
-liu,2017,1551,10.1097/MD.0000000000006130,FALSE,Wolters Kluwer,Medicine,0025-7974,0025-7974,NA,0025-7974,NA,TRUE,28248866,PMC5340439,ut:000395795900011,NA,TRUE
+liu,2017,1551,10.1097/md.0000000000006130,FALSE,Wolters Kluwer,Medicine,0025-7974,0025-7974,NA,0025-7974,NA,TRUE,28248866,PMC5340439,ut:000395795900011,NA,TRUE
 liu,2017,1560,10.1088/1367-2630/aa5f8e,FALSE,IOP Publishing,New Journal of Physics,1367-2630,NA,1367-2630,1367-2630,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,ut:000398666100004,NA,TRUE
 liu,2017,1565,10.1186/s13063-017-1898-3,FALSE,Springer,Trials,1745-6215,NA,1745-6215,1745-6215,NA,TRUE,28372563,PMC5379716,ut:000398119900001,NA,TRUE
 liu,2017,1566,10.1038/srep43512,FALSE,Springer,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,NA,TRUE,28266628,PMC5339898,ut:000395637500001,NA,TRUE
@@ -902,7 +902,7 @@ liu,2017,1642,10.1002/brb3.763,FALSE,Wiley,Brain and Behavior,2162-3279,NA,NA,21
 liu,2017,1694.6,10.3389/fchem.2017.00028,FALSE,Frontiers,Frontiers in Chemistry,2296-2646,NA,2296-2646,2296-2646,NA,TRUE,28487854,PMC5403830,ut:000400374400001,NA,TRUE
 liu,2017,1722.5,10.1534/g3.116.028308,FALSE,Genetics Society of America,G3: Genes|Genomes|Genetics,2160-1836,NA,2160-1836,2160-1836,NA,TRUE,27678519,PMC5144961,ut:000390591400012,NA,TRUE
 liu,2017,1750.8,10.1186/s13049-017-0395-8,FALSE,Springer,"Scandinavian Journal of Trauma, Resuscitation and Emergency Medicine",1757-7241,NA,1757-7241,1757-7241,NA,TRUE,28526053,PMC5438497,ut:000401773100001,NA,TRUE
-liu,2017,1757,10.1364/OE.25.008192,FALSE,Optical Society of America (OSA),Optics Express,1094-4087,NA,1094-4087,1094-4087,NA,TRUE,28380934,NA,ut:000398536000094,NA,FALSE
+liu,2017,1757,10.1364/oe.25.008192,FALSE,Optical Society of America (OSA),Optics Express,1094-4087,NA,1094-4087,1094-4087,NA,TRUE,28380934,NA,ut:000398536000094,NA,FALSE
 liu,2017,1784,10.1177/1687814017695174,FALSE,SAGE Publications,Advances in Mechanical Engineering,1687-8140,1687-8140,1687-8140,1687-8132,NA,TRUE,NA,NA,ut:000400394500001,NA,TRUE
 liu,2017,1823.9,10.3389/fphys.2017.00043,FALSE,Frontiers,Frontiers in Physiology,1664-042X,NA,1664-042X,1664-042X,NA,TRUE,28220076,PMC5292575,ut:000393235000001,NA,TRUE
 liu,2017,1830,10.1016/j.npep.2017.03.005,TRUE,Elsevier,Neuropeptides,0143-4179,0143-4179,NA,0143-4179,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,28434790,NA,ut:000405880200001,NA,FALSE
@@ -914,17 +914,17 @@ liu,2017,1934,10.1088/1361-6463/aa57bc,TRUE,IOP Publishing,Journal of Physics D:
 liu,2017,1939,10.1371/journal.pntd.0005390,FALSE,Public Library of Science (PLoS),PLOS Neglected Tropical Diseases,1935-2735,NA,1935-2735,1935-2727,http://creativecommons.org/licenses/by/4.0/,TRUE,28192437,PMC5325601,ut:000396406600023,NA,TRUE
 liu,2017,1940,10.1371/journal.pcbi.1005608,FALSE,Public Library of Science (PLoS),PLOS Computational Biology,1553-7358,NA,1553-7358,1553-734X,http://creativecommons.org/licenses/by/4.0/,TRUE,28640810,PMC5501685,ut:000404565400053,NA,TRUE
 liu,2017,1974.9,10.1063/1.4977812,TRUE,AIP Publishing,Journal of Applied Physics,0021-8979,0021-8979,1089-7550,0021-8979,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,ut:000400623700006,NA,FALSE
-liu,2017,1993,10.1097/PTS.0000000000000369,TRUE,Wolters Kluwer,Journal of Patient Safety,1549-8417,1549-8417,NA,1549-8417,NA,TRUE,28234728,NA,NA,NA,FALSE
+liu,2017,1993,10.1097/pts.0000000000000369,TRUE,Wolters Kluwer,Journal of Patient Safety,1549-8417,1549-8417,NA,1549-8417,NA,TRUE,28234728,NA,NA,NA,FALSE
 liu,2017,1994.6,10.1155/2017/5806351,FALSE,Hindawi Publishing Corporation,Evidence-Based Complementary and Alternative Medicine,1741-427X,1741-427X,1741-4288,1741-427X,http://creativecommons.org/licenses/by/4.0/,TRUE,28270851,PMC5320299,ut:000394876600001,NA,TRUE
 liu,2017,2007,10.1371/journal.pgen.1006729,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,1553-7390,http://creativecommons.org/licenses/by/4.0/,TRUE,28414802,PMC5411104,ut:000402549200037,NA,TRUE
-liu,2017,2030.5,10.2147/JPR.S119845,FALSE,Dove Medical Press,Journal of Pain Research,1178-7090,NA,1178-7090,1178-7090,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,NA,NA,ut:000389840700001,NA,TRUE
-liu,2017,2030.5,10.2147/JPR.S138113,FALSE,Dove Medical Press,Journal of Pain Research,1178-7090,NA,1178-7090,1178-7090,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,28761374,PMC5522674,ut:000405597700005,NA,TRUE
-liu,2017,2059.9,10.2147/JPR.S128597,FALSE,Dove Medical Press,Journal of Pain Research,1178-7090,NA,1178-7090,1178-7090,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,28435317,PMC5388344,ut:000398611900001,NA,TRUE
-liu,2017,2078.9,10.2147/JPR.S125667,FALSE,Dove Medical Press,Journal of Pain Research,1178-7090,NA,1178-7090,1178-7090,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,28331360,PMC5356922,ut:000396321300001,NA,TRUE
+liu,2017,2030.5,10.2147/jpr.s119845,FALSE,Dove Medical Press,Journal of Pain Research,1178-7090,NA,1178-7090,1178-7090,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,NA,NA,ut:000389840700001,NA,TRUE
+liu,2017,2030.5,10.2147/jpr.s138113,FALSE,Dove Medical Press,Journal of Pain Research,1178-7090,NA,1178-7090,1178-7090,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,28761374,PMC5522674,ut:000405597700005,NA,TRUE
+liu,2017,2059.9,10.2147/jpr.s128597,FALSE,Dove Medical Press,Journal of Pain Research,1178-7090,NA,1178-7090,1178-7090,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,28435317,PMC5388344,ut:000398611900001,NA,TRUE
+liu,2017,2078.9,10.2147/jpr.s125667,FALSE,Dove Medical Press,Journal of Pain Research,1178-7090,NA,1178-7090,1178-7090,http://creativecommons.org/licenses/by-nc/3.0/,TRUE,28331360,PMC5356922,ut:000396321300001,NA,TRUE
 liu,2017,2150,10.1080/07292473.2017.1326584,TRUE,Taylor & Francis,War & Society,0729-2473,0729-2473,2042-4345,0729-2473,NA,TRUE,NA,NA,ut:000402098000004,NA,FALSE
 liu,2017,2150,10.1080/08351813.2017.1301293,TRUE,Taylor & Francis,Research on Language and Social Interaction,0835-1813,0835-1813,1532-7973,0835-1813,NA,TRUE,NA,NA,ut:000404581100001,NA,FALSE
 liu,2017,2151.1,10.3389/fcimb.2017.00278,FALSE,Frontiers,Frontiers in Cellular and Infection Microbiology,2235-2988,NA,2235-2988,2235-2988,NA,TRUE,28695112,PMC5483443,ut:000404073500001,NA,TRUE
-liu,2017,2174,10.1044/2016_JSLHR-H-16-0160,TRUE,American Speech Language Hearing Association,Journal of Speech Language and Hearing Research,1092-4388,1092-4388,NA,1092-4388,http://creativecommons.org/licenses/by/4.0/,TRUE,28651255,NA,NA,NA,FALSE
+liu,2017,2174,10.1044/2016_jslhr-h-16-0160,TRUE,American Speech Language Hearing Association,Journal of Speech Language and Hearing Research,1092-4388,1092-4388,NA,1092-4388,http://creativecommons.org/licenses/by/4.0/,TRUE,28651255,NA,NA,NA,FALSE
 liu,2017,2174,10.2196/jmir.7101,FALSE,JMIR Publications,Journal of Medical Internet Research,1438-8871,NA,1438-8871,1438-8871,NA,TRUE,28619700,PMC5491899,ut:000408351500002,NA,TRUE
 liu,2017,2215,10.1093/sf/sox043,TRUE,Oxford University Press (OUP),Social Forces,0037-7732,0037-7732,1534-7605,0037-7732,NA,TRUE,NA,NA,NA,NA,FALSE
 liu,2017,2236.7,10.3389/fpsyg.2017.00460,FALSE,Frontiers,Frontiers in Psychology,1664-1078,NA,1664-1078,1664-1078,NA,TRUE,28424641,PMC5372824,ut:000397587600002,NA,TRUE
@@ -934,8 +934,8 @@ liu,2017,2463,10.1073/pnas.1617758114,TRUE,National Academy of Sciences,Proceedi
 liu,2017,2500,10.1002/cphc.201700126,TRUE,Wiley,ChemPhysChem,1439-4235,NA,NA,1439-4235,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28295951,PMC5484993,ut:000403885800004,NA,FALSE
 liu,2017,2530,10.1073/pnas.1616456114,TRUE,National Academy of Sciences,Proceedings of the National Academy of Sciences,0027-8424,0027-8424,1091-6490,0027-8424,http://www.pnas.org/site/misc/userlicense.xhtml,TRUE,28242683,PMC5358360,NA,NA,FALSE
 liu,2017,2541,10.18632/oncotarget.15547,FALSE,Impact Journals,OncoTarget,1949-2553,NA,1949-2553,1949-2553,NA,TRUE,28430630,PMC5444764,ut:000400456200081,NA,FALSE
-liu,2017,2629.1,10.1172/JCI90678,FALSE,American Society for Clinical Investigation,Journal of Clinical Investigation,0021-9738,0021-9738,1558-8238,0021-9738,NA,TRUE,28287401,PMC5373882,ut:000398183300026,NA,FALSE
-liu,2017,2641.1,10.1158/2326-6066.CIR-16-0150,TRUE,American Association for Cancer Research (AACR),Cancer Immunology Research,2326-6066,2326-6066,2326-6074,2326-6066,NA,TRUE,28159748,NA,ut:000396023000006,NA,FALSE
+liu,2017,2629.1,10.1172/jci90678,FALSE,American Society for Clinical Investigation,Journal of Clinical Investigation,0021-9738,0021-9738,1558-8238,0021-9738,NA,TRUE,28287401,PMC5373882,ut:000398183300026,NA,FALSE
+liu,2017,2641.1,10.1158/2326-6066.cir-16-0150,TRUE,American Association for Cancer Research (AACR),Cancer Immunology Research,2326-6066,2326-6066,2326-6074,2326-6066,NA,TRUE,28159748,NA,ut:000396023000006,NA,FALSE
 liu,2017,2691,10.1016/j.amjms.2017.05.013,TRUE,Elsevier,The American Journal of the Medical Sciences,0002-9629,0002-9629,NA,0002-9629,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,NA,FALSE
 liu,2017,2778,10.1126/sciadv.1700345,FALSE,American Association for the Advancement of Science (AAAS),Science Advances,2375-2548,NA,2375-2548,2375-2548,NA,TRUE,28695197,NA,ut:000406370700067,NA,TRUE
 liu,2017,2960,10.1016/j.sab.2017.03.002,TRUE,Elsevier,Spectrochimica Acta Part B: Atomic Spectroscopy,0584-8547,0584-8547,NA,0584-8547,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000401200700017,NA,FALSE
@@ -950,10 +950,10 @@ liu,2017,3750,10.1002/mrm.26574,TRUE,Wiley,Magnetic Resonance in Medicine,0740-3
 liu,2017,435,10.1080/21663831.2017.1343207,FALSE,Taylor & Francis,Materials Research Letters,2166-3831,NA,2166-3831,2166-3831,NA,TRUE,NA,NA,NA,NA,FALSE
 liu,2017,4440,10.1038/ncomms14949,FALSE,Springer,Nature Communications,2041-1723,NA,2041-1723,2041-1723,NA,TRUE,28440271,PMC5413966,ut:000400065800001,NA,TRUE
 liu,2017,471,10.1016/j.dib.2016.12.046,FALSE,Elsevier,Data in Brief,2352-3409,2352-3409,NA,2352-3409,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,28070549,PMC5219593,NA,NA,TRUE
-liu,2017,652,10.1042/BSR20160514,FALSE,Portland Press,Bioscience Reports,0144-8463,0144-8463,1573-4935,0144-8463,http://creativecommons.org/licenses/by/4.0/,TRUE,27986865,PMC5271673,ut:000395096100021,NA,FALSE
+liu,2017,652,10.1042/bsr20160514,FALSE,Portland Press,Bioscience Reports,0144-8463,0144-8463,1573-4935,0144-8463,http://creativecommons.org/licenses/by/4.0/,TRUE,27986865,PMC5271673,ut:000395096100021,NA,FALSE
 liu,2017,717,10.3390/app7040383,FALSE,MDPI,Applied Sciences,2076-3417,NA,2076-3417,2076-3417,NA,TRUE,NA,NA,ut:000404447600073,NA,TRUE
 liu,2017,987,10.1016/j.jbef.2017.04.002,TRUE,Elsevier,Journal of Behavioral and Experimental Finance,2214-6350,2214-6350,NA,2214-6350,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000405854600005,NA,FALSE
-liu,2017,987,10.1097/QMH.0000000000000133,TRUE,Wolters Kluwer,Quality Management in Health Care,1063-8628,1063-8628,NA,1063-8628,NA,TRUE,28375953,PMC5381467,ut:000399390400003,NA,FALSE
+liu,2017,987,10.1097/qmh.0000000000000133,TRUE,Wolters Kluwer,Quality Management in Health Care,1063-8628,1063-8628,NA,1063-8628,NA,TRUE,28375953,PMC5381467,ut:000399390400003,NA,FALSE
 lnu,2016,2200,10.1007/s00107-016-1102-6,TRUE,Springer,European Journal of Wood and Wood Products,0018-3768,0018-3768,1436-736X,0018-3768,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000392318500002,NA,FALSE
 lnu,2016,2200,10.1007/s00792-016-0882-2,TRUE,Springer,Extremophiles,1431-0651,1431-0651,1433-4909,1431-0651,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000387270500009,NA,FALSE
 lnu,2016,2200,10.1007/s10086-016-1595-y,TRUE,Springer,Journal of Wood Science,1435-0211,1435-0211,1611-4663,1435-0211,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000394991100008,NA,FALSE
@@ -968,7 +968,7 @@ ltu,2012,2630,10.1080/02827581.2012.656142,TRUE,Taylor & Francis,Scandinavian Jo
 ltu,2012,2630,10.1080/17480272.2012.699461,TRUE,Taylor & Francis,Wood Material Science and Engineering,1748-0272,1748-0272,1748-0280,1748-0272,NA,TRUE,NA,NA,NA,NA,FALSE
 ltu,2013,2630,10.1080/03585522.2012.693272,TRUE,Taylor & Francis,Scandinavian Economic History Review,0358-5522,0358-5522,1750-2837,0358-5522,NA,TRUE,NA,NA,NA,NA,FALSE
 ltu,2014,234,10.4161/bioe.36328,TRUE,Taylor & Francis,Bioengineered,2165-5979,2165-5979,2165-5987,2165-5979,NA,TRUE,25424444,PMC4601276,ut:000349212600007,NA,FALSE
-ltu,2014,2429,10.1080/0013791X.2014.952466,TRUE,Taylor & Francis,The Engineering Economist,0013-791X,0013-791X,1547-2701,0013-791X,NA,TRUE,NA,NA,ut:000353499300003,NA,FALSE
+ltu,2014,2429,10.1080/0013791x.2014.952466,TRUE,Taylor & Francis,The Engineering Economist,0013-791X,0013-791X,1547-2701,0013-791X,NA,TRUE,NA,NA,ut:000353499300003,NA,FALSE
 ltu,2014,2429,10.1080/17480930.2014.942519,TRUE,Taylor & Francis,"International Journal of Mining, Reclamation and Environment",1748-0930,1748-0930,1748-0949,1748-0930,NA,TRUE,NA,NA,ut:000343814000006,NA,FALSE
 ltu,2015,2429,10.1080/14783363.2015.1068587,TRUE,Taylor & Francis,Total Quality Management & Business Excellence,1478-3363,1478-3363,1478-3371,1478-3363,NA,TRUE,NA,NA,ut:000362175300012,NA,FALSE
 ltu,2016,2132,10.1080/03719553.2016.1224048,TRUE,Taylor & Francis,Mineral Processing and Extractive Metallurgy,0371-9553,0371-9553,1743-2855,0371-9553,NA,TRUE,NA,NA,NA,NA,FALSE
@@ -998,13 +998,13 @@ ltu,2017,1344,10.3390/en10030332,FALSE,MDPI,Energies,1996-1073,NA,1996-1073,1996
 ltu,2017,1562,10.3390/ijerph13121248,FALSE,MDPI,International Journal of Environmental Research and Public Health,1660-4601,1661-7827,1660-4601,1660-4601,NA,TRUE,27999272,PMC5201389,ut:000392280100019,http://www.mdpi.com/1660-4601/13/12/1248,TRUE
 ltu,2017,1599,10.3390/s17010181,FALSE,MDPI,Sensors,1424-8220,NA,1424-8220,1424-8220,NA,TRUE,28106817,PMC5298754,ut:000393021000180,http://www.mdpi.com/1424-8220/17/1/181/htm,TRUE
 ltu,2017,2243,10.1016/j.apgeochem.2017.02.012,TRUE,Elsevier,Applied Geochemistry,0883-2927,0883-2927,NA,0883-2927,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000398867700009,http://www.sciencedirect.com/science/article/pii/S0883292716302141,FALSE
-ltu,2017,2260,10.1016/j.chemolab.2017.05.016#sthash.VNp1MNah.dpuf,TRUE,Elsevier,Chemometrics and Intelligent Laboratory Systems,0169-7439,0169-7439,1873-3239,0169-7439,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S0169743917300734,FALSE
-ltu,2017,239,10.4028/www.scientific.net/MSF.891.18#sthash.pqs6shZX.dpuf,TRUE,Trans Tech Publications,Materials Science Forum,1662-9752,0255-5476,1662-9752,0255-5476,NA,TRUE,NA,NA,NA,https://www.scientific.net/MSF.891.18,FALSE
+ltu,2017,2260,10.1016/j.chemolab.2017.05.016#sthash.vnp1mnah.dpuf,TRUE,Elsevier,Chemometrics and Intelligent Laboratory Systems,0169-7439,0169-7439,1873-3239,0169-7439,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S0169743917300734,FALSE
+ltu,2017,239,10.4028/www.scientific.net/msf.891.18#sthash.pqs6shzx.dpuf,TRUE,Trans Tech Publications,Materials Science Forum,1662-9752,0255-5476,1662-9752,0255-5476,NA,TRUE,NA,NA,NA,https://www.scientific.net/MSF.891.18,FALSE
 ltu,2017,2960,10.1016/j.biortech.2017.04.002,TRUE,Elsevier,Bioresource Technology,0960-8524,0960-8524,1873-2976,0960-8524,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,28412146,NA,ut:000405980700038,http://www.sciencedirect.com/science/article/pii/S0960852417304832,FALSE
 ltu,2017,3140,10.1016/j.carbon.2017.02.007,TRUE,Elsevier,Carbon,0008-6223,0008-6223,1873-3891,0008-6223,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000397549300053,http://www.sciencedirect.com/science/article/pii/S0008622317301252,FALSE
-ltu,2017,560,10.1039/C6RA27065D,FALSE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000393755100024,http://pubs.rsc.org/en/content/articlepdf/2017/ra/c6ra27065d,FALSE
-ltu,2017,560,10.1039/C6RA28574K,FALSE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000393757100006,http://pubs.rsc.org/en/content/articlepdf/2017/ra/c6ra28574k,FALSE
-ltu,2017,588,10.1039/C6RA25410A,FALSE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000393748000028,http://pubs.rsc.org/en/content/articlelanding/2017/ra/c6ra25410a#!divAbstract,FALSE
+ltu,2017,560,10.1039/c6ra27065d,FALSE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000393755100024,http://pubs.rsc.org/en/content/articlepdf/2017/ra/c6ra27065d,FALSE
+ltu,2017,560,10.1039/c6ra28574k,FALSE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000393757100006,http://pubs.rsc.org/en/content/articlepdf/2017/ra/c6ra28574k,FALSE
+ltu,2017,588,10.1039/c6ra25410a,FALSE,Royal Society of Chemistry (RSC),RSC Advances,2046-2069,NA,2046-2069,2046-2069,NA,TRUE,NA,NA,ut:000393748000028,http://pubs.rsc.org/en/content/articlelanding/2017/ra/c6ra25410a#!divAbstract,FALSE
 ltu,2017,888,10.4236/eng.2017.95024,FALSE,Scientific Research Publishing,Engineering,1947-3931,1947-3931,1947-394X,1947-394X,http://creativecommons.org/licenses/by/4.0/,TRUE,NA,NA,NA,http://file.scirp.org/pdf/ENG_2017052716204530.pdf,FALSE
 ltu,2017,931,NA,FALSE,Scientific Research Publishing,Bioresources,NA,1930-2126,1930-2126,1930-2126,NA,FALSE,NA,NA,NA,http://ojs.cnr.ncsu.edu/index.php/BioRes/article/view/BioRes_12_2_3122_Sadatnezhad_Continuous_Surface_Densification_Wood,FALSE
 ltu,2017,95,NA,FALSE,Scientific Research Publishing,Civil Engineering Journal,2476-3055,NA,NA,2476-3055,NA,FALSE,NA,NA,NA,http://civilejournal.org/index.php/cej/article/view/310,FALSE
@@ -1025,9 +1025,9 @@ lu,2015,1115,10.1080/23335432.2015.1014848,FALSE,Taylor & Francis,International 
 lu,2015,2074,10.1080/00140139.2015.1019575,TRUE,Taylor & Francis,Ergonomics,0014-0139,0014-0139,1366-5847,0014-0139,NA,TRUE,25761380,PMC4566900,ut:000369436300005,NA,FALSE
 lu,2015,2074,10.3109/00365513.2015.1099724,TRUE,Taylor & Francis,Scandinavian Journal of Clinical and Laboratory Investigation,0036-5513,0036-5513,1502-7686,0036-5513,NA,TRUE,26647957,PMC4720044,ut:000366183000011,NA,FALSE
 lu,2015,2132,10.1080/13504509.2015.1128492,TRUE,Taylor & Francis,International Journal of Sustainable Development & World Ecology,1350-4509,1350-4509,1745-2627,1350-4509,NA,TRUE,NA,NA,ut:000382541300003,NA,FALSE
-lu,2015,2132,10.1080/1573062X.2015.1111913,TRUE,Taylor & Francis,Urban Water Journal,1573-062X,1573-062X,1744-9006,1573-062X,NA,TRUE,NA,NA,ut:000392208900006,NA,FALSE
+lu,2015,2132,10.1080/1573062x.2015.1111913,TRUE,Taylor & Francis,Urban Water Journal,1573-062X,1573-062X,1744-9006,1573-062X,NA,TRUE,NA,NA,ut:000392208900006,NA,FALSE
 lu,2015,2132,10.3109/00365513.2015.1025427,TRUE,Taylor & Francis,Scandinavian Journal of Clinical and Laboratory Investigation,0036-5513,0036-5513,1502-7686,0036-5513,NA,TRUE,25919022,PMC4487590,ut:000353654200009,NA,FALSE
-lu,2015,2132,10.3109/0284186X.2015.1075663,TRUE,Taylor & Francis,Acta Oncologica,0284-186X,0284-186X,1651-226X,0284-186X,NA,TRUE,26362587,PMC4819809,ut:000371249500005,NA,FALSE
+lu,2015,2132,10.3109/0284186x.2015.1075663,TRUE,Taylor & Francis,Acta Oncologica,0284-186X,0284-186X,1651-226X,0284-186X,NA,TRUE,26362587,PMC4819809,ut:000371249500005,NA,FALSE
 lu,2015,2132,10.3109/17435390.2015.1048324,TRUE,Taylor & Francis,Nanotoxicology,1743-5390,1743-5390,1743-5404,1743-5390,NA,TRUE,26186033,PMC4819849,ut:000371822800010,NA,FALSE
 lu,2015,2429,10.1080/02698595.2014.953343,TRUE,Taylor & Francis,International Studies in the Philosophy of Science,0269-8595,0269-8595,1469-9281,0269-8595,NA,TRUE,NA,NA,ut:000346055600005,NA,FALSE
 lu,2015,248,10.1080/00207543.2012.761363,TRUE,Taylor & Francis,International Journal of Production Research,0020-7543,0020-7543,1366-588X,0020-7543,NA,TRUE,NA,NA,ut:000328246000011,NA,FALSE
@@ -1049,8 +1049,8 @@ lu,2016,2132,10.1080/14693062.2016.1167009,TRUE,Taylor & Francis,Climate Policy,
 lu,2016,2132,10.1080/17435390.2016.1189615,TRUE,Taylor & Francis,Nanotoxicology,1743-5390,1743-5390,1743-5404,1743-5390,NA,TRUE,27181920,PMC4975093,ut:000382337100015,NA,FALSE
 lu,2016,2132,10.1080/23254823.2016.1253977,TRUE,Taylor & Francis,European Journal of Cultural and Political Sociology,2325-4823,2325-4823,2325-4815,2325-4815,NA,TRUE,NA,NA,NA,NA,FALSE
 lu,2016,2132,10.1080/87565641.2016.1243111,TRUE,Taylor & Francis,Developmental Neuropsychology,8756-5641,8756-5641,1532-6942,1532-6942,NA,TRUE,28059564,NA,ut:000395349600004,NA,FALSE
-lu,2016,2132,10.1179/2047971915Y.0000000021,TRUE,Taylor & Francis,International Journal of Healthcare Management,2047-9700,2047-9700,2047-9719,2047-9700,NA,TRUE,NA,NA,NA,NA,FALSE
-lu,2016,2132,10.3109/0284186X.2016.1146826,TRUE,Taylor & Francis,Acta Oncologica,0284-186X,0284-186X,1651-226X,0284-186X,NA,TRUE,27050668,PMC4950423,ut:000381102800006,NA,FALSE
+lu,2016,2132,10.1179/2047971915y.0000000021,TRUE,Taylor & Francis,International Journal of Healthcare Management,2047-9700,2047-9700,2047-9719,2047-9700,NA,TRUE,NA,NA,NA,NA,FALSE
+lu,2016,2132,10.3109/0284186x.2016.1146826,TRUE,Taylor & Francis,Acta Oncologica,0284-186X,0284-186X,1651-226X,0284-186X,NA,TRUE,27050668,PMC4950423,ut:000381102800006,NA,FALSE
 lu,2016,2132,10.3109/14017431.2016.1154598,TRUE,Taylor & Francis,Scandinavian Cardiovascular Journal,1401-7431,1401-7431,1651-2006,1401-7431,NA,TRUE,26882241,PMC4898163,ut:000377282900009,NA,FALSE
 lu,2016,2200,10.1007/s00018-016-2365-0,TRUE,Springer,Cellular and Molecular Life Sciences,1420-682X,1420-682X,1420-9071,1420-682X,http://creativecommons.org/licenses/by/4.0,TRUE,27652381,PMC5272905,ut:000393694900011,NA,FALSE
 lu,2016,2200,10.1007/s00125-016-4113-2,TRUE,Springer,Diabetologia,0012-186X,0012-186X,1432-0428,0012-186X,http://creativecommons.org/licenses/by/4.0,TRUE,27796421,NA,ut:000389634000015,NA,FALSE
@@ -1147,7 +1147,7 @@ mah,2016,2200,10.1007/s12187-016-9435-6,TRUE,Springer,Child Indicators Research,
 mah,2016,2200,10.1007/s12529-016-9625-0,TRUE,Springer,International Journal of Behavioral Medicine,1070-5503,1070-5503,1532-7558,1070-5503,http://creativecommons.org/licenses/by/4.0,TRUE,28028732,NA,NA,NA,FALSE
 mah,2016,2200,10.1007/s13277-016-5280-y,TRUE,Springer,Tumor Biology,1010-4283,1010-4283,1423-0380,1010-4283,http://creativecommons.org/licenses/by/4.0,TRUE,27476172,PMC5097081,ut:000387538700076,NA,FALSE
 mah,2016,346,10.1177/2158244016633739,FALSE,SAGE Publications,SAGE Open,2158-2440,2158-2440,2158-2440,2158-2440,NA,TRUE,NA,NA,NA,http://sgo.sagepub.com/content/6/1/2158244016633739,TRUE
-mah,2016,468,10.1080/2331186X.2016.1184604,FALSE,Taylor & Francis,Cogent Education,2331-186X,NA,2331-186X,2331-186X,NA,TRUE,NA,NA,ut:000385834300001,NA,TRUE
+mah,2016,468,10.1080/2331186x.2016.1184604,FALSE,Taylor & Francis,Cogent Education,2331-186X,NA,2331-186X,2331-186X,NA,TRUE,NA,NA,ut:000385834300001,NA,TRUE
 mdh,2016,2200,10.1007/s00170-016-9377-7,TRUE,Springer,The International Journal of Advanced Manufacturing Technology,0268-3768,0268-3768,1433-3015,0268-3768,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000401505000030,NA,FALSE
 mdh,2016,2200,10.1007/s10270-016-0556-7,TRUE,Springer,Software & Systems Modeling,1619-1366,1619-1366,1619-1374,1619-1366,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,NA,NA,FALSE
 mdh,2016,2200,10.1007/s10659-016-9613-2,TRUE,Springer,Journal of Elasticity,0374-3535,0374-3535,1573-2681,0374-3535,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000396525700006,NA,FALSE
@@ -1235,8 +1235,8 @@ slu,2014,1851.18,10.1016/j.theriogenology.2014.02.014,TRUE,Elsevier,Theriogenolo
 slu,2014,1854.9,10.1186/s13028-014-0061-3,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,25297979,PMC4194406,ut:000342776500001,NA,TRUE
 slu,2014,1901.53,10.1186/1756-3305-7-410,FALSE,BioMed Central,Parasites & Vectors,1756-3305,1756-3305,NA,1756-3305,NA,TRUE,25175357,PMC4156605,ut:000341205100001,NA,TRUE
 slu,2014,1905.58,10.1111/1462-2920.12596,TRUE,Wiley,Environmental Microbiology,1462-2912,NA,NA,1462-2912,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25142400,NA,ut:000350546200016,NA,FALSE
-slu,2014,2137,10.1080/1081602X.2014.927783,TRUE,Taylor & Francis,The History of the Family,1081-602X,1081-602X,1873-5398,1081-602X,NA,TRUE,NA,NA,ut:000341642500009,NA,FALSE
-slu,2014,2171,10.1017/S0950268814002891,TRUE,Cambridge University Press (CUP),Epidemiology and Infection,0950-2688,0950-2688,1469-4409,0950-2688,NA,TRUE,25373497,PMC4456771,ut:000355760600015,NA,FALSE
+slu,2014,2137,10.1080/1081602x.2014.927783,TRUE,Taylor & Francis,The History of the Family,1081-602X,1081-602X,1873-5398,1081-602X,NA,TRUE,NA,NA,ut:000341642500009,NA,FALSE
+slu,2014,2171,10.1017/s0950268814002891,TRUE,Cambridge University Press (CUP),Epidemiology and Infection,0950-2688,0950-2688,1469-4409,0950-2688,NA,TRUE,25373497,PMC4456771,ut:000355760600015,NA,FALSE
 slu,2014,2173,10.1111/rda.12346,TRUE,Wiley,Reproduction in Domestic Animals,0936-6768,NA,NA,0936-6768,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,24930481,PMC4286828,ut:000339561900023,NA,FALSE
 slu,2014,2183.29,10.1111/conl.12087,FALSE,Wiley,Conservation Letters,1755-263X,NA,NA,1755-263X,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000350544200006,NA,TRUE
 slu,2014,2183.29,10.1111/gcb.12527,TRUE,Wiley,Global Change Biology,1354-1013,NA,NA,1354-1013,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,24535943,PMC4257505,ut:000340287300007,NA,FALSE
@@ -1273,8 +1273,8 @@ slu,2014,2412.58,10.1111/ejss.12228,TRUE,Wiley,European Journal of Soil Science,
 slu,2014,2428.97,10.1016/j.foreco.2014.01.020,TRUE,Elsevier,Forest Ecology and Management,0378-1127,0378-1127,NA,0378-1127,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000334082900019,NA,FALSE
 slu,2014,2436.88,10.1089/fpd.2014.1863,TRUE,Mary Ann Liebert,Foodborne Pathogens and Disease,1535-3141,1535-3141,1556-7125,1535-3141,NA,TRUE,25562377,NA,ut:000352302500002,NA,FALSE
 slu,2014,253.87,10.1371/journal.pone.0096086,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,24811199,PMC4014485,ut:000338213300019,NA,TRUE
-slu,2014,2538.74,10.1002/2013GB004770,TRUE,Wiley,Global Biogeochemical Cycles,0886-6236,NA,NA,0886-6236,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000335809500009,NA,FALSE
-slu,2014,2538.74,10.1002/2013WR015197,TRUE,Wiley,Water Resources Research,0043-1397,NA,NA,0043-1397,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25641996,PMC4302979,ut:000336026000033,NA,FALSE
+slu,2014,2538.74,10.1002/2013gb004770,TRUE,Wiley,Global Biogeochemical Cycles,0886-6236,NA,NA,0886-6236,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000335809500009,NA,FALSE
+slu,2014,2538.74,10.1002/2013wr015197,TRUE,Wiley,Water Resources Research,0043-1397,NA,NA,0043-1397,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25641996,PMC4302979,ut:000336026000033,NA,FALSE
 slu,2014,2618,10.1007/s12571-014-0331-y,TRUE,Springer,Food Security,1876-4517,1876-4517,1876-4525,1876-4517,NA,TRUE,NA,NA,ut:000334525500005,NA,FALSE
 slu,2014,2730,10.1093/icesjms/fsu230,TRUE,Oxford University Press (OUP),ICES Journal of Marine Science,1054-3139,1054-3139,1095-9289,1054-3139,NA,TRUE,NA,NA,ut:000356233800027,NA,FALSE
 slu,2014,410.89,10.3390/f5030535,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000333403600010,NA,TRUE
@@ -1285,16 +1285,16 @@ slu,2014,592.89,10.3390/d6030500,FALSE,MDPI,Diversity,1424-2818,NA,1424-2818,142
 slu,2014,592.89,10.3390/f5081931,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000341099200007,NA,TRUE
 slu,2014,597.14,10.3390/f5122967,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000346798100002,NA,TRUE
 slu,2014,598.41,10.3390/f6010047,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000348403700003,NA,TRUE
-slu,2014,646,10.15226/2374-815X/1/4/00121,FALSE,Symbiosis,"Journal of Gastroenterology, Pancreatology & Liver Disorders",2374-815X,NA,2374-815X,2374-815X,NA,TRUE,NA,NA,NA,NA,FALSE
+slu,2014,646,10.15226/2374-815x/1/4/00121,FALSE,Symbiosis,"Journal of Gastroenterology, Pancreatology & Liver Disorders",2374-815X,NA,2374-815X,2374-815X,NA,TRUE,NA,NA,NA,NA,FALSE
 slu,2014,657.44,10.3390/f5082037,FALSE,MDPI,Forests,1999-4907,NA,1999-4907,1999-4907,NA,TRUE,NA,NA,ut:000341099200013,NA,TRUE
 slu,2014,696,10.5194/hessd-11-3787-2014,FALSE,Copernicus Publications,Hydrology and Earth System Sciences Discussions,1812-2116,NA,1812-2116,1812-2116,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,NA,NA,TRUE
 slu,2014,729.39,10.1186/1756-0500-6-464,FALSE,BioMed Central,BMC Research Notes,1756-0500,1756-0500,NA,1756-0500,NA,TRUE,24229396,PMC3835548,NA,NA,TRUE
 slu,2014,730.59,10.1021/ic4023486,TRUE,American Chemical Society (ACS),Inorganic Chemistry,0020-1669,0020-1669,1520-510X,0020-1669,http://pubs.acs.org/page/policy/authorchoice_termsofuse.html,TRUE,24392745,PMC3905692,ut:000330204000042,NA,FALSE
 slu,2014,739.6,10.3390/rs6032084,FALSE,MDPI,Remote Sensing,2072-4292,NA,2072-4292,2072-4292,NA,TRUE,NA,NA,ut:000334797000017,NA,TRUE
 slu,2014,783,10.5194/hess-18-3623-2014,FALSE,Copernicus Publications,Hydrology and Earth System Sciences,1607-7938,NA,1607-7938,1027-5606,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000343118500018,NA,TRUE
-slu,2014,789.65,10.5751/ES-06750-190315,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,NA,1708-3087,NA,TRUE,NA,NA,ut:000343247200036,NA,TRUE
+slu,2014,789.65,10.5751/es-06750-190315,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,NA,1708-3087,NA,TRUE,NA,NA,ut:000343247200036,NA,TRUE
 slu,2014,803.51,10.1016/j.foodpol.2014.10.012,TRUE,Elsevier,Food Policy,0306-9192,0306-9192,NA,0306-9192,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000348748600004,NA,FALSE
-slu,2014,852,10.5751/ES-06665-190407,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,NA,1708-3087,NA,TRUE,NA,NA,ut:000347440700004,NA,TRUE
+slu,2014,852,10.5751/es-06665-190407,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,NA,1708-3087,NA,TRUE,NA,NA,ut:000347440700004,NA,TRUE
 slu,2014,960,10.3389/fpls.2014.00077,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,1664-462X,NA,TRUE,24639681,PMC3945484,ut:000332335400001,NA,TRUE
 slu,2014,960,10.3389/fpls.2014.00373,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,1664-462X,NA,TRUE,25126092,PMC4115670,ut:000342042800001,NA,TRUE
 slu,2014,978.03,10.1371/journal.pone.0099998,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,24926792,PMC4057421,ut:000338278100105,NA,TRUE
@@ -1387,8 +1387,8 @@ slu,2015,1728.84,10.1186/s12862-015-0461-7,FALSE,BioMed Central,BMC Evolutionary
 slu,2015,1730,10.1186/s40066-015-0029-1,FALSE,BioMed Central,Agriculture & Food Security,2048-7010,NA,2048-7010,2048-7010,NA,TRUE,NA,NA,NA,NA,TRUE
 slu,2015,1764,10.1186/s13028-015-0124-0,FALSE,BioMed Central,Acta Veterinaria Scandinavica,1751-0147,NA,1751-0147,0044-605X,NA,TRUE,26104188,PMC4491221,ut:000357454900001,NA,TRUE
 slu,2015,1794.58,10.3389/fpls.2015.01186,FALSE,Frontiers,Frontiers in Plant Science,1664-462X,NA,1664-462X,1664-462X,NA,TRUE,26779220,PMC4702147,NA,NA,TRUE
-slu,2015,1800,10.3920/CEP140024,TRUE,Wageningen Academic Publishers,Comparative Exercise Physiology,1755-2540,1755-2540,1755-2559,1755-2540,NA,TRUE,NA,NA,ut:000215103500005,NA,FALSE
-slu,2015,1800,10.3920/CEP150005,TRUE,Wageningen Academic Publishers,Comparative Exercise Physiology,1755-2540,1755-2540,1755-2559,1755-2540,NA,TRUE,NA,NA,ut:000215103600006,NA,FALSE
+slu,2015,1800,10.3920/cep140024,TRUE,Wageningen Academic Publishers,Comparative Exercise Physiology,1755-2540,1755-2540,1755-2559,1755-2540,NA,TRUE,NA,NA,ut:000215103500005,NA,FALSE
+slu,2015,1800,10.3920/cep150005,TRUE,Wageningen Academic Publishers,Comparative Exercise Physiology,1755-2540,1755-2540,1755-2559,1755-2540,NA,TRUE,NA,NA,ut:000215103600006,NA,FALSE
 slu,2015,1808.39,10.1186/s13002-015-0036-0,FALSE,BioMed Central,Journal of Ethnobiology and Ethnomedicine,1746-4269,NA,1746-4269,1746-4269,NA,TRUE,26077671,PMC4474580,ut:000356580900001,NA,TRUE
 slu,2015,1858.23,10.1186/s12866-015-0537-y,FALSE,BioMed Central,BMC Microbiology,1471-2180,NA,1471-2180,1471-2180,NA,TRUE,26458507,PMC4603578,ut:000362587100001,NA,TRUE
 slu,2015,1860.56,10.1111/jav.00623,TRUE,Wiley,Journal of Avian Biology,0908-8857,NA,NA,0908-8857,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000357949300001,NA,FALSE
@@ -1431,7 +1431,7 @@ slu,2015,2255.33,10.1186/s13028-015-0135-x,FALSE,BioMed Central,Acta Veterinaria
 slu,2015,2303.34,10.1016/j.jchromb.2015.07.009,TRUE,Elsevier,Journal of Chromatography B,1570-0232,1570-0232,NA,1570-0232,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26218771,NA,ut:000359874700014,NA,FALSE
 slu,2015,2315.41,10.1080/02827581.2015.1028435,TRUE,Taylor & Francis,Scandinavian Journal of Forest Research,0282-7581,0282-7581,1651-1891,0282-7581,NA,TRUE,NA,NA,ut:000356500300004,NA,FALSE
 slu,2015,2331.26,10.1186/s40793-015-0092-z,FALSE,BioMed Central,Standards in Genomic Sciences,1944-3277,NA,1944-3277,1944-3277,NA,TRUE,26566424,PMC4642661,ut:000368002100005,NA,TRUE
-slu,2015,2337,10.1017/S1751731115000750,TRUE,Cambridge University Press (CUP),animal,1751-7311,1751-7311,1751-732X,1751-7311,NA,TRUE,25959256,PMC4762244,ut:000377121500013,NA,FALSE
+slu,2015,2337,10.1017/s1751731115000750,TRUE,Cambridge University Press (CUP),animal,1751-7311,1751-7311,1751-732X,1751-7311,NA,TRUE,25959256,PMC4762244,ut:000377121500013,NA,FALSE
 slu,2015,2369.93,10.1186/s12885-015-1073-8,FALSE,BioMed Central,BMC Cancer,1471-2407,NA,1471-2407,1471-2407,http://www.springer.com/tdm,TRUE,25881026,PMC4336758,ut:000349792900001,NA,TRUE
 slu,2015,2622.5,10.1111/1751-7915.12330,FALSE,Wiley,Microbial Biotechnology,1751-7915,NA,NA,1751-7915,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26686366,PMC4767286,ut:000371234500005,NA,TRUE
 slu,2015,2647,10.1080/02827581.2015.1046482,TRUE,Taylor & Francis,Scandinavian Journal of Forest Research,0282-7581,0282-7581,1651-1891,0282-7581,NA,TRUE,NA,NA,ut:000361601800011,NA,FALSE
@@ -1453,7 +1453,7 @@ slu,2015,2747.67,10.1111/nph.13536,TRUE,Wiley,New Phytologist,0028-646X,NA,NA,00
 slu,2015,2790.85,10.1111/imb.12176,TRUE,Wiley,Insect Molecular Biology,0962-1075,NA,NA,0962-1075,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,26033210,NA,ut:000357883500009,NA,FALSE
 slu,2015,2833.55,10.1111/jvs.12387,TRUE,Wiley,Journal of Vegetation Science,1100-9233,NA,NA,1100-9233,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000375147500007,NA,FALSE
 slu,2015,2945.38,10.1016/j.agee.2015.12.021,TRUE,Elsevier,"Agriculture, Ecosystems & Environment",0167-8809,0167-8809,NA,0167-8809,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000370100800017,NA,FALSE
-slu,2015,3134.5,10.1002/2015JG003190,TRUE,Wiley,Journal of Geophysical Research: Biogeosciences,2169-8953,NA,NA,2169-8953,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000368908700019,NA,FALSE
+slu,2015,3134.5,10.1002/2015jg003190,TRUE,Wiley,Journal of Geophysical Research: Biogeosciences,2169-8953,NA,NA,2169-8953,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000368908700019,NA,FALSE
 slu,2015,3283.78,10.1111/gcb.12872,TRUE,Wiley,Global Change Biology,1354-1013,NA,NA,1354-1013,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,25611952,NA,ut:000358485200014,NA,FALSE
 slu,2015,3305.81,10.3168/jds.2015-9755,TRUE,American Dairy Science Association,Journal of Dairy Science,0022-0302,0022-0302,NA,0022-0302,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,26547638,NA,ut:000367214700054,NA,FALSE
 slu,2015,3365,10.1242/jeb.116798,TRUE,Company of Biologists,Journal of Experimental Biology,0022-0949,0022-0949,1477-9145,0022-0949,NA,TRUE,26056246,PMC4528704,ut:000359009100028,NA,FALSE
@@ -1504,7 +1504,7 @@ slu,2016,1224,10.1002/ece3.2279,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,N
 slu,2016,1224,10.1002/ece3.2597,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28070296,PMC5216661,ut:000392069500027,NA,TRUE
 slu,2016,1224,10.1002/ece3.2601,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,NA,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28070299,PMC5216679,ut:000392069500030,NA,TRUE
 slu,2016,1228.64,10.1371/journal.pone.0166510,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27846312,PMC5113013,ut:000387794600073,NA,TRUE
-slu,2016,123.57,10.5897/JEN2016.0159,FALSE,Academic Journals,Journal of Entomology and Nematology,2006-9855,NA,2006-9855,2006-9855,NA,TRUE,NA,NA,NA,NA,FALSE
+slu,2016,123.57,10.5897/jen2016.0159,FALSE,Academic Journals,Journal of Entomology and Nematology,2006-9855,NA,2006-9855,2006-9855,NA,TRUE,NA,NA,NA,NA,FALSE
 slu,2016,1234.34,10.1371/journal.pone.0147004,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26799558,PMC4723141,ut:000368655300052,NA,TRUE
 slu,2016,1234.34,10.1371/journal.pone.0147791,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26840533,PMC4739691,ut:000369550200059,NA,TRUE
 slu,2016,1237.47,10.1371/journal.pone.0148960,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26866480,PMC4750853,ut:000370050700048,NA,TRUE
@@ -1608,7 +1608,7 @@ slu,2016,1976.1,10.1371/journal.pgen.1005924,FALSE,Public Library of Science (PL
 slu,2016,2000.46,10.1186/s13068-016-0640-9,FALSE,BioMed Central,Biotechnology for Biofuels,1754-6834,NA,1754-6834,1754-6834,NA,TRUE,27800015,PMC5078929,ut:000386092900001,NA,TRUE
 slu,2016,2020.43,10.1371/journal.pntd.0005043,FALSE,Public Library of Science (PLoS),PLOS Neglected Tropical Diseases,1935-2735,NA,1935-2735,1935-2727,http://creativecommons.org/licenses/by/4.0/,TRUE,27768698,PMC5074459,ut:000386676200031,NA,TRUE
 slu,2016,2087.34,10.1186/s13071-016-1503-8,FALSE,BioMed Central,Parasites & Vectors,1756-3305,NA,1756-3305,1756-3305,NA,TRUE,27094215,PMC4837528,ut:000375038700001,NA,TRUE
-slu,2016,2132,10.1017/S0024282916000359,TRUE,Cambridge University Press (CUP),The Lichenologist,0024-2829,0024-2829,1096-1135,0024-2829,NA,TRUE,NA,NA,ut:000385656500010,NA,FALSE
+slu,2016,2132,10.1017/s0024282916000359,TRUE,Cambridge University Press (CUP),The Lichenologist,0024-2829,0024-2829,1096-1135,0024-2829,NA,TRUE,NA,NA,ut:000385656500010,NA,FALSE
 slu,2016,2200,10.1007/s00227-016-2977-9,TRUE,Springer,Marine Biology,0025-3162,0025-3162,1432-1793,0025-3162,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000386356100005,NA,FALSE
 slu,2016,2200,10.1007/s00299-016-2062-3,TRUE,Springer,Plant Cell Reports,0721-7714,0721-7714,1432-203X,0721-7714,http://creativecommons.org/licenses/by/4.0,TRUE,27699473,PMC5206254,ut:000391396000008,NA,FALSE
 slu,2016,2200,10.1007/s00334-016-0586-7,TRUE,Springer,Vegetation History and Archaeobotany,0939-6314,0939-6314,1617-6278,0939-6314,http://creativecommons.org/licenses/by/4.0,TRUE,NA,NA,ut:000398929000001,NA,FALSE
@@ -1655,7 +1655,7 @@ slu,2016,2454.49,10.1016/j.scitotenv.2016.03.230,TRUE,Elsevier,Science of The To
 slu,2016,2454.49,10.1016/j.scitotenv.2016.04.147,TRUE,Elsevier,Science of The Total Environment,0048-9697,0048-9697,NA,0048-9697,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27177134,NA,ut:000378206300026,NA,FALSE
 slu,2016,2480.39,10.1016/j.geoderma.2016.06.024,TRUE,Elsevier,Geoderma,0016-7061,0016-7061,NA,0016-7061,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000381544000007,NA,FALSE
 slu,2016,2480.39,10.1016/j.geoderma.2016.06.026,TRUE,Elsevier,Geoderma,0016-7061,0016-7061,NA,0016-7061,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000390632000007,NA,FALSE
-slu,2016,2488,10.1071/RD15315,TRUE,CSIRO Publishing,"Reproduction, Fertility and Development",1031-3613,1031-3613,NA,1031-3613,NA,TRUE,26922243,NA,ut:000399309500004,NA,FALSE
+slu,2016,2488,10.1071/rd15315,TRUE,CSIRO Publishing,"Reproduction, Fertility and Development",1031-3613,1031-3613,NA,1031-3613,NA,TRUE,26922243,NA,ut:000399309500004,NA,FALSE
 slu,2016,2631.49,10.1111/1365-2664.12709,TRUE,Wiley,Journal of Applied Ecology,0021-8901,NA,NA,0021-8901,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000387768800019,NA,FALSE
 slu,2016,2634.8,10.1111/1365-2664.12654,TRUE,Wiley,Journal of Applied Ecology,0021-8901,NA,NA,0021-8901,http://doi.wiley.com/10.1002/tdm_license_1.1,TRUE,NA,NA,ut:000380065600018,NA,FALSE
 slu,2016,2677.62,10.1016/j.apsoil.2016.05.011,TRUE,Elsevier,Applied Soil Ecology,0929-1393,0929-1393,NA,0929-1393,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000384860400006,NA,FALSE
@@ -1709,18 +1709,18 @@ su,2015,2230,10.1136/jech-2014-205058,TRUE,BMJ,Journal of Epidemiology and Commu
 su,2015,2429,10.1080/00268976.2014.1003985,TRUE,Taylor & Francis,Molecular Physics,0026-8976,0026-8976,1362-3028,0026-8976,NA,TRUE,NA,NA,ut:000360906000007,NA,FALSE
 su,2015,787,10.1186/s40488-015-0031-y,FALSE,Springer,Journal of Statistical Distributions and Applications,2195-5832,NA,2195-5832,2195-5832,NA,TRUE,NA,NA,NA,http://jsdajournal.springeropen.com/articles/10.1186/s40488-015-0031-y,TRUE
 su,2016,0,10.1080/20004508.2016.1275187,FALSE,Taylor & Francis,Education Inquiry,2000-4508,NA,2000-4508,2000-4508,NA,TRUE,NA,NA,NA,NA,TRUE
-su,2016,1007.31,10.5751/ES-08368-210140,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,1708-3087,1708-3087,NA,TRUE,NA,NA,ut:000373935100043,http://www.ecologyandsociety.org/vol21/iss1/art40/,TRUE
-su,2016,1008.99,10.5751/ES-08812-210425,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,1708-3087,1708-3087,NA,TRUE,NA,NA,ut:000391199400028,http://www.ecologyandsociety.org/vol21/iss4/art25/,TRUE
+su,2016,1007.31,10.5751/es-08368-210140,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,1708-3087,1708-3087,NA,TRUE,NA,NA,ut:000373935100043,http://www.ecologyandsociety.org/vol21/iss1/art40/,TRUE
+su,2016,1008.99,10.5751/es-08812-210425,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,1708-3087,1708-3087,NA,TRUE,NA,NA,ut:000391199400028,http://www.ecologyandsociety.org/vol21/iss4/art25/,TRUE
 su,2016,1012.25,10.3390/w8120572,FALSE,MDPI,Water,2073-4441,NA,2073-4441,2073-4441,NA,TRUE,NA,NA,ut:000392480200025,NA,TRUE
-su,2016,1022.82,10.5751/ES-09051-220128,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,NA,1708-3087,NA,TRUE,NA,NA,ut:000399397700035,NA,TRUE
+su,2016,1022.82,10.5751/es-09051-220128,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,NA,1708-3087,NA,TRUE,NA,NA,ut:000399397700035,NA,TRUE
 su,2016,1065,10.1093/nar/gkw356,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,0305-1048,NA,TRUE,27151197,PMC4987909,ut:000379786800018,NA,TRUE
 su,2016,1065,10.1093/nar/gkw849,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,0305-1048,NA,TRUE,27664219,PMC5314790,ut:000396576300003,NA,TRUE
 su,2016,1065,10.1093/nar/gkw923,FALSE,Oxford University Press (OUP),Nucleic Acids Research,0305-1048,0305-1048,1362-4962,0305-1048,NA,TRUE,27742821,PMC5210627,ut:000396575500096,NA,TRUE
 su,2016,1071,10.1016/j.childyouth.2016.05.011,TRUE,Elsevier,Children and Youth Services Review,0190-7409,0190-7409,NA,0190-7409,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000379097800019,http://www.sciencedirect.com/science/article/pii/S0190740916301554,FALSE
 su,2016,1080,10.5194/nhess-16-1571-2016,FALSE,Copernicus Publications,Natural Hazards and Earth System Sciences,1684-9981,NA,1684-9981,1561-8633,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000379421700003,NA,TRUE
-su,2016,1103.7,10.5751/ES-08605-210316,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,1708-3087,1708-3087,NA,TRUE,NA,NA,ut:000385720400020,http://www.ecologyandsociety.org/vol21/iss3/art16/,TRUE
+su,2016,1103.7,10.5751/es-08605-210316,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,1708-3087,1708-3087,NA,TRUE,NA,NA,ut:000385720400020,http://www.ecologyandsociety.org/vol21/iss3/art16/,TRUE
 su,2016,1120,10.1002/ece3.2536,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,2045-7758,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,28031795,PMC5167037,ut:000392062100009,http://onlinelibrary.wiley.com/doi/10.1002/ece3.2536/full,TRUE
-su,2016,1138,10.1108/JFMM-04-2016-0033,TRUE,Emerald,Journal of Fashion Marketing and Management,1361-2026,1361-2026,NA,1361-2026,http://www.emeraldinsight.com/page/tdm,TRUE,NA,NA,ut:000387174000010,http://www.emeraldinsight.com/doi/full/10.1108/JFMM-04-2016-0033,FALSE
+su,2016,1138,10.1108/jfmm-04-2016-0033,TRUE,Emerald,Journal of Fashion Marketing and Management,1361-2026,1361-2026,NA,1361-2026,http://www.emeraldinsight.com/page/tdm,TRUE,NA,NA,ut:000387174000010,http://www.emeraldinsight.com/doi/full/10.1108/JFMM-04-2016-0033,FALSE
 su,2016,1165,10.1038/srep21203,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,26883070,PMC4756319,ut:000370230600002,NA,TRUE
 su,2016,1165,10.1038/srep26620,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,http://www.springer.com/tdm,TRUE,27197757,PMC4873736,ut:000376193100001,NA,TRUE
 su,2016,1165,10.1038/srep27749,FALSE,Nature Publishing Group,Scientific Reports,2045-2322,NA,2045-2322,2045-2322,NA,TRUE,27324057,PMC4914976,ut:000378230100001,NA,TRUE
@@ -1731,7 +1731,7 @@ su,2016,1165,10.1038/srep38821,FALSE,Nature Publishing Group,Scientific Reports,
 su,2016,1173,10.1016/j.childyouth.2016.09.021,TRUE,Elsevier,Children and Youth Services Review,0190-7409,0190-7409,NA,0190-7409,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,NA,http://www.sciencedirect.com/science/article/pii/S0190740916303000,FALSE
 su,2016,1180,10.1186/s12911-016-0309-0,FALSE,BioMed Central,BMC Medical Informatics and Decision Making,1472-6947,NA,1472-6947,1472-6947,NA,TRUE,27459846,PMC4965720,ut:000405363700001,https://bmcmedinformdecismak.biomedcentral.com/articles/10.1186/s12911-016-0309-0,TRUE
 su,2016,1180,10.1186/s12911-016-0311-6,FALSE,BioMed Central,BMC Medical Informatics and Decision Making,1472-6947,NA,1472-6947,1472-6947,NA,TRUE,27459993,PMC4965710,ut:000405363700003,http://bmcmedinformdecismak.biomedcentral.com/articles/10.1186/s12911-016-0311-6,TRUE
-su,2016,1197.07,10.5751/ES-08920-220102,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,1708-3087,1708-3087,NA,TRUE,NA,NA,ut:000399397700013,http://www.ecologyandsociety.org/vol22/iss1/art2/,TRUE
+su,2016,1197.07,10.5751/es-08920-220102,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,1708-3087,1708-3087,NA,TRUE,NA,NA,ut:000399397700013,http://www.ecologyandsociety.org/vol22/iss1/art2/,TRUE
 su,2016,1200.74,10.1136/bmjopen-2015-009440,FALSE,BMJ,BMJ Open,2044-6055,2044-6055,2044-6055,2044-6055,NA,TRUE,27113233,PMC4853986,ut:000376391400016,NA,TRUE
 su,2016,1224,10.1002/ece3.2310,FALSE,Wiley,Ecology and Evolution,2045-7758,NA,2045-7758,2045-7758,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27547340,PMC4983577,ut:000381578400004,http://onlinelibrary.wiley.com/doi/10.1002/ece3.2310/full,TRUE
 su,2016,1239,10.1371/journal.pone.0147924,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,26820737,PMC4731055,ut:000369528400055,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0147924,TRUE
@@ -1739,11 +1739,11 @@ su,2016,1260,10.5194/gmd-9-2741-2016,FALSE,Copernicus Publications,Geoscientific
 su,2016,1261.35,10.1371/journal.pone.0163091,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27732600,PMC5061329,ut:000385505300009,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0163091,TRUE
 su,2016,1284.87,10.1371/journal.pone.0155295,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27223898,PMC4880328,ut:000376881700019,NA,TRUE
 su,2016,1285.2,10.5194/acp-16-15135-2016,FALSE,Copernicus Publications,Atmospheric Chemistry and Physics,1680-7324,NA,1680-7324,1680-7316,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000390648900002,NA,TRUE
-su,2016,1308,10.5751/ES-08826-220114,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,NA,1708-3087,NA,TRUE,NA,NA,ut:000399397700006,NA,TRUE
+su,2016,1308,10.5751/es-08826-220114,FALSE,Resilience Alliance,Ecology and Society,1708-3087,1708-3087,NA,1708-3087,NA,TRUE,NA,NA,ut:000399397700006,NA,TRUE
 su,2016,1312.12,10.3390/rs8020140,FALSE,MDPI,Remote Sensing,2072-4292,NA,2072-4292,2072-4292,NA,TRUE,NA,NA,ut:000371898800035,NA,TRUE
 su,2016,1330,10.1163/24056480-00104001,TRUE,Brill Academic Publishers,Journal of World Literature,2405-6472,2405-6472,2405-6480,2405-6472,NA,TRUE,NA,NA,NA,NA,FALSE
 su,2016,1365,10.1371/journal.pone.0156855,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,http://creativecommons.org/licenses/by/4.0/,TRUE,27253326,PMC4890767,ut:000377218700066,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0156855,TRUE
-su,2016,1379,10.1142/S1363919616400132,TRUE,World Scientific Publishing,International Journal of Innovation Management,1363-9196,1363-9196,1757-5877,1363-9196,NA,TRUE,NA,NA,ut:000394501400005,http://www.worldscientific.com/doi/10.1142/S1363919616400132,FALSE
+su,2016,1379,10.1142/s1363919616400132,TRUE,World Scientific Publishing,International Journal of Innovation Management,1363-9196,1363-9196,1757-5877,1363-9196,NA,TRUE,NA,NA,ut:000394501400005,http://www.worldscientific.com/doi/10.1142/S1363919616400132,FALSE
 su,2016,1397.6,10.1371/journal.pone.0151993,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,NA,TRUE,26998832,PMC4801336,ut:000372694700091,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0151993,TRUE
 su,2016,1397.6,10.1371/journal.pone.0152745,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,NA,TRUE,27030968,PMC4816578,ut:000373121800132,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0152745,TRUE
 su,2016,1397.6,10.1371/journal.pone.0158326,FALSE,Public Library of Science (PLoS),PLOS ONE,1932-6203,NA,1932-6203,1932-6203,NA,TRUE,27410261,PMC4943737,ut:000379508300021,http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0158326,TRUE
@@ -1778,15 +1778,15 @@ su,2016,1533,10.1016/j.npep.2016.08.008,TRUE,Elsevier,Neuropeptides,0143-4179,01
 su,2016,1550,10.3354/meps11592,TRUE,Inter-Research Science Center,Marine Ecology Progress Series,0171-8630,0171-8630,1616-1599,0171-8630,NA,TRUE,NA,NA,ut:000371142500006,NA,FALSE
 su,2016,1607,10.1016/j.avb.2016.02.006,TRUE,Elsevier,Aggression and Violent Behavior,1359-1789,1359-1789,NA,1359-1789,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000375516300003,http://www.sciencedirect.com/science/article/pii/S1359178916300064,FALSE
 su,2016,1620,10.5194/bg-13-6121-2016,FALSE,Copernicus Publications,Biogeosciences,1726-4189,1726-4170,1726-4189,1726-4170,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000387864200001,http://www.biogeosciences.net/13/6121/2016/,TRUE
-su,2016,1642.5,10.1002/2016EF000434,FALSE,Wiley,Earth's Future,2328-4277,NA,2328-4277,2328-4277,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000395001800008,http://onlinelibrary.wiley.com/doi/10.1002/2016EF000434/full,TRUE
+su,2016,1642.5,10.1002/2016ef000434,FALSE,Wiley,Earth's Future,2328-4277,NA,2328-4277,2328-4277,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000395001800008,http://onlinelibrary.wiley.com/doi/10.1002/2016EF000434/full,TRUE
 su,2016,1725,10.5194/acp-16-10941-2016,FALSE,Copernicus Publications,Atmospheric Chemistry and Physics,1680-7324,1680-7316,1680-7324,1680-7316,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000383963200001,http://www.atmos-chem-phys.net/16/10941/2016/,TRUE
 su,2016,1727,10.1136/jech-2015-206547,TRUE,BMJ,Journal of Epidemiology and Community Health,0143-005X,0143-005X,1470-2738,0143-005X,NA,TRUE,26733672,PMC4893147,ut:000376596100008,http://jech.bmj.com/content/70/6/569.full,FALSE
 su,2016,1740,10.3389/fnagi.2016.00034,FALSE,Frontiers,Frontiers in Aging Neuroscience,1663-4365,NA,1663-4365,1663-4365,NA,TRUE,26973509,PMC4773588,ut:000371113200001,http://journal.frontiersin.org/article/10.3389/fnagi.2016.00034/full,TRUE
 su,2016,1750,10.1002/ange.201605999,TRUE,Wiley,Angewandte Chemie,0044-8249,NA,NA,0044-8249,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,NA,NA,FALSE
 su,2016,1758.82,10.1016/j.concog.2016.06.012,TRUE,Elsevier,Consciousness and Cognition,1053-8100,1053-8100,NA,1053-8100,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27351780,NA,ut:000383638800004,NA,FALSE
-su,2016,1773,10.1144/M46.118,TRUE,Geological Society of London,"Geological Society, London, Memoirs",0435-4052,0435-4052,2041-4722,0435-4052,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,1773,10.1144/M46.182,TRUE,Geological Society of London,"Geological Society, London, Memoirs",0435-4052,0435-4052,2041-4722,0435-4052,NA,TRUE,NA,NA,NA,NA,FALSE
-su,2016,1773,10.1144/M46.183,TRUE,Geological Society of London,"Geological Society, London, Memoirs",0435-4052,0435-4052,2041-4722,0435-4052,NA,TRUE,NA,NA,NA,NA,FALSE
+su,2016,1773,10.1144/m46.118,TRUE,Geological Society of London,"Geological Society, London, Memoirs",0435-4052,0435-4052,2041-4722,0435-4052,NA,TRUE,NA,NA,NA,NA,FALSE
+su,2016,1773,10.1144/m46.182,TRUE,Geological Society of London,"Geological Society, London, Memoirs",0435-4052,0435-4052,2041-4722,0435-4052,NA,TRUE,NA,NA,NA,NA,FALSE
+su,2016,1773,10.1144/m46.183,TRUE,Geological Society of London,"Geological Society, London, Memoirs",0435-4052,0435-4052,2041-4722,0435-4052,NA,TRUE,NA,NA,NA,NA,FALSE
 su,2016,1798,10.3389/fnins.2016.00007,FALSE,Frontiers,Frontiers in Neuroscience,1662-453X,NA,1662-453X,1662-453X,NA,TRUE,26834534,PMC4718990,ut:000368584900001,NA,TRUE
 su,2016,1806.96,10.3389/fevo.2016.00134,FALSE,Frontiers,Frontiers in Ecology and Evolution,2296-701X,NA,2296-701X,2296-701X,NA,TRUE,NA,NA,NA,NA,TRUE
 su,2016,1806.96,10.3389/fimmu.2016.00096,FALSE,Frontiers,Frontiers in Immunology,1664-3224,NA,1664-3224,1664-3224,NA,TRUE,27014275,PMC4794487,ut:000372147600001,NA,TRUE
@@ -1815,7 +1815,7 @@ su,2016,2013.45,10.3389/fmicb.2016.01209,FALSE,Frontiers,Frontiers in Microbiolo
 su,2016,2108.8,10.1111/1365-2435.12670,TRUE,Wiley,Functional Ecology,0269-8463,NA,1365-2435,0269-8463,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000387362600010,http://onlinelibrary.wiley.com/doi/10.1111/1365-2435.12670/full,FALSE
 su,2016,2121,10.1073/pnas.1522445113,TRUE,National Academy of Sciences,Proceedings of the National Academy of Sciences,0027-8424,0027-8424,1091-6490,0027-8424,NA,TRUE,27185950,PMC4896668,ut:000376784600036,http://www.pnas.org/content/113/22/6160.long,FALSE
 su,2016,2132,10.1080/16506073.2016.1143526,TRUE,Taylor & Francis,Cognitive Behaviour Therapy,1650-6073,1650-6073,1651-2316,1650-6073,NA,TRUE,26886248,PMC4867878,ut:000374581500002,NA,FALSE
-su,2016,2132,10.2752/147800415X14224554625154,TRUE,Taylor & Francis,Cultural and Social History,1478-0038,1478-0038,1478-0046,1478-0038,NA,TRUE,NA,NA,ut:000354228300002,NA,FALSE
+su,2016,2132,10.2752/147800415x14224554625154,TRUE,Taylor & Francis,Cultural and Social History,1478-0038,1478-0038,1478-0046,1478-0038,NA,TRUE,NA,NA,ut:000354228300002,NA,FALSE
 su,2016,2139.81,10.1371/journal.pgen.1006522,FALSE,Public Library of Science (PLoS),PLOS Genetics,1553-7404,NA,1553-7404,1553-7390,http://creativecommons.org/licenses/by/4.0/,TRUE,27941972,PMC5189948,ut:000392138700051,NA,TRUE
 su,2016,2142,10.1016/j.fct.2016.03.028,TRUE,Elsevier,Food and Chemical Toxicology,0278-6915,0278-6915,1873-6351,0278-6915,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27046699,NA,ut:000376804400011,http://www.sciencedirect.com/science/article/pii/S0278691516300928,FALSE
 su,2016,2142,10.1016/j.tiv.2016.05.014,TRUE,Elsevier,Toxicology in Vitro,0887-2333,0887-2333,1879-3177,0887-2333,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27241584,NA,ut:000380603700013,http://www.sciencedirect.com/science/article/pii/S0887233316301096,FALSE
@@ -1872,10 +1872,10 @@ su,2016,2275,10.1093/ije/dyw048,TRUE,Oxford University Press (OUP),International
 su,2016,2275,10.1093/rfs/hhw014,TRUE,Oxford University Press (OUP),Review of Financial Studies,0893-9454,0893-9454,1465-7368,0893-9454,NA,TRUE,NA,NA,ut:000386207400007,https://academic.oup.com/rfs/article/29/10/2814/2223352/,FALSE
 su,2016,2276,10.3389/fpsyg.2016.01450,FALSE,Frontiers,Frontiers in Psychology,1664-1078,NA,1664-1078,1664-1078,NA,TRUE,NA,NA,ut:000384508200001,http://journal.frontiersin.org/article/10.3389/fpsyg.2016.01450/full,TRUE
 su,2016,2290,10.3389/fpsyg.2016.01146,FALSE,Frontiers,Frontiers in Psychology,1664-1078,NA,1664-1078,1664-1078,NA,TRUE,27559320,PMC4978721,ut:000381093100001,http://journal.frontiersin.org/article/10.3389/fpsyg.2016.01146/full,TRUE
-su,2016,2313.56,10.1128/mBio.01670-15,FALSE,American Society for Microbiology,mBio,2150-7511,NA,2150-7511,2150-7511,NA,TRUE,26884432,PMC4752598,ut:000373933100067,NA,TRUE
-su,2016,2329,10.1002/2016GL070275,TRUE,Wiley,Geophysical Research Letters,0094-8276,0094-8276,1944-8007,0094-8276,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000383290300057,http://onlinelibrary.wiley.com/doi/10.1002/2016GL070275/full,FALSE
+su,2016,2313.56,10.1128/mbio.01670-15,FALSE,American Society for Microbiology,mBio,2150-7511,NA,2150-7511,2150-7511,NA,TRUE,26884432,PMC4752598,ut:000373933100067,NA,TRUE
+su,2016,2329,10.1002/2016gl070275,TRUE,Wiley,Geophysical Research Letters,0094-8276,0094-8276,1944-8007,0094-8276,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000383290300057,http://onlinelibrary.wiley.com/doi/10.1002/2016GL070275/full,FALSE
 su,2016,2330.89,10.1021/acscatal.6b01760,TRUE,American Chemical Society (ACS),ACS Catalysis,2155-5435,2155-5435,2155-5435,2155-5435,http://pubs.acs.org/page/policy/authorchoice_ccby_termsofuse.html,TRUE,NA,NA,ut:000385057900046,http://pubs.acs.org/doi/full/10.1021/acscatal.6b01760,FALSE
-su,2016,2340,10.1088/0031-8949/2015/T166/014063,TRUE,IOP Publishing,Physica Scripta,0031-8949,0031-8949,1402-4896,0031-8949,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,ut:000368901600064,NA,FALSE
+su,2016,2340,10.1088/0031-8949/2015/t166/014063,TRUE,IOP Publishing,Physica Scripta,0031-8949,0031-8949,1402-4896,0031-8949,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,ut:000368901600064,NA,FALSE
 su,2016,2340,10.1093/eurpub/ckw025,TRUE,Oxford University Press (OUP),European Journal of Public Health,1101-1262,1101-1262,1464-360X,1101-1262,NA,TRUE,27032996,PMC4884330,ut:000377470800024,NA,FALSE
 su,2016,2345.1,10.1016/j.jbi.2016.11.006,TRUE,Elsevier,Journal of Biomedical Informatics,1532-0464,1532-0464,NA,1532-0464,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27919732,NA,ut:000406235200008,NA,FALSE
 su,2016,2357,10.3389/fnins.2016.00533,FALSE,Frontiers,Frontiers in Neuroscience,1662-453X,NA,1662-453X,1662-453X,NA,TRUE,NA,NA,ut:000388649600001,NA,TRUE
@@ -1895,8 +1895,8 @@ su,2016,2570.59,10.1016/j.quascirev.2016.07.029,TRUE,Elsevier,Quaternary Science
 su,2016,2570.59,10.1016/j.quascirev.2016.07.032,TRUE,Elsevier,Quaternary Science Reviews,0277-3791,0277-3791,NA,0277-3791,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000383825400020,NA,FALSE
 su,2016,2600,10.1093/bjc/azv114,TRUE,Oxford University Press (OUP),British Journal of Criminology,0007-0955,0007-0955,1464-3529,0007-0955,NA,TRUE,NA,NA,ut:000387987800012,NA,FALSE
 su,2016,2650,10.1093/ntr/ntw188,TRUE,Oxford University Press (OUP),Nicotine & Tobacco Research,1462-2203,1462-2203,1469-994X,1462-2203,NA,TRUE,NA,NA,ut:000397273900003,http://ntr.oxfordjournals.org/content/early/2016/08/18/ntr.ntw188.full,FALSE
-su,2016,2658,10.1017/S1368980016001440,TRUE,Cambridge University Press (CUP),Public Health Nutrition,1368-9800,1368-9800,1475-2727,1368-9800,NA,TRUE,27329947,PMC5217467,NA,https://www.cambridge.org/core/journals/public-health-nutrition/article/div-classtitlesocial-patterning-of-overeating-binge-eating-compensatory-behaviours-and-symptoms-of-bulimia-nervosa-in-young-adult-women-results-from-the-australian-longitudinal-study-on-womens-healthdiv/9FB541DBA5FA92022911FE93700CDBD5,FALSE
-su,2016,2667,10.1017/S2045796016000445,TRUE,Cambridge University Press (CUP),Epidemiology and Psychiatric Sciences,2045-7960,2045-7960,2045-7979,2045-7960,NA,TRUE,NA,NA,NA,https://www.cambridge.org/core/journals/epidemiology-and-psychiatric-sciences/article/div-classtitlethe-use-of-psychiatric-services-by-young-adults-who-came-to-sweden-as-teenage-refugees-a-national-cohort-studydiv/52E7A0AB5F2357F7078D4C5E799DB1CB/core-reader,FALSE
+su,2016,2658,10.1017/s1368980016001440,TRUE,Cambridge University Press (CUP),Public Health Nutrition,1368-9800,1368-9800,1475-2727,1368-9800,NA,TRUE,27329947,PMC5217467,NA,https://www.cambridge.org/core/journals/public-health-nutrition/article/div-classtitlesocial-patterning-of-overeating-binge-eating-compensatory-behaviours-and-symptoms-of-bulimia-nervosa-in-young-adult-women-results-from-the-australian-longitudinal-study-on-womens-healthdiv/9FB541DBA5FA92022911FE93700CDBD5,FALSE
+su,2016,2667,10.1017/s2045796016000445,TRUE,Cambridge University Press (CUP),Epidemiology and Psychiatric Sciences,2045-7960,2045-7960,2045-7979,2045-7960,NA,TRUE,NA,NA,NA,https://www.cambridge.org/core/journals/epidemiology-and-psychiatric-sciences/article/div-classtitlethe-use-of-psychiatric-services-by-young-adults-who-came-to-sweden-as-teenage-refugees-a-national-cohort-studydiv/52E7A0AB5F2357F7078D4C5E799DB1CB/core-reader,FALSE
 su,2016,2680.34,10.1073/pnas.1601196113,TRUE,National Academy of Sciences,Proceedings of the National Academy of Sciences,0027-8424,0027-8424,1091-6490,0027-8424,http://www.pnas.org/site/misc/userlicense.xhtml,TRUE,27432958,PMC4978307,ut:000380586600010,NA,FALSE
 su,2016,2700,10.1038/ismej.2016.17,TRUE,Nature Publishing Group,ISME Journal,1751-7362,1751-7362,1751-7370,1751-7362,NA,TRUE,26918665,PMC4989308,ut:000386664600011,NA,FALSE
 su,2016,2706,10.1016/j.ecoser.2016.08.004,TRUE,Elsevier,Ecosystem Services,2212-0416,2212-0416,NA,2212-0416,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000385526300015,http://www.sciencedirect.com/science/article/pii/S2212041616302170,FALSE
@@ -1929,7 +1929,7 @@ su,2016,2941.18,10.1002/ange.201601505,TRUE,Wiley,Angewandte Chemie,0044-8249,NA
 su,2016,2941.18,10.1002/anie.201602137,TRUE,Wiley,Angewandte Chemie,1433-7851,NA,NA,1433-7851,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27219856,PMC5089581,ut:000383253300041,NA,FALSE
 su,2016,2941.18,10.1002/anie.201606108,TRUE,Wiley,Angewandte Chemie International Edition,1433-7851,1433-7851,1521-3773,1433-7851,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27538999,PMC5113805,ut:000384713100026,http://onlinelibrary.wiley.com/doi/10.1002/anie.201606108/full,FALSE
 su,2016,295.36,10.1016/j.chemosphere.2016.08.082,TRUE,Elsevier,Chemosphere,0045-6535,0045-6535,NA,0045-6535,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,27643982,NA,ut:000385318200080,NA,FALSE
-su,2016,3000,10.1002/2016JF004050,TRUE,Wiley,Journal of Geophysical Research: Earth Surface,2169-9003,NA,NA,2169-9003,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000392831800012,NA,FALSE
+su,2016,3000,10.1002/2016jf004050,TRUE,Wiley,Journal of Geophysical Research: Earth Surface,2169-9003,NA,NA,2169-9003,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,NA,NA,ut:000392831800012,NA,FALSE
 su,2016,3000,10.1242/jeb.129411,TRUE,The Company of Biologists,Journal of Experimental Biology,0022-0949,0022-0949,1477-9145,0022-0949,NA,TRUE,NA,NA,NA,http://jeb.biologists.org/content/219/19/2971,FALSE
 su,2016,3006,10.1111/add.13454,TRUE,Wiley,Addiction,0965-2140,0965-2140,1360-0443,0965-2140,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27178010,PMC5089658,ut:000383713500022,http://onlinelibrary.wiley.com/doi/10.1111/add.13454/full,FALSE
 su,2016,3046.47,10.1088/0143-0807/37/5/055603,TRUE,IOP Publishing,European Journal of Physics,0143-0807,0143-0807,1361-6404,0143-0807,http://iopscience.iop.org/info/page/text-and-data-mining,TRUE,NA,NA,ut:000381819000040,http://iopscience.iop.org/article/10.1088/0143-0807/37/5/055603,FALSE
@@ -1938,9 +1938,9 @@ su,2016,3139.9,10.1016/j.clay.2016.10.002,TRUE,Elsevier,Applied Clay Science,016
 su,2016,3157,10.1016/j.gloenvcha.2016.06.008,TRUE,Elsevier,Global Environmental Change,0959-3780,0959-3780,NA,0959-3780,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000383297200006,http://www.sciencedirect.com/science/article/pii/S0959378016300826,FALSE
 su,2016,3260,10.1111/1462-2920.13407,TRUE,Wiley,Environmental Microbiology,1462-2912,1462-2912,1462-2920,1462-2912,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27306515,NA,ut:000392946900012,http://onlinelibrary.wiley.com/doi/10.1111/1462-2920.13407/full,FALSE
 su,2016,3300,10.1038/npjqi.2016.10,FALSE,Nature Publishing Group,npj Quantum Information,2056-6387,NA,2056-6387,2056-6387,http://www.springer.com/tdm,TRUE,NA,NA,ut:000392279900001,NA,TRUE
-su,2016,3404,10.1074/jbc.M115.701540,TRUE,American Society for Biochemistry & Molecular Biology (ASBMB),Journal of Biological Chemistry,0021-9258,0021-9258,1083-351X,0021-9258,NA,TRUE,26867577,PMC4817197,ut:000383447600042,NA,FALSE
+su,2016,3404,10.1074/jbc.m115.701540,TRUE,American Society for Biochemistry & Molecular Biology (ASBMB),Journal of Biological Chemistry,0021-9258,0021-9258,1083-351X,0021-9258,NA,TRUE,26867577,PMC4817197,ut:000383447600042,NA,FALSE
 su,2016,3500,10.1002/anie.201608605,TRUE,Wiley,Angewandte Chemie International Edition,1433-7851,1433-7851,1521-3773,1433-7851,http://doi.wiley.com/10.1002/tdm_license_1,TRUE,27735124,PMC5129484,ut:000387028000040,http://onlinelibrary.wiley.com/doi/10.1002/anie.201608605/full,FALSE
-su,2016,3500,10.1175/JPO-D-15-0219.1,TRUE,American Meteorological Society,Journal of Physical Oceanography,0022-3670,0022-3670,1520-0485,0022-3670,NA,TRUE,NA,NA,ut:000380799200011,NA,FALSE
+su,2016,3500,10.1175/jpo-d-15-0219.1,TRUE,American Meteorological Society,Journal of Physical Oceanography,0022-3670,0022-3670,1520-0485,0022-3670,NA,TRUE,NA,NA,ut:000380799200011,NA,FALSE
 su,2016,3700,10.1038/ncomms12016,FALSE,Nature Publishing Group,Nature Communications,2041-1723,NA,2041-1723,2041-1723,NA,TRUE,27327838,PMC4919534,ut:000379091000001,NA,TRUE
 su,2016,3700,10.1038/ncomms12113,FALSE,Nature Publishing Group,Nature Communications,2041-1723,NA,2041-1723,2041-1723,NA,TRUE,27385026,PMC4941054,ut:000380303100001,NA,TRUE
 su,2016,3700,10.1038/ncomms12776,FALSE,Nature Publishing Group,Nature Communications,2041-1723,NA,2041-1723,2041-1723,NA,TRUE,27627859,PMC5027618,ut:000385256500006,NA,TRUE
@@ -1973,7 +1973,7 @@ su,2016,708.816,10.1021/acs.jpcc.5b12490,TRUE,American Chemical Society (ACS),Th
 su,2016,734,10.1080/19491034.2016.1220465,TRUE,Taylor & Francis,Nucleus,1949-1034,1949-1034,1949-1042,1949-1042,NA,TRUE,27541860,PMC5039005,ut:000384442800010,NA,FALSE
 su,2016,892.5,10.5194/gmd-9-1673-2016,FALSE,Copernicus Publications,Geoscientific Model Development,1991-9603,NA,1991-9603,1991-959X,http://creativecommons.org/licenses/by/3.0/,TRUE,NA,NA,ut:000376937800002,NA,TRUE
 su,2016,893,10.1016/j.jmva.2016.02.013,TRUE,Elsevier,Journal of Multivariate Analysis,0047-259X,0047-259X,NA,0047-259X,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000375826400004,http://www.sciencedirect.com/science/article/pii/S0047259X16000579,FALSE
-su,2016,907.17,10.1107/S160057671601863X,TRUE,International Union of Crystallography (IUCr),Journal of Applied Crystallography,1600-5767,NA,1600-5767,0021-8898,http://creativecommons.org/licenses/by/2.0/uk/legalcode,TRUE,28190994,PMC5294395,ut:000394289400030,NA,FALSE
+su,2016,907.17,10.1107/s160057671601863x,TRUE,International Union of Crystallography (IUCr),Journal of Applied Crystallography,1600-5767,NA,1600-5767,0021-8898,http://creativecommons.org/licenses/by/2.0/uk/legalcode,TRUE,28190994,PMC5294395,ut:000394289400030,NA,FALSE
 su,2016,933.22,10.1021/acs.orglett.6b01132,TRUE,American Chemical Society (ACS),Organic Letters,1523-7060,1523-7060,1523-7052,1523-7052,http://pubs.acs.org/page/policy/authorchoice_ccby_termsofuse.html,TRUE,27166509,NA,ut:000376476300045,http://pubs.acs.org/doi/full/10.1021/acs.orglett.6b01132,FALSE
 su,2016,987.5,10.1080/23746149.2016.1165630,TRUE,Taylor & Francis,Advances in Physics: X,2374-6149,NA,2374-6149,2374-6149,NA,TRUE,NA,NA,ut:000398353500004,NA,FALSE
 su,2016,992.16,10.1016/j.alcr.2016.11.002,TRUE,Elsevier,Advances in Life Course Research,1040-2608,1040-2608,NA,1040-2608,http://www.elsevier.com/tdm/userlicense/1.0/,TRUE,NA,NA,ut:000403857600001,NA,FALSE
@@ -1981,7 +1981,7 @@ umu,2008,2660,10.1080/17450120802069109,TRUE,Taylor & Francis,Vulnerable Childre
 umu,2013,2429,10.1080/09644016.2013.835201,TRUE,Taylor & Francis,Environmental Politics,0964-4016,0964-4016,1743-8934,0964-4016,NA,TRUE,NA,NA,ut:000334661300009,NA,FALSE
 umu,2013,2429,10.1080/17542863.2013.800568,TRUE,Taylor & Francis,International Journal of Culture and Mental Health,1754-2863,1754-2863,1754-2871,1754-2871,NA,TRUE,24999370,PMC4066927,NA,NA,FALSE
 umu,2013,2630,10.1080/13607863.2012.758231,TRUE,Taylor & Francis,Aging & Mental Health,1360-7863,1360-7863,1364-6915,1360-7863,NA,TRUE,23339600,PMC3701937,ut:000320913300015,NA,FALSE
-umu,2014,3040,10.3109/0284186X.2014.953258,TRUE,Taylor & Francis,Acta Oncologica,0284-186X,0284-186X,1651-226X,0284-186X,NA,TRUE,25180912,PMC4438349,ut:000342282100001,NA,FALSE
+umu,2014,3040,10.3109/0284186x.2014.953258,TRUE,Taylor & Francis,Acta Oncologica,0284-186X,0284-186X,1651-226X,0284-186X,NA,TRUE,25180912,PMC4438349,ut:000342282100001,NA,FALSE
 umu,2014,755,10.1159/000358121,FALSE,Karger,Cerebrovascular Diseases Extra,1664-5456,NA,1664-5456,1664-5456,NA,TRUE,24715896,PMC3975210,NA,NA,TRUE
 umu,2014,755,10.1159/000364816,FALSE,Karger,Dementia and Geriatric Cognitive Disorders Extra,1664-5464,NA,1664-5464,1664-5464,NA,TRUE,25177334,PMC4132238,NA,NA,TRUE
 umu,2015,0,10.3109/03009734.2015.1122687,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,26849806,PMC4812053,ut:000372123700003,NA,FALSE
@@ -2001,9 +2001,9 @@ umu,2016,0,10.3109/03009734.2016.1152332,FALSE,Taylor & Francis,Upsala Journal o
 umu,2016,2074,10.1080/14790718.2016.1155591,TRUE,Taylor & Francis,International Journal of Multilingualism,1479-0718,1479-0718,1747-7530,1479-0718,NA,TRUE,NA,NA,ut:000399550200006,NA,FALSE
 umu,2016,2132,10.1080/00313831.2015.1119723,TRUE,Taylor & Francis,Scandinavian Journal of Educational Research,0031-3831,0031-3831,1470-1170,0031-3831,NA,TRUE,NA,NA,ut:000393802200007,NA,FALSE
 umu,2016,2132,10.1080/01443410.2016.1143087,TRUE,Taylor & Francis,Educational Psychology,0144-3410,0144-3410,1469-5820,0144-3410,NA,TRUE,NA,NA,ut:000395093000005,NA,FALSE
-umu,2016,2132,10.1080/0966369X.2016.1249346,TRUE,Taylor & Francis,"Gender, Place & Culture",0966-369X,0966-369X,1360-0524,0966-369X,NA,TRUE,NA,NA,ut:000392834200009,NA,FALSE
-umu,2016,2132,10.1080/0969594X.2016.1142935,TRUE,Taylor & Francis,"Assessment in Education: Principles, Policy & Practice",0969-594X,0969-594X,1465-329X,0969-594X,NA,TRUE,NA,NA,ut:000400610000002,NA,FALSE
-umu,2016,2132,10.1080/1088937X.2016.1148794,TRUE,Taylor & Francis,Polar Geography,1088-937X,1088-937X,1939-0513,1088-937X,NA,TRUE,NA,NA,ut:000386442200003,NA,FALSE
+umu,2016,2132,10.1080/0966369x.2016.1249346,TRUE,Taylor & Francis,"Gender, Place & Culture",0966-369X,0966-369X,1360-0524,0966-369X,NA,TRUE,NA,NA,ut:000392834200009,NA,FALSE
+umu,2016,2132,10.1080/0969594x.2016.1142935,TRUE,Taylor & Francis,"Assessment in Education: Principles, Policy & Practice",0969-594X,0969-594X,1465-329X,0969-594X,NA,TRUE,NA,NA,ut:000400610000002,NA,FALSE
+umu,2016,2132,10.1080/1088937x.2016.1148794,TRUE,Taylor & Francis,Polar Geography,1088-937X,1088-937X,1939-0513,1088-937X,NA,TRUE,NA,NA,ut:000386442200003,NA,FALSE
 umu,2016,2132,10.1080/14623943.2016.1206881,TRUE,Taylor & Francis,Reflective Practice,1462-3943,1462-3943,1470-1103,1462-3943,NA,TRUE,NA,NA,ut:000384681300005,NA,FALSE
 umu,2016,2132,10.1080/17441692.2016.1149202,TRUE,Taylor & Francis,Global Public Health,1744-1692,1744-1692,1744-1706,1744-1692,NA,TRUE,26948258,NA,NA,NA,FALSE
 umu,2016,2132,10.3109/08039488.2016.1162846,TRUE,Taylor & Francis,Nordic Journal of Psychiatry,0803-9488,0803-9488,1502-4725,0803-9488,NA,TRUE,27103550,NA,ut:000383037300001,NA,FALSE
@@ -2051,7 +2051,7 @@ uu,2014,0,10.1159/000365274,FALSE,Karger,Audiology and Neurotology Extra,1664-55
 uu,2014,2132,10.1080/00393274.2012.751670,TRUE,Taylor & Francis,Studia Neophilologica,0039-3274,0039-3274,1651-2308,0039-3274,NA,TRUE,NA,NA,ut:000319199300008,NA,FALSE
 uu,2014,2132,10.1080/00393274.2013.822742,TRUE,Taylor & Francis,Studia Neophilologica,0039-3274,0039-3274,1651-2308,0039-3274,NA,TRUE,NA,NA,ut:000335850200002,NA,FALSE
 uu,2014,2132,10.1080/00393274.2013.871975,TRUE,Taylor & Francis,Studia Neophilologica,0039-3274,0039-3274,1651-2308,0039-3274,NA,TRUE,NA,NA,ut:000335850200012,NA,FALSE
-uu,2014,2429,10.1080/1070289X.2013.868351,TRUE,Taylor & Francis,Identities,1070-289X,1070-289X,1547-3384,1070-289X,NA,TRUE,NA,NA,ut:000343216200007,NA,FALSE
+uu,2014,2429,10.1080/1070289x.2013.868351,TRUE,Taylor & Francis,Identities,1070-289X,1070-289X,1547-3384,1070-289X,NA,TRUE,NA,NA,ut:000343216200007,NA,FALSE
 uu,2014,321,10.1159/000362868,FALSE,Karger,Case Reports in Neurology,1662-680X,NA,1662-680X,1662-680X,NA,TRUE,24987361,PMC4067733,NA,NA,TRUE
 uu,2014,935,10.4161/15384101.2014.964985,TRUE,Taylor & Francis,Cell Cycle,1538-4101,1538-4101,1551-4005,1551-4005,NA,TRUE,25483080,PMC4615048,ut:000348329200013,NA,FALSE
 uu,2015,0,10.3109/03009734.2015.1037031,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,25951045,PMC4526876,ut:000359819800008,NA,FALSE
@@ -2159,7 +2159,7 @@ uu,2016,2200,10.1007/s40072-016-0080-3,TRUE,Springer,Stochastics and Partial Dif
 uu,2016,2200,10.1208/s12248-016-9977-z,TRUE,Springer,The AAPS Journal,1550-7416,NA,1550-7416,1550-7416,http://creativecommons.org/licenses/by/4.0,TRUE,27634384,NA,ut:000392210900017,NA,FALSE
 uu,2016,2200,10.1245/s10434-016-5703-4,TRUE,Springer,Annals of Surgical Oncology,1068-9265,1068-9265,1534-4681,1068-9265,http://creativecommons.org/licenses/by/4.0,TRUE,27904972,NA,ut:000399013200012,NA,FALSE
 uu,2016,321,10.1159/000444874,FALSE,Karger,Case Reports in Neurology,1662-680X,NA,1662-680X,1662-680X,NA,TRUE,27065427,PMC4821142,ut:000378535900010,NA,TRUE
-uu,2016,969,10.1080/2331186X.2016.1247610,FALSE,Taylor & Francis,Cogent Education,2331-186X,NA,2331-186X,2331-186X,NA,TRUE,NA,NA,ut:000387266300001,NA,TRUE
+uu,2016,969,10.1080/2331186x.2016.1247610,FALSE,Taylor & Francis,Cogent Education,2331-186X,NA,2331-186X,2331-186X,NA,TRUE,NA,NA,ut:000387266300001,NA,TRUE
 uu,2016,982,10.1080/21592535.2015.1123842,FALSE,Taylor & Francis,Biomatter,2159-2535,NA,2159-2535,2159-2527,NA,TRUE,26787304,PMC5055208,NA,NA,FALSE
 uu,2016,982,10.1080/21592535.2015.1133394,FALSE,Taylor & Francis,Biomatter,2159-2535,NA,2159-2535,2159-2527,NA,TRUE,26727581,PMC4927199,NA,NA,FALSE
 uu,2017,0,10.1080/03009734.2016.1274806,FALSE,Taylor & Francis,Upsala Journal of Medical Sciences,0300-9734,0300-9734,2000-1967,0300-9734,NA,TRUE,28256956,NA,ut:000396476600001,NA,FALSE


### PR DESCRIPTION
All DOIs have been normalised. I've also made some changes to the processing script to repeat this step easily:

`python apc_csv_processing.py -n -q ffffffffffffffffff -e utf8 --no-crossref --no-pubmed --no-doaj ../data/apc_se.csv`

This will start a dry run without any data enrichment, but the DOIs will get normalised along the road. the `-n` and `-q` params are necessary to mimic the quotation style of the apc_se file which is different from ours.